### PR TITLE
fix(metadata): correct theme label and remove invalid dataset triple

### DIFF
--- a/models/blums2025cofris/metadata.ttl
+++ b/models/blums2025cofris/metadata.ttl
@@ -20,7 +20,6 @@
     mod:designedForTask ocmv:ConceptualClarification, ocmv:OntologicalAnalysis;
     ocmv:context ocmv:Research;
     dct:source <https://www.utwente.nl/en/eemcs/vmbo2025/papers/vmbo-2025-paper-9-2.pdf>.
-<https://purl.org/ontouml-models/catalog> dcat:dataset <https://w3id.org/ontouml-models/model/blums2025cofris/>.
 <https://w3id.org/ontouml-models/model/blums2025cofris/> dcat:distribution <https://w3id.org/ontouml-models/model/blums2025cofris/distribution/ttl>.
 <https://w3id.org/ontouml-models/model/blums2025cofris/distribution/ttl> a dcat:Distribution;
     dct:title "Turtle distribution of \"Core Ontology for Financial Reporting Information Systems 3.0\""@en;

--- a/models/sariev2024maritime/metadata.yaml
+++ b/models/sariev2024maritime/metadata.yaml
@@ -9,7 +9,7 @@ keyword:
  - digital twin
  - port management
  - vessel traffic management
-theme: Class H – Social Sciences
+theme: Class H - Social Sciences
 editorialNote: 
 ontologyType:
  - domain


### PR DESCRIPTION
- Fixed incorrect theme label in `sariev2024maritime/metadata.yaml` (changed “Class H – Social Sciences” to “Class H - Social Sciences”)
- Removed mistakenly added dataset triple from `blums2025cofris/metadata.ttl`