### PR TITLE
fix ontouml vocabulary prefix in cunha2025soberana dataset

### DIFF
--- a/models/cunha2025soberana/ontology.ttl
+++ b/models/cunha2025soberana/ontology.ttl
@@ -1,5 +1,5 @@
 @prefix : <https://w3id.org/ontouml-models/model/cunha2025soberana/>.
-@prefix ontouml: <https://purl.org/ontouml-models/vocabulary/>.
+@prefix ontouml: <https://w3id.org/ontouml#>.
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
 @prefix owl: <http://www.w3.org/2002/07/owl#>.


### PR DESCRIPTION
The ontology.ttl file of this dataset was misusing the old path to the ontouml vocabulary. The usage of the wrong prefix caused errors when reading the data from the dataset. Fixing the prefix solved the problem.