### PR TITLE
fix ocmv prefix in 42 datasets' metadata.ttl

### DIFF
--- a/models/alkhalaf2024/metadata.ttl
+++ b/models/alkhalaf2024/metadata.ttl
@@ -1,4 +1,4 @@
-@prefix ontouml: <https://w3id.org/ontouml#>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
 @prefix owl: <http://www.w3.org/2002/07/owl#>.

--- a/models/alkhalaf2024/metadata.ttl
+++ b/models/alkhalaf2024/metadata.ttl
@@ -17,8 +17,8 @@
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:contributor <https://dblp.org/pid/292/3745>, <https://dblp.org/pid/25/929-2>, <https://dblp.org/pid/201/2998>;
-    mod:designedForTask ontouml:ConceptualClarification, ontouml:Interoperability, ontouml:OntologicalAnalysis;
-    ontouml:context ontouml:Research;
+    mod:designedForTask ocmv:ConceptualClarification, ocmv:Interoperability, ocmv:OntologicalAnalysis;
+    ocmv:context ocmv:Research;
     dct:source <https://doi.org/10.5220/0012183900003598>.
 <https://w3id.org/ontouml-models/model/alkhalaf2024/> dcat:distribution <https://w3id.org/ontouml-models/model/alkhalaf2024/distribution/ttl>.
 <https://w3id.org/ontouml-models/model/alkhalaf2024/distribution/ttl> a dcat:Distribution;

--- a/models/bank-account2013/metadata.ttl
+++ b/models/bank-account2013/metadata.ttl
@@ -1,4 +1,4 @@
-@prefix ontouml: <https://w3id.org/ontouml#>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
 @prefix owl: <http://www.w3.org/2002/07/owl#>.

--- a/models/bank-account2013/metadata.ttl
+++ b/models/bank-account2013/metadata.ttl
@@ -16,8 +16,8 @@
     skos:editorialNote "Ontology created during an Ontology Engineering lecture by students who wanted to remain anonymous. The ontology was build in a different editor tool and imported to Visual Paradigm, the current diagrammation may not exacly match the original one.";
     dct:language "pt-br";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    mod:designedForTask ontouml:ConceptualClarification, ontouml:Learning;
-    ontouml:context ontouml:Classroom.
+    mod:designedForTask ocmv:ConceptualClarification, ocmv:Learning;
+    ocmv:context ocmv:Classroom.
 <https://w3id.org/ontouml-models/model/bank-account2013/> dcat:distribution <https://w3id.org/ontouml-models/model/bank-account2013/distribution/ttl>.
 <https://w3id.org/ontouml-models/model/bank-account2013/distribution/ttl> a dcat:Distribution;
     dct:title "Turtle distribution of \"Bank Account Ontology\""@en;

--- a/models/barcelos2024resiliont/metadata.ttl
+++ b/models/barcelos2024resiliont/metadata.ttl
@@ -1,4 +1,4 @@
-@prefix ontouml: <https://w3id.org/ontouml#>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
 @prefix owl: <http://www.w3.org/2002/07/owl#>.

--- a/models/barcelos2024resiliont/metadata.ttl
+++ b/models/barcelos2024resiliont/metadata.ttl
@@ -19,8 +19,8 @@
     dcat:landingPage <https://w3id.org/resiliont/git>;
     dct:license <https://www.apache.org/licenses/LICENSE-2.0>;
     dct:contributor <https://dblp.org/pid/96/8280>, <https://dblp.org/pid/63/9777>, <https://dblp.org/pid/212/6684>, <https://dblp.org/pid/134/4947>, <https://dblp.org/pid/95/6356>, <https://dblp.org/pid/72/6796>, <https://dblp.org/pid/11/78>;
-    mod:designedForTask ontouml:ConceptualClarification, ontouml:OntologicalAnalysis;
-    ontouml:context ontouml:Research;
+    mod:designedForTask ocmv:ConceptualClarification, ocmv:OntologicalAnalysis;
+    ocmv:context ocmv:Research;
     dct:source <https://raw.githubusercontent.com/pedropaulofb/resiliont/main/resources/Ontological%20Foundations%20of%20Resilience.pdf>.
 <https://w3id.org/ontouml-models/model/barcelos2024resiliont/> dcat:distribution <https://w3id.org/ontouml-models/model/barcelos2024resiliont/distribution/ttl>.
 <https://w3id.org/ontouml-models/model/barcelos2024resiliont/distribution/ttl> a dcat:Distribution;

--- a/models/blums2024ccf/metadata.ttl
+++ b/models/blums2024ccf/metadata.ttl
@@ -1,4 +1,4 @@
-@prefix ontouml: <https://w3id.org/ontouml#>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
 @prefix owl: <http://www.w3.org/2002/07/owl#>.

--- a/models/blums2024ccf/metadata.ttl
+++ b/models/blums2024ccf/metadata.ttl
@@ -17,8 +17,8 @@
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:contributor <https://dblp.org/pid/184/4586.html>, <https://dblp.org/pid/70/260.html>;
-    mod:designedForTask ontouml:ConceptualClarification, ontouml:Interoperability, ontouml:OntologicalAnalysis;
-    ontouml:context ontouml:Research, ontouml:Industry;
+    mod:designedForTask ocmv:ConceptualClarification, ocmv:Interoperability, ocmv:OntologicalAnalysis;
+    ocmv:context ocmv:Research, ocmv:Industry;
     dct:source <http://doi.org/10.13140/RG.2.2.31144.99843>.
 <https://w3id.org/ontouml-models/model/blums2024ccf/> dcat:distribution <https://w3id.org/ontouml-models/model/blums2024ccf/distribution/ttl>.
 <https://w3id.org/ontouml-models/model/blums2024ccf/distribution/ttl> a dcat:Distribution;

--- a/models/calhau2024capabilities/metadata.ttl
+++ b/models/calhau2024capabilities/metadata.ttl
@@ -16,8 +16,8 @@
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:contributor <https://dblp.org/pid/63/9777>, <https://dblp.org/pid/11/78>, <https://dblp.org/pid/134/4947>, <https://dblp.org/pid/212/6684>, <https://dblp.org/pid/269/9350>, <https://dblp.org/pid/91/2201>, <https://dblp.org/pid/91/3408>, <https://dblp.org/pid/p/LuisFerreiraPires>;
-    mod:designedForTask ontouml:ConceptualClarification;
-    ontouml:context ontouml:Research;
+    mod:designedForTask ocmv:ConceptualClarification;
+    ocmv:context ocmv:Research;
     dct:source <https://doi.org/10.1007/s10270-024-01151-7>, <https://doi.org/10.1007/978-3-031-46587-1_1>.
 <https://w3id.org/ontouml-models/model/calhau2024capabilities/> dcat:distribution <https://w3id.org/ontouml-models/model/calhau2024capabilities/distribution/ttl>.
 <https://w3id.org/ontouml-models/model/calhau2024capabilities/distribution/ttl> a dcat:Distribution;

--- a/models/calhau2024capabilities/metadata.ttl
+++ b/models/calhau2024capabilities/metadata.ttl
@@ -1,4 +1,4 @@
-@prefix ontouml: <https://w3id.org/ontouml#>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
 @prefix owl: <http://www.w3.org/2002/07/owl#>.

--- a/models/demori2023miscon/metadata.ttl
+++ b/models/demori2023miscon/metadata.ttl
@@ -1,4 +1,4 @@
-@prefix ontouml: <https://w3id.org/ontouml#>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
 @prefix owl: <http://www.w3.org/2002/07/owl#>.

--- a/models/demori2023miscon/metadata.ttl
+++ b/models/demori2023miscon/metadata.ttl
@@ -18,8 +18,8 @@
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:contributor <https://dblp.org/pid/342/7506>, <https://dblp.org/pid/166/2068>, <https://dblp.org/pid/125/7740>, <https://dblp.org/pid/352/9170>, <https://dblp.org/pid/352/9879>, <https://dblp.org/pid/35/9023>, <https://dblp.org/pid/96/3201>, <https://dblp.org/pid/c/MariaClaudiaReisCavalcanti>;
-    mod:designedForTask ontouml:ConceptualClarification, ontouml:DecisionSupportSystem, ontouml:OntologicalAnalysis;
-    ontouml:context ontouml:Research;
+    mod:designedForTask ocmv:ConceptualClarification, ocmv:DecisionSupportSystem, ocmv:OntologicalAnalysis;
+    ocmv:context ocmv:Research;
     dct:source <https://doi.org/10.5220/0012088600003541>.
 <https://w3id.org/ontouml-models/model/demori2023miscon/> dcat:distribution <https://w3id.org/ontouml-models/model/demori2023miscon/distribution/ttl>.
 <https://w3id.org/ontouml-models/model/demori2023miscon/distribution/ttl> a dcat:Distribution;

--- a/models/elghosh2024eucaim/metadata.ttl
+++ b/models/elghosh2024eucaim/metadata.ttl
@@ -1,4 +1,4 @@
-@prefix ontouml: <https://w3id.org/ontouml#>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
 @prefix owl: <http://www.w3.org/2002/07/owl#>.

--- a/models/elghosh2024eucaim/metadata.ttl
+++ b/models/elghosh2024eucaim/metadata.ttl
@@ -18,8 +18,8 @@
     dcat:landingPage <https://doi.org/10.5281/zenodo.11109765>;
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:contributor <https://dblp.org/pid/199/9510.html>, <https://dblp.org/pid/118/0942.html>, <https://dblp.org/pid/43/1967.html>, <https://dblp.org/pid/d/ChristelDanielLeBozec.html>, <https://dblp.org/pid/96/1080.html>, <https://dblp.org/pid/12/11202.html>, <https://dblp.org/pid/83/4811.html>, <https://dblp.org/pid/47/2102.html>, <https://dblp.org/pid/20/3693.html>;
-    mod:designedForTask ontouml:ConceptualClarification, ontouml:Interoperability, ontouml:OntologicalAnalysis;
-    ontouml:context ontouml:Research, ontouml:Industry;
+    mod:designedForTask ocmv:ConceptualClarification, ocmv:Interoperability, ocmv:OntologicalAnalysis;
+    ocmv:context ocmv:Research, ocmv:Industry;
     dct:source <https://www.utwente.nl/en/eemcs/fois2024/resources/papers/el-ghosh-et-al-towards-semantic-interoperability-among-heterogeneous-cancer-data-models-using-a-layered-modular-hyper-ontology.pdf>, <https://www.utwente.nl/en/eemcs/fois2024/resources/papers/el-ghosh-et-al-grounding-a-hyper-ontology-on-mcode-ontological-conceptual-model-and-foundational-ontologies-for-semantic-interoperability-in-the-oncology-domain.pdf>.
 <https://w3id.org/ontouml-models/model/elghosh2024eucaim/> dcat:distribution <https://w3id.org/ontouml-models/model/elghosh2024eucaim/distribution/ttl>.
 <https://w3id.org/ontouml-models/model/elghosh2024eucaim/distribution/ttl> a dcat:Distribution;

--- a/models/ferreira2024ontopix/metadata.ttl
+++ b/models/ferreira2024ontopix/metadata.ttl
@@ -1,4 +1,4 @@
-@prefix ontouml: <https://w3id.org/ontouml#>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
 @prefix owl: <http://www.w3.org/2002/07/owl#>.

--- a/models/ferreira2024ontopix/metadata.ttl
+++ b/models/ferreira2024ontopix/metadata.ttl
@@ -16,8 +16,8 @@
     dct:language "pt-br";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:contributor <https://www.linkedin.com/in/gabferreira-/>, <https://orcid.org/0009-0005-4081-6615>, <https://dblp.org/pid/309/4924>, <https://dblp.org/pid/b/FAraujoBaiao>;
-    mod:designedForTask ontouml:ConceptualClarification, ontouml:Interoperability, ontouml:OntologicalAnalysis;
-    ontouml:context ontouml:Research;
+    mod:designedForTask ocmv:ConceptualClarification, ocmv:Interoperability, ocmv:OntologicalAnalysis;
+    ocmv:context ocmv:Research;
     dct:source <https://ceur-ws.org/Vol-3905/short2.pdf>.
 <https://w3id.org/ontouml-models/model/ferreira2024ontopix/> dcat:distribution <https://w3id.org/ontouml-models/model/ferreira2024ontopix/distribution/ttl>.
 <https://w3id.org/ontouml-models/model/ferreira2024ontopix/distribution/ttl> a dcat:Distribution;

--- a/models/formula-one2023/metadata.ttl
+++ b/models/formula-one2023/metadata.ttl
@@ -1,4 +1,4 @@
-@prefix ontouml: <https://w3id.org/ontouml#>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
 @prefix owl: <http://www.w3.org/2002/07/owl#>.

--- a/models/formula-one2023/metadata.ttl
+++ b/models/formula-one2023/metadata.ttl
@@ -16,8 +16,8 @@
     dcat:theme lcc:G;
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    mod:designedForTask ontouml:Example;
-    ontouml:context ontouml:Research.
+    mod:designedForTask ocmv:Example;
+    ocmv:context ocmv:Research.
 <https://w3id.org/ontouml-models/model/formula-one2023/> dcat:distribution <https://w3id.org/ontouml-models/model/formula-one2023/distribution/ttl>.
 <https://w3id.org/ontouml-models/model/formula-one2023/distribution/ttl> a dcat:Distribution;
     dct:title "Turtle distribution of \"Formula One Example Ontology\""@en;

--- a/models/genealogy2013/metadata.ttl
+++ b/models/genealogy2013/metadata.ttl
@@ -1,4 +1,4 @@
-@prefix ontouml: <https://w3id.org/ontouml#>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
 @prefix owl: <http://www.w3.org/2002/07/owl#>.

--- a/models/genealogy2013/metadata.ttl
+++ b/models/genealogy2013/metadata.ttl
@@ -16,8 +16,8 @@
     skos:editorialNote "Ontology created during an Ontology Engineering lecture by students who wanted to remain anonymous. The ontology was build in a different editor tool and imported to Visual Paradigm, the current diagrammation may not exactly match the original one.";
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    mod:designedForTask ontouml:ConceptualClarification, ontouml:Learning;
-    ontouml:context ontouml:Classroom.
+    mod:designedForTask ocmv:ConceptualClarification, ocmv:Learning;
+    ocmv:context ocmv:Classroom.
 <https://w3id.org/ontouml-models/model/genealogy2013/> dcat:distribution <https://w3id.org/ontouml-models/model/genealogy2013/distribution/ttl>.
 <https://w3id.org/ontouml-models/model/genealogy2013/distribution/ttl> a dcat:Distribution;
     dct:title "Turtle distribution of \"Simple Genealogy Ontology\""@en;

--- a/models/heirbrant2023boekbazaar/metadata.ttl
+++ b/models/heirbrant2023boekbazaar/metadata.ttl
@@ -1,4 +1,4 @@
-@prefix ontouml: <https://w3id.org/ontouml#>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
 @prefix owl: <http://www.w3.org/2002/07/owl#>.

--- a/models/heirbrant2023boekbazaar/metadata.ttl
+++ b/models/heirbrant2023boekbazaar/metadata.ttl
@@ -18,8 +18,8 @@
     dcat:landingPage <https://boekbazaar.be/home>;
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:contributor <https://www.linkedin.com/in/joachim-heirbrant-532aa1233/>, <https://dblp.org/pid/251/5991>, <https://dblp.org/pid/95/6356>;
-    mod:designedForTask ontouml:ConceptualClarification, ontouml:InformationRetrieval, ontouml:SoftwareEngineering;
-    ontouml:context ontouml:Industry, ontouml:Research;
+    mod:designedForTask ocmv:ConceptualClarification, ocmv:InformationRetrieval, ocmv:SoftwareEngineering;
+    ocmv:context ocmv:Industry, ocmv:Research;
     dct:source <https://lib.ugent.be/catalog/rug01:003144709>, <https://lib.ugent.be/fulltxt/RUG01/003/144/709/RUG01-003144709_2023_0001_AC.pdf>.
 <https://w3id.org/ontouml-models/model/heirbrant2023boekbazaar/> dcat:distribution <https://w3id.org/ontouml-models/model/heirbrant2023boekbazaar/distribution/ttl>.
 <https://w3id.org/ontouml-models/model/heirbrant2023boekbazaar/distribution/ttl> a dcat:Distribution;

--- a/models/leao2024ontomed/metadata.ttl
+++ b/models/leao2024ontomed/metadata.ttl
@@ -1,4 +1,4 @@
-@prefix ontouml: <https://w3id.org/ontouml#>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
 @prefix owl: <http://www.w3.org/2002/07/owl#>.

--- a/models/leao2024ontomed/metadata.ttl
+++ b/models/leao2024ontomed/metadata.ttl
@@ -18,8 +18,8 @@
     dct:language "pt-br";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:contributor <https://www.linkedin.com/in/renzo-henrique-guzzo-le%C3%A3o-193aa4234/>, <https://dblp.org/pid/36/6967>, <https://dblp.org/pid/91/3408>;
-    mod:designedForTask ontouml:DecisionSupportSystem, ontouml:ConceptualClarification, ontouml:OntologicalAnalysis;
-    ontouml:context ontouml:Research;
+    mod:designedForTask ocmv:DecisionSupportSystem, ocmv:ConceptualClarification, ocmv:OntologicalAnalysis;
+    ocmv:context ocmv:Research;
     dct:source <https://doi.org/10.5753/eries.2024.244714>.
 <https://w3id.org/ontouml-models/model/leao2024ontomed/> dcat:distribution <https://w3id.org/ontouml-models/model/leao2024ontomed/distribution/ttl>.
 <https://w3id.org/ontouml-models/model/leao2024ontomed/distribution/ttl> a dcat:Distribution;

--- a/models/lindeberg2024legal-enforcement/metadata.ttl
+++ b/models/lindeberg2024legal-enforcement/metadata.ttl
@@ -1,4 +1,4 @@
-@prefix ontouml: <https://w3id.org/ontouml#>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
 @prefix owl: <http://www.w3.org/2002/07/owl#>.

--- a/models/lindeberg2024legal-enforcement/metadata.ttl
+++ b/models/lindeberg2024legal-enforcement/metadata.ttl
@@ -17,8 +17,8 @@
     dct:language "en-gb";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:contributor <https://orcid.org/0000-0001-7194-9617>, <https://orcid.org/0000-0001-7806-749X>, <https://orcid.org/0000-0001-9044-5836>, <https://orcid.org/0000-0002-7416-8725>, <https://orcid.org/0000-0003-3290-2597>;
-    mod:designedForTask ontouml:ConceptualClarification;
-    ontouml:context ontouml:Research;
+    mod:designedForTask ocmv:ConceptualClarification;
+    ocmv:context ocmv:Research;
     dct:source <https://doi.org/10.1007/978-3-031-75599-6_20>.
 <https://w3id.org/ontouml-models/model/lindeberg2024legal-enforcement/> dcat:distribution <https://w3id.org/ontouml-models/model/lindeberg2024legal-enforcement/distribution/ttl>.
 <https://w3id.org/ontouml-models/model/lindeberg2024legal-enforcement/distribution/ttl> a dcat:Distribution;

--- a/models/machacova2023gym/metadata.ttl
+++ b/models/machacova2023gym/metadata.ttl
@@ -1,4 +1,4 @@
-@prefix ontouml: <https://w3id.org/ontouml#>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
 @prefix owl: <http://www.w3.org/2002/07/owl#>.

--- a/models/machacova2023gym/metadata.ttl
+++ b/models/machacova2023gym/metadata.ttl
@@ -16,8 +16,8 @@
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:contributor <https://dblp.org/pid/358/4857>, <https://dblp.org/pid/253/7051>;
-    mod:designedForTask ontouml:Example;
-    ontouml:context ontouml:Research;
+    mod:designedForTask ocmv:Example;
+    ocmv:context ocmv:Research;
     dct:source <https://dspace.cvut.cz/handle/10467/107233>.
 <https://w3id.org/ontouml-models/model/machacova2023gym/> dcat:distribution <https://w3id.org/ontouml-models/model/machacova2023gym/distribution/ttl>.
 <https://w3id.org/ontouml-models/model/machacova2023gym/distribution/ttl> a dcat:Distribution;

--- a/models/meirelles2024credit-operations/metadata.ttl
+++ b/models/meirelles2024credit-operations/metadata.ttl
@@ -1,4 +1,4 @@
-@prefix ontouml: <https://w3id.org/ontouml#>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
 @prefix owl: <http://www.w3.org/2002/07/owl#>.

--- a/models/meirelles2024credit-operations/metadata.ttl
+++ b/models/meirelles2024credit-operations/metadata.ttl
@@ -16,8 +16,8 @@
     dct:language "pt-br";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:contributor <https://orcid.org/0009-0003-8838-3367>;
-    mod:designedForTask ontouml:ConceptualClarification, ontouml:Interoperability, ontouml:OntologicalAnalysis;
-    ontouml:context ontouml:Research;
+    mod:designedForTask ocmv:ConceptualClarification, ocmv:Interoperability, ocmv:OntologicalAnalysis;
+    ocmv:context ocmv:Research;
     dct:source <http://repositorio.ufes.br/handle/10/18082>.
 <https://w3id.org/ontouml-models/model/meirelles2024credit-operations/> dcat:distribution <https://w3id.org/ontouml-models/model/meirelles2024credit-operations/distribution/ttl>.
 <https://w3id.org/ontouml-models/model/meirelles2024credit-operations/distribution/ttl> a dcat:Distribution;

--- a/models/melo2024onto-educational/metadata.ttl
+++ b/models/melo2024onto-educational/metadata.ttl
@@ -1,4 +1,4 @@
-@prefix ontouml: <https://w3id.org/ontouml#>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
 @prefix owl: <http://www.w3.org/2002/07/owl#>.

--- a/models/melo2024onto-educational/metadata.ttl
+++ b/models/melo2024onto-educational/metadata.ttl
@@ -17,8 +17,8 @@
     dct:language "pt-br";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:contributor <https://dblp.org/pid/368/9900>, <https://dblp.org/pid/121/5314>;
-    mod:designedForTask ontouml:ConceptualClarification, ontouml:InformationRetrieval, ontouml:Interoperability;
-    ontouml:context ontouml:Research;
+    mod:designedForTask ocmv:ConceptualClarification, ocmv:InformationRetrieval, ocmv:Interoperability;
+    ocmv:context ocmv:Research;
     dct:source <https://www.inf.ufrgs.br/ontobras/wp-content/uploads/2024/10/ontobras_2024_paper_4.pdf>.
 <https://w3id.org/ontouml-models/model/melo2024onto-educational/> dcat:distribution <https://w3id.org/ontouml-models/model/melo2024onto-educational/distribution/ttl>.
 <https://w3id.org/ontouml-models/model/melo2024onto-educational/distribution/ttl> a dcat:Distribution;

--- a/models/mgic-antt2011/metadata.ttl
+++ b/models/mgic-antt2011/metadata.ttl
@@ -1,4 +1,4 @@
-@prefix ontouml: <https://w3id.org/ontouml#>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
 @prefix owl: <http://www.w3.org/2002/07/owl#>.

--- a/models/mgic-antt2011/metadata.ttl
+++ b/models/mgic-antt2011/metadata.ttl
@@ -17,8 +17,8 @@
     skos:editorialNote "The models were imported to Visual Paradigm from a file generated from the last known version of the complete ontology, which was originally build on Enterprise Architect. After the importation, unused elements were removed and stereotypes fixed using the OntoUML plugin for Visual Paradigm. The diagrams were kept as they were, only with organization of relationships. Some notes for internal use were removed, but domain notes were kept. Essential and inseparable constraints were kept in the visualization, but the meta-properties were added to their corresponding compositions. Class Fiscal da ANTT 2 was merged to class Fiscal da ANTT, however Fiscal 2 was not merged to Fiscal because of their different stereotypes. The original diagrams were also generated from the same eap file, however, for these, nothing was done in order to correct the layout of the diagrams and importation problems may have happened. The main-source for this work does not describe the ontology itself, but the project in which the ontology was built. The original file also contained goal models, which were removed.";
     dct:language "pt-br";
     dct:contributor <https://dblp.org/pid/96/8280>, <https://dblp.org/pid/134/4947>, <https://dblp.org/pid/54/10278>;
-    mod:designedForTask ontouml:ConceptualClarification;
-    ontouml:context ontouml:Industry;
+    mod:designedForTask ocmv:ConceptualClarification;
+    ocmv:context ocmv:Industry;
     dct:source <https://www.scitepress.org/Link.aspx?doi=10.5220/0003695200030011>.
 <https://w3id.org/ontouml-models/model/mgic-antt2011/> dcat:distribution <https://w3id.org/ontouml-models/model/mgic-antt2011/distribution/ttl>.
 <https://w3id.org/ontouml-models/model/mgic-antt2011/distribution/ttl> a dcat:Distribution;

--- a/models/nascimento2023spacecon/metadata.ttl
+++ b/models/nascimento2023spacecon/metadata.ttl
@@ -1,4 +1,4 @@
-@prefix ontouml: <https://w3id.org/ontouml#>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
 @prefix owl: <http://www.w3.org/2002/07/owl#>.

--- a/models/nascimento2023spacecon/metadata.ttl
+++ b/models/nascimento2023spacecon/metadata.ttl
@@ -18,8 +18,8 @@
     dcat:landingPage <https://github.com/lvnascimento/spacecon>;
     dct:license <https://opensource.org/license/mit>;
     dct:contributor <https://dblp.org/pid/45/3567>, <https://dblp.org/pid/o/JosePalazzoMoreiradeOliveira>;
-    mod:designedForTask ontouml:ConceptualClarification, ontouml:Interoperability;
-    ontouml:context ontouml:Research;
+    mod:designedForTask ocmv:ConceptualClarification, ocmv:Interoperability;
+    ocmv:context ocmv:Research;
     dct:source <https://doi.org/10.1007/978-3-031-47262-6_19>.
 <https://w3id.org/ontouml-models/model/nascimento2023spacecon/> dcat:distribution <https://w3id.org/ontouml-models/model/nascimento2023spacecon/distribution/ttl>.
 <https://w3id.org/ontouml-models/model/nascimento2023spacecon/distribution/ttl> a dcat:Distribution;

--- a/models/nazar2024marchine-learning/metadata.ttl
+++ b/models/nazar2024marchine-learning/metadata.ttl
@@ -1,4 +1,4 @@
-@prefix ontouml: <https://w3id.org/ontouml#>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
 @prefix owl: <http://www.w3.org/2002/07/owl#>.

--- a/models/nazar2024marchine-learning/metadata.ttl
+++ b/models/nazar2024marchine-learning/metadata.ttl
@@ -17,8 +17,8 @@
     dct:language "pt-br";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:contributor <https://www.linkedin.com/in/antonio-nazar/>, <https://www.linkedin.com/in/gabriel-trindade-corr%C3%AAa-15526b342/>;
-    mod:designedForTask ontouml:Learning;
-    ontouml:context ontouml:Classroom.
+    mod:designedForTask ocmv:Learning;
+    ocmv:context ocmv:Classroom.
 <https://w3id.org/ontouml-models/model/nazar2024marchine-learning/> dcat:distribution <https://w3id.org/ontouml-models/model/nazar2024marchine-learning/distribution/ttl>.
 <https://w3id.org/ontouml-models/model/nazar2024marchine-learning/distribution/ttl> a dcat:Distribution;
     dct:title "Turtle distribution of \"Machine Learning Ontology\""@en;

--- a/models/o3ontology2015/metadata.ttl
+++ b/models/o3ontology2015/metadata.ttl
@@ -1,4 +1,4 @@
-@prefix ontouml: <https://w3id.org/ontouml#>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
 @prefix owl: <http://www.w3.org/2002/07/owl#>.

--- a/models/o3ontology2015/metadata.ttl
+++ b/models/o3ontology2015/metadata.ttl
@@ -16,8 +16,8 @@
     skos:editorialNote "Author wanted to remain anonymous. The ontology was build in a different editor tool and imported to Visual Paradigm, the current diagrammation may not exactly match the original one.";
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    mod:designedForTask ontouml:ConceptualClarification, ontouml:SoftwareEngineering;
-    ontouml:context ontouml:Research.
+    mod:designedForTask ocmv:ConceptualClarification, ocmv:SoftwareEngineering;
+    ocmv:context ocmv:Research.
 <https://w3id.org/ontouml-models/model/o3ontology2015/> dcat:distribution <https://w3id.org/ontouml-models/model/o3ontology2015/distribution/ttl>.
 <https://w3id.org/ontouml-models/model/o3ontology2015/distribution/ttl> a dcat:Distribution;
     dct:title "Turtle distribution of \"O3 Ontology\""@en;

--- a/models/parking-business2013/metadata.ttl
+++ b/models/parking-business2013/metadata.ttl
@@ -1,4 +1,4 @@
-@prefix ontouml: <https://w3id.org/ontouml#>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
 @prefix owl: <http://www.w3.org/2002/07/owl#>.

--- a/models/parking-business2013/metadata.ttl
+++ b/models/parking-business2013/metadata.ttl
@@ -16,8 +16,8 @@
     skos:editorialNote "Ontology created during a lecture by students who wanted to remain anonymous. The ontology was build in a different editor tool and imported to Visual Paradigm, the current diagrammation may not exactly match the original one.";
     dct:language "pt-br";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    mod:designedForTask ontouml:ConceptualClarification, ontouml:Learning;
-    ontouml:context ontouml:Classroom.
+    mod:designedForTask ocmv:ConceptualClarification, ocmv:Learning;
+    ocmv:context ocmv:Classroom.
 <https://w3id.org/ontouml-models/model/parking-business2013/> dcat:distribution <https://w3id.org/ontouml-models/model/parking-business2013/distribution/ttl>.
 <https://w3id.org/ontouml-models/model/parking-business2013/distribution/ttl> a dcat:Distribution;
     dct:title "Turtle distribution of \"Parking Business Ontology\""@en;

--- a/models/piest2024dsr-kb/metadata.ttl
+++ b/models/piest2024dsr-kb/metadata.ttl
@@ -18,8 +18,8 @@
     dcat:landingPage <https://github.com/SebastianPiest/dsr-kb>;
     dct:license <https://opensource.org/licenses/MIT>;
     dct:contributor <https://dblp.org/pid/187/6481>, <https://dblp.org/pid/377/0420>, <https://dblp.org/pid/63/5160>, <https://www.linkedin.com/in/ricardo-junior-cunha/>;
-    mod:designedForTask ontouml:ConceptualClarification, ontouml:OntologicalAnalysis;
-    ontouml:context ontouml:Research;
+    mod:designedForTask ocmv:ConceptualClarification, ocmv:OntologicalAnalysis;
+    ocmv:context ocmv:Research;
     dct:source <https://www.utwente.nl/en/eemcs/fois2024/resources/papers/piest-et-al-a-domain-reference-ontology-for-design-science-research-knowledge-bases.pdf>.
 <https://w3id.org/ontouml-models/model/piest2024dsr-kb/> dcat:distribution <https://w3id.org/ontouml-models/model/piest2024dsr-kb/distribution/ttl>.
 <https://w3id.org/ontouml-models/model/piest2024dsr-kb/distribution/ttl> a dcat:Distribution;

--- a/models/piest2024dsr-kb/metadata.ttl
+++ b/models/piest2024dsr-kb/metadata.ttl
@@ -1,4 +1,4 @@
-@prefix ontouml: <https://w3id.org/ontouml#>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
 @prefix owl: <http://www.w3.org/2002/07/owl#>.

--- a/models/pinheiro2024api/metadata.ttl
+++ b/models/pinheiro2024api/metadata.ttl
@@ -1,4 +1,4 @@
-@prefix ontouml: <https://w3id.org/ontouml#>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
 @prefix owl: <http://www.w3.org/2002/07/owl#>.

--- a/models/pinheiro2024api/metadata.ttl
+++ b/models/pinheiro2024api/metadata.ttl
@@ -16,8 +16,8 @@
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:contributor <https://dblp.org/pid/306/9640>, <https://dblp.org/pid/38/10199>, <https://dblp.org/pid/217/4594>;
-    mod:designedForTask ontouml:ConceptualClarification;
-    ontouml:context ontouml:Research;
+    mod:designedForTask ocmv:ConceptualClarification;
+    ocmv:context ocmv:Research;
     dct:source <https://doi.org/10.1007/978-3-031-64755-0_13>.
 <https://w3id.org/ontouml-models/model/pinheiro2024api/> dcat:distribution <https://w3id.org/ontouml-models/model/pinheiro2024api/distribution/ttl>.
 <https://w3id.org/ontouml-models/model/pinheiro2024api/distribution/ttl> a dcat:Distribution;

--- a/models/project-assets2013/metadata.ttl
+++ b/models/project-assets2013/metadata.ttl
@@ -1,4 +1,4 @@
-@prefix ontouml: <https://w3id.org/ontouml#>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
 @prefix owl: <http://www.w3.org/2002/07/owl#>.

--- a/models/project-assets2013/metadata.ttl
+++ b/models/project-assets2013/metadata.ttl
@@ -16,8 +16,8 @@
     skos:editorialNote "Ontology created during a lecture by students who wanted to remain anonymous. The ontology was build in a different editor tool and imported to Visual Paradigm, the current diagrammation may not exactly match the original one.";
     dct:language "pt-br";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    mod:designedForTask ontouml:ConceptualClarification, ontouml:Learning;
-    ontouml:context ontouml:Classroom.
+    mod:designedForTask ocmv:ConceptualClarification, ocmv:Learning;
+    ocmv:context ocmv:Classroom.
 <https://w3id.org/ontouml-models/model/project-assets2013/> dcat:distribution <https://w3id.org/ontouml-models/model/project-assets2013/distribution/ttl>.
 <https://w3id.org/ontouml-models/model/project-assets2013/distribution/ttl> a dcat:Distribution;
     dct:title "Turtle distribution of \"Project Assets\""@en;

--- a/models/public-organization2013/metadata.ttl
+++ b/models/public-organization2013/metadata.ttl
@@ -1,4 +1,4 @@
-@prefix ontouml: <https://w3id.org/ontouml#>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
 @prefix owl: <http://www.w3.org/2002/07/owl#>.

--- a/models/public-organization2013/metadata.ttl
+++ b/models/public-organization2013/metadata.ttl
@@ -16,8 +16,8 @@
     skos:editorialNote "Ontology created during an Ontology Engineering lecture by students who wanted to remain anonymous. The ontology was build in a different editor tool and imported to Visual Paradigm, the current diagrammation may not exactly match the original one.";
     dct:language "pt-br";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    mod:designedForTask ontouml:ConceptualClarification, ontouml:Learning;
-    ontouml:context ontouml:Classroom.
+    mod:designedForTask ocmv:ConceptualClarification, ocmv:Learning;
+    ocmv:context ocmv:Classroom.
 <https://w3id.org/ontouml-models/model/public-organization2013/> dcat:distribution <https://w3id.org/ontouml-models/model/public-organization2013/distribution/ttl>.
 <https://w3id.org/ontouml-models/model/public-organization2013/distribution/ttl> a dcat:Distribution;
     dct:title "Turtle distribution of \"Ecology Public Organization\""@en;

--- a/models/road-accident2013/metadata.ttl
+++ b/models/road-accident2013/metadata.ttl
@@ -16,8 +16,8 @@
     skos:editorialNote "Ontology created during an Ontology Engineering lecture by students who wanted to remain anonymous. The ontology was build in a different editor tool and imported to Visual Paradigm, the current diagrammation may not exactly match the original one.";
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    mod:designedForTask ontouml:ConceptualClarification, ontouml:Learning;
-    ontouml:context ontouml:Classroom.
+    mod:designedForTask ocmv:ConceptualClarification, ocmv:Learning;
+    ocmv:context ocmv:Classroom.
 <https://w3id.org/ontouml-models/model/road-accident2013/> dcat:distribution <https://w3id.org/ontouml-models/model/road-accident2013/distribution/ttl>.
 <https://w3id.org/ontouml-models/model/road-accident2013/distribution/ttl> a dcat:Distribution;
     dct:title "Turtle distribution of \"Road Traffic Accident Ontology\""@en;

--- a/models/road-accident2013/metadata.ttl
+++ b/models/road-accident2013/metadata.ttl
@@ -1,4 +1,4 @@
-@prefix ontouml: <https://w3id.org/ontouml#>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
 @prefix owl: <http://www.w3.org/2002/07/owl#>.

--- a/models/rocha2023ciencia-aberta/metadata.ttl
+++ b/models/rocha2023ciencia-aberta/metadata.ttl
@@ -1,4 +1,4 @@
-@prefix ontouml: <https://w3id.org/ontouml#>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
 @prefix owl: <http://www.w3.org/2002/07/owl#>.

--- a/models/rocha2023ciencia-aberta/metadata.ttl
+++ b/models/rocha2023ciencia-aberta/metadata.ttl
@@ -16,8 +16,8 @@
     dct:language "pt-br";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:contributor <https://dblp.org/pid/222/8384>, <https://orcid.org/0000-0003-0650-0121>;
-    mod:designedForTask ontouml:ConceptualClarification, ontouml:Interoperability;
-    ontouml:context ontouml:Research;
+    mod:designedForTask ocmv:ConceptualClarification, ocmv:Interoperability;
+    ocmv:context ocmv:Research;
     dct:source <https://periodicos.ufmg.br/index.php/fronteiras-rc/article/view/42050>.
 <https://w3id.org/ontouml-models/model/rocha2023ciencia-aberta/> dcat:distribution <https://w3id.org/ontouml-models/model/rocha2023ciencia-aberta/distribution/ttl>.
 <https://w3id.org/ontouml-models/model/rocha2023ciencia-aberta/distribution/ttl> a dcat:Distribution;

--- a/models/sariev2024maritime/metadata.ttl
+++ b/models/sariev2024maritime/metadata.ttl
@@ -1,4 +1,4 @@
-@prefix ontouml: <https://w3id.org/ontouml#>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
 @prefix owl: <http://www.w3.org/2002/07/owl#>.

--- a/models/sariev2024maritime/metadata.ttl
+++ b/models/sariev2024maritime/metadata.ttl
@@ -16,8 +16,8 @@
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:contributor <https://www.linkedin.com/in/bekbolot-sariev-7bb6b0265/>;
-    mod:designedForTask ontouml:ConceptualClarification, ontouml:Interoperability, ontouml:DecisionSupportSystem;
-    ontouml:context ontouml:Research;
+    mod:designedForTask ocmv:ConceptualClarification, ocmv:Interoperability, ocmv:DecisionSupportSystem;
+    ocmv:context ocmv:Research;
     dct:source <https://purl.utwente.nl/essays/101204>.
 <https://w3id.org/ontouml-models/model/sariev2024maritime/> dcat:distribution <https://w3id.org/ontouml-models/model/sariev2024maritime/distribution/ttl>.
 <https://w3id.org/ontouml-models/model/sariev2024maritime/distribution/ttl> a dcat:Distribution;

--- a/models/schoonderbeek2024eamon/metadata.ttl
+++ b/models/schoonderbeek2024eamon/metadata.ttl
@@ -1,4 +1,4 @@
-@prefix ontouml: <https://w3id.org/ontouml#>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
 @prefix owl: <http://www.w3.org/2002/07/owl#>.

--- a/models/schoonderbeek2024eamon/metadata.ttl
+++ b/models/schoonderbeek2024eamon/metadata.ttl
@@ -17,8 +17,8 @@
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:contributor <https://dblp.org/pid/381/4970>, <https://dblp.org/pid/p/ErikProper>;
-    mod:designedForTask ontouml:ConceptualClarification, ontouml:OntologicalAnalysis;
-    ontouml:context ontouml:Research;
+    mod:designedForTask ocmv:ConceptualClarification, ocmv:OntologicalAnalysis;
+    ocmv:context ocmv:Research;
     dct:source <https://doi.org/10.1007/s10270-023-01146-w>.
 <https://w3id.org/ontouml-models/model/schoonderbeek2024eamon/> dcat:distribution <https://w3id.org/ontouml-models/model/schoonderbeek2024eamon/distribution/ttl>.
 <https://w3id.org/ontouml-models/model/schoonderbeek2024eamon/distribution/ttl> a dcat:Distribution;

--- a/models/scientific-experiment2013/metadata.ttl
+++ b/models/scientific-experiment2013/metadata.ttl
@@ -16,8 +16,8 @@
     skos:editorialNote "Ontology created during an Ontology Engineering lecture by students who wanted to remain anonymous. The ontology was build in a different editor tool and imported to Visual Paradigm, the current diagrammation may not exactly match the original one.";
     dct:language "pt-br";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    mod:designedForTask ontouml:ConceptualClarification, ontouml:Learning;
-    ontouml:context ontouml:Classroom.
+    mod:designedForTask ocmv:ConceptualClarification, ocmv:Learning;
+    ocmv:context ocmv:Classroom.
 <https://w3id.org/ontouml-models/model/scientific-experiment2013/> dcat:distribution <https://w3id.org/ontouml-models/model/scientific-experiment2013/distribution/ttl>.
 <https://w3id.org/ontouml-models/model/scientific-experiment2013/distribution/ttl> a dcat:Distribution;
     dct:title "Turtle distribution of \"Scientific Experiment Ontology\""@en;

--- a/models/scientific-experiment2013/metadata.ttl
+++ b/models/scientific-experiment2013/metadata.ttl
@@ -1,4 +1,4 @@
-@prefix ontouml: <https://w3id.org/ontouml#>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
 @prefix owl: <http://www.w3.org/2002/07/owl#>.

--- a/models/scientific-publication2013/metadata.ttl
+++ b/models/scientific-publication2013/metadata.ttl
@@ -1,4 +1,4 @@
-@prefix ontouml: <https://w3id.org/ontouml#>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
 @prefix owl: <http://www.w3.org/2002/07/owl#>.

--- a/models/scientific-publication2013/metadata.ttl
+++ b/models/scientific-publication2013/metadata.ttl
@@ -16,8 +16,8 @@
     skos:editorialNote "Ontology created during an Ontology Engineering lecture by students who wanted to remain anonymous. The ontology was build in a different editor tool and imported to Visual Paradigm, the current diagrammation may not exactly match the original one.";
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    mod:designedForTask ontouml:ConceptualClarification, ontouml:Learning;
-    ontouml:context ontouml:Classroom.
+    mod:designedForTask ocmv:ConceptualClarification, ocmv:Learning;
+    ocmv:context ocmv:Classroom.
 <https://w3id.org/ontouml-models/model/scientific-publication2013/> dcat:distribution <https://w3id.org/ontouml-models/model/scientific-publication2013/distribution/ttl>.
 <https://w3id.org/ontouml-models/model/scientific-publication2013/distribution/ttl> a dcat:Distribution;
     dct:title "Turtle distribution of \"Scientific Publication Ontology\""@en;

--- a/models/services2015/metadata.ttl
+++ b/models/services2015/metadata.ttl
@@ -16,8 +16,8 @@
     skos:editorialNote "Author required to remain anonymous.";
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    mod:designedForTask ontouml:ConceptualClarification;
-    ontouml:context ontouml:Industry.
+    mod:designedForTask ocmv:ConceptualClarification;
+    ocmv:context ocmv:Industry.
 <https://w3id.org/ontouml-models/model/services2015/> dcat:distribution <https://w3id.org/ontouml-models/model/services2015/distribution/ttl>.
 <https://w3id.org/ontouml-models/model/services2015/distribution/ttl> a dcat:Distribution;
     dct:title "Turtle distribution of \"Services Ontology\""@en;

--- a/models/services2015/metadata.ttl
+++ b/models/services2015/metadata.ttl
@@ -1,4 +1,4 @@
-@prefix ontouml: <https://w3id.org/ontouml#>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
 @prefix owl: <http://www.w3.org/2002/07/owl#>.

--- a/models/short-examples2013/metadata.ttl
+++ b/models/short-examples2013/metadata.ttl
@@ -1,4 +1,4 @@
-@prefix ontouml: <https://w3id.org/ontouml#>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
 @prefix owl: <http://www.w3.org/2002/07/owl#>.

--- a/models/short-examples2013/metadata.ttl
+++ b/models/short-examples2013/metadata.ttl
@@ -16,8 +16,8 @@
     skos:editorialNote "Ontology created during an Ontology Engineering lecture by students who wanted to remain anonymous. The ontology was build in a different editor tool and imported to Visual Paradigm, the current diagrammation may not exactly match the original one.";
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    mod:designedForTask ontouml:Learning;
-    ontouml:context ontouml:Classroom.
+    mod:designedForTask ocmv:Learning;
+    ocmv:context ocmv:Classroom.
 <https://w3id.org/ontouml-models/model/short-examples2013/> dcat:distribution <https://w3id.org/ontouml-models/model/short-examples2013/distribution/ttl>.
 <https://w3id.org/ontouml-models/model/short-examples2013/distribution/ttl> a dcat:Distribution;
     dct:title "Turtle distribution of \"Short Examples of OntoUML Ontologies\""@en;

--- a/models/silva2021sebim/metadata.ttl
+++ b/models/silva2021sebim/metadata.ttl
@@ -1,4 +1,4 @@
-@prefix ontouml: <https://w3id.org/ontouml#>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
 @prefix owl: <http://www.w3.org/2002/07/owl#>.

--- a/models/silva2021sebim/metadata.ttl
+++ b/models/silva2021sebim/metadata.ttl
@@ -20,8 +20,8 @@
     dcat:landingPage <https://github.com/cgtsbr/sebim>;
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:contributor <https://dblp.org/pid/278/1460>, <https://dblp.org/pid/121/5314>;
-    mod:designedForTask ontouml:DecisionSupportSystem, ontouml:InformationRetrieval, ontouml:Interoperability;
-    ontouml:context ontouml:Research, ontouml:Industry;
+    mod:designedForTask ocmv:DecisionSupportSystem, ocmv:InformationRetrieval, ocmv:Interoperability;
+    ocmv:context ocmv:Research, ocmv:Industry;
     dct:source <https://repositorio.ufmg.br/handle/1843/51648>, <https://repositorio.ufmg.br/handle/1843/51649>, <https://repositorio.ufmg.br/handle/1843/59093>, <https://repositorio.ufmg.br/handle/1843/59670>.
 <https://w3id.org/ontouml-models/model/silva2021sebim/> dcat:distribution <https://w3id.org/ontouml-models/model/silva2021sebim/distribution/ttl>.
 <https://w3id.org/ontouml-models/model/silva2021sebim/distribution/ttl> a dcat:Distribution;

--- a/models/silva2023onto4caal/metadata.ttl
+++ b/models/silva2023onto4caal/metadata.ttl
@@ -1,4 +1,4 @@
-@prefix ontouml: <https://w3id.org/ontouml#>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
 @prefix owl: <http://www.w3.org/2002/07/owl#>.

--- a/models/silva2023onto4caal/metadata.ttl
+++ b/models/silva2023onto4caal/metadata.ttl
@@ -18,8 +18,8 @@
     dcat:landingPage <https://github.com/timoteogomes/Nota-o-UML-da-Onto4CAAL>, <https://github.com/timoteogomes/Notacao-UML-da-Onto4Elev>;
     dct:license <https://creativecommons.org/licenses/by-nc-nd/3.0/br/>;
     dct:contributor <https://dblp.org/pid/237/7238>, <https://dblp.org/pid/31/5316>;
-    mod:designedForTask ontouml:ConceptualClarification, ontouml:DecisionSupportSystem, ontouml:Interoperability;
-    ontouml:context ontouml:Research;
+    mod:designedForTask ocmv:ConceptualClarification, ocmv:DecisionSupportSystem, ocmv:Interoperability;
+    ocmv:context ocmv:Research;
     dct:source <https://repositorio.ufpe.br/handle/123456789/50033>, <https://doi.org/10.1093/comjnl/bxad053>, <http://wer.inf.puc-rio.br/WERpapers/artigos/artigos_WER22/WER_2022_Camera_ready_paper_34.pdf>, <http://www.inf.puc-rio.br/~wer/WERpapers/artigos/artigos_WER21/WER_2021_paper_16.pdf>.
 <https://w3id.org/ontouml-models/model/silva2023onto4caal/> dcat:distribution <https://w3id.org/ontouml-models/model/silva2023onto4caal/distribution/ttl>.
 <https://w3id.org/ontouml-models/model/silva2023onto4caal/distribution/ttl> a dcat:Distribution;

--- a/models/silva2023onto4elev/metadata.ttl
+++ b/models/silva2023onto4elev/metadata.ttl
@@ -1,4 +1,4 @@
-@prefix ontouml: <https://w3id.org/ontouml#>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
 @prefix owl: <http://www.w3.org/2002/07/owl#>.

--- a/models/silva2023onto4elev/metadata.ttl
+++ b/models/silva2023onto4elev/metadata.ttl
@@ -18,8 +18,8 @@
     dcat:landingPage <https://github.com/timoteogomes/Nota-o-UML-da-Onto4CAAL>, <https://github.com/timoteogomes/Notacao-UML-da-Onto4Elev>;
     dct:license <https://creativecommons.org/licenses/by-nc-nd/3.0/br/>;
     dct:contributor <https://dblp.org/pid/237/7238>, <https://dblp.org/pid/31/5316>;
-    mod:designedForTask ontouml:ConceptualClarification, ontouml:DecisionSupportSystem, ontouml:Interoperability;
-    ontouml:context ontouml:Research;
+    mod:designedForTask ocmv:ConceptualClarification, ocmv:DecisionSupportSystem, ocmv:Interoperability;
+    ocmv:context ocmv:Research;
     dct:source <https://repositorio.ufpe.br/handle/123456789/50033>, <https://doi.org/10.1093/comjnl/bxad053>, <http://wer.inf.puc-rio.br/WERpapers/artigos/artigos_WER22/WER_2022_Camera_ready_paper_34.pdf>, <http://www.inf.puc-rio.br/~wer/WERpapers/artigos/artigos_WER21/WER_2021_paper_16.pdf>.
 <https://w3id.org/ontouml-models/model/silva2023onto4elev/> dcat:distribution <https://w3id.org/ontouml-models/model/silva2023onto4elev/distribution/ttl>.
 <https://w3id.org/ontouml-models/model/silva2023onto4elev/distribution/ttl> a dcat:Distribution;

--- a/models/soares2024fair/metadata.ttl
+++ b/models/soares2024fair/metadata.ttl
@@ -1,4 +1,4 @@
-@prefix ontouml: <https://w3id.org/ontouml#>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
 @prefix owl: <http://www.w3.org/2002/07/owl#>.

--- a/models/soares2024fair/metadata.ttl
+++ b/models/soares2024fair/metadata.ttl
@@ -17,8 +17,8 @@
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:contributor <https://dblp.org/pid/331/1678>, <https://dblp.org/pid/p/LuisFerreiraPires>, <https://dblp.org/pid/68/84>, <https://dblp.org/pid/63/9777>, <https://dblp.org/pid/205/0604>, <https://dblp.org/pid/15/5508>, <https://dblp.org/pid/19/6474>, <https://dblp.org/pid/44/1984>, <https://dblp.org/pid/331/1865>, <https://dblp.org/pid/121/5232>, <https://dblp.org/pid/92/5149>, <https://dblp.org/pid/77/7381>, <https://dblp.org/pid/00/2863>, <https://dblp.org/pid/91/10025>, <https://dblp.org/pid/181/6647>, <https://dblp.org/pid/331/1682>, <https://dblp.org/pid/89/2110>, <https://dblp.org/pid/92/3940>, <https://dblp.org/pid/82/9539> ;
-    mod:designedForTask ontouml:ConceptualClarification, ontouml:Interoperability;
-    ontouml:context ontouml:Research;
+    mod:designedForTask ocmv:ConceptualClarification, ocmv:Interoperability;
+    ocmv:context ocmv:Research;
     dct:source <https://ceur-ws.org/Vol-3849/forum4.pdf>.
 <https://w3id.org/ontouml-models/model/soares2024fair/> dcat:distribution <https://w3id.org/ontouml-models/model/soares2024fair/distribution/ttl>.
 <https://w3id.org/ontouml-models/model/soares2024fair/distribution/ttl> a dcat:Distribution;

--- a/models/social-contracts2013/metadata.ttl
+++ b/models/social-contracts2013/metadata.ttl
@@ -1,4 +1,4 @@
-@prefix ontouml: <https://w3id.org/ontouml#>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
 @prefix owl: <http://www.w3.org/2002/07/owl#>.

--- a/models/social-contracts2013/metadata.ttl
+++ b/models/social-contracts2013/metadata.ttl
@@ -16,8 +16,8 @@
     skos:editorialNote "Ontology created during a lecture by students who wanted to remain anonymous. The ontology was build in a different editor tool and imported to Visual Paradigm, the current diagrammation may not exactly match the original one.";
     dct:language "pt-br";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    mod:designedForTask ontouml:ConceptualClarification, ontouml:Learning;
-    ontouml:context ontouml:Classroom.
+    mod:designedForTask ocmv:ConceptualClarification, ocmv:Learning;
+    ocmv:context ocmv:Classroom.
 <https://w3id.org/ontouml-models/model/social-contracts2013/> dcat:distribution <https://w3id.org/ontouml-models/model/social-contracts2013/distribution/ttl>.
 <https://w3id.org/ontouml-models/model/social-contracts2013/distribution/ttl> a dcat:Distribution;
     dct:title "Turtle distribution of \"State and Social Contracts Ontology\""@en;

--- a/models/telecom-equipment2013/metadata.ttl
+++ b/models/telecom-equipment2013/metadata.ttl
@@ -16,8 +16,8 @@
     skos:editorialNote "Ontology created during an Ontology Engineering lecture by students who wanted to remain anonymous. The ontology was build in a different editor tool and imported to Visual Paradigm, the current diagrammation may not exactly match the original one.";
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    mod:designedForTask ontouml:ConceptualClarification, ontouml:Learning;
-    ontouml:context ontouml:Classroom.
+    mod:designedForTask ocmv:ConceptualClarification, ocmv:Learning;
+    ocmv:context ocmv:Classroom.
 <https://w3id.org/ontouml-models/model/telecom-equipment2013/> dcat:distribution <https://w3id.org/ontouml-models/model/telecom-equipment2013/distribution/ttl>.
 <https://w3id.org/ontouml-models/model/telecom-equipment2013/distribution/ttl> a dcat:Distribution;
     dct:title "Turtle distribution of \"Telecommunications Equipment\""@en;

--- a/models/telecom-equipment2013/metadata.ttl
+++ b/models/telecom-equipment2013/metadata.ttl
@@ -1,4 +1,4 @@
-@prefix ontouml: <https://w3id.org/ontouml#>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
 @prefix owl: <http://www.w3.org/2002/07/owl#>.

--- a/models/tender2013/metadata.ttl
+++ b/models/tender2013/metadata.ttl
@@ -1,4 +1,4 @@
-@prefix ontouml: <https://w3id.org/ontouml#>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
 @prefix owl: <http://www.w3.org/2002/07/owl#>.

--- a/models/tender2013/metadata.ttl
+++ b/models/tender2013/metadata.ttl
@@ -16,8 +16,8 @@
     skos:editorialNote "Ontology created during an Ontology Engineering lecture by students who wanted to remain anonymous. The ontology was build in a different editor tool and imported to Visual Paradigm, the current diagrammation may not exactly match the original one.";
     dct:language "pt-br";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    mod:designedForTask ontouml:ConceptualClarification, ontouml:Learning;
-    ontouml:context ontouml:Classroom.
+    mod:designedForTask ocmv:ConceptualClarification, ocmv:Learning;
+    ocmv:context ocmv:Classroom.
 <https://w3id.org/ontouml-models/model/tender2013/> dcat:distribution <https://w3id.org/ontouml-models/model/tender2013/distribution/ttl>.
 <https://w3id.org/ontouml-models/model/tender2013/distribution/ttl> a dcat:Distribution;
     dct:title "Turtle distribution of \"Tender Ontology\""@en;

--- a/models/tesolin2023hint/metadata.ttl
+++ b/models/tesolin2023hint/metadata.ttl
@@ -1,4 +1,4 @@
-@prefix ontouml: <https://w3id.org/ontouml#>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
 @prefix owl: <http://www.w3.org/2002/07/owl#>.

--- a/models/tesolin2023hint/metadata.ttl
+++ b/models/tesolin2023hint/metadata.ttl
@@ -18,8 +18,8 @@
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:contributor <https://dblp.org/pid/166/2068>, <https://dblp.org/pid/342/7506>, <https://dblp.org/pid/125/7740>, <https://dblp.org/pid/c/MariaClaudiaReisCavalcanti>;
-    mod:designedForTask ontouml:ConceptualClarification, ontouml:DecisionSupportSystem, ontouml:OntologicalAnalysis;
-    ontouml:context ontouml:Research;
+    mod:designedForTask ocmv:ConceptualClarification, ocmv:DecisionSupportSystem, ocmv:OntologicalAnalysis;
+    ocmv:context ocmv:Research;
     dct:source <https://doi.org/10.1016/j.future.2023.08.008>, <https://ceur-ws.org/Vol-3346/Paper6.pdf>.
 <https://w3id.org/ontouml-models/model/tesolin2023hint/> dcat:distribution <https://w3id.org/ontouml-models/model/tesolin2023hint/distribution/ttl>.
 <https://w3id.org/ontouml-models/model/tesolin2023hint/distribution/ttl> a dcat:Distribution;

--- a/models/xhani2023xmlpo/metadata.ttl
+++ b/models/xhani2023xmlpo/metadata.ttl
@@ -19,8 +19,8 @@
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:contributor <https://orcid.org/0000-0003-2536-0574>, <https://dblp.org/pid/74/7740>, <https://dblp.org/pid/s/MartenvanSinderen>, <https://dblp.org/pid/p/LuisFerreiraPires>;
-    mod:designedForTask ontouml:ConceptualClarification;
-    ontouml:context ontouml:Research;
+    mod:designedForTask ocmv:ConceptualClarification;
+    ocmv:context ocmv:Research;
     dct:source <https://doi.org/10.3990/1.9789036558594>, <https://www.utwente.nl/en/eemcs/fois2024/resources/papers/xhani-next-generation-cross-sectoral-data-platform-for-the-agri-food-sector.pdf>, <https://www.utwente.nl/en/eemcs/fois2024/resources/papers/xhani-et-al-xmlpo.pdf>.
 <https://w3id.org/ontouml-models/model/xhani2023xmlpo/> dcat:distribution <https://w3id.org/ontouml-models/model/xhani2023xmlpo/distribution/ttl>.
 <https://w3id.org/ontouml-models/model/xhani2023xmlpo/distribution/ttl> a dcat:Distribution;

--- a/models/xhani2023xmlpo/metadata.ttl
+++ b/models/xhani2023xmlpo/metadata.ttl
@@ -1,4 +1,4 @@
-@prefix ontouml: <https://w3id.org/ontouml#>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
 @prefix owl: <http://www.w3.org/2002/07/owl#>.


### PR DESCRIPTION
This PR fixes 42 datasets that had a wrong prefix in their metadata.ttl files. The modification made was: 
FROM: @prefix ontouml: <https://w3id.org/ontouml#>.
TO: @prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
