### PR TITLE
Correct DCAT distribution to Visual Paradigm (vpp) across multiple models

### DIFF
--- a/models/alkhalaf2024/metadata.ttl
+++ b/models/alkhalaf2024/metadata.ttl
@@ -30,8 +30,8 @@
     dct:title "JSON distribution of \"Ontology to Explain SARS-CoV-2 Variants' Effects\""@en;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
     dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/alkhalaf2024/ontology.json>.
-<https://w3id.org/ontouml-models/model/alkhalaf2024/> dcat:distribution <https://w3id.org/ontouml-models/model/alkhalaf2024/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/alkhalaf2024/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Ontology to Explain SARS-CoV-2 Variants' Effects\""@en;
+<https://w3id.org/ontouml-models/model/alkhalaf2024/> dcat:distribution <https://w3id.org/ontouml-models/model/alkhalaf2024/distribution/vpp>.
+<https://w3id.org/ontouml-models/model/alkhalaf2024/distribution/vpp> a dcat:Distribution;
+    dct:title "Visual Paradigm distribution of \"Ontology to Explain SARS-CoV-2 Variants' Effects\""@en;
     dcat:mediaType <https://www.visual-paradigm.com/vpp>;
     dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/alkhalaf2024/ontology.vpp>.

--- a/models/bank-account2013/metadata.ttl
+++ b/models/bank-account2013/metadata.ttl
@@ -28,8 +28,8 @@
     dct:title "JSON distribution of \"Bank Account Ontology\""@en;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
     dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/bank-account2013/ontology.json>.
-<https://w3id.org/ontouml-models/model/bank-account2013/> dcat:distribution <https://w3id.org/ontouml-models/model/bank-account2013/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/bank-account2013/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Bank Account Ontology\""@en;
+<https://w3id.org/ontouml-models/model/bank-account2013/> dcat:distribution <https://w3id.org/ontouml-models/model/bank-account2013/distribution/vpp>.
+<https://w3id.org/ontouml-models/model/bank-account2013/distribution/vpp> a dcat:Distribution;
+    dct:title "Visual Paradigm distribution of \"Bank Account Ontology\""@en;
     dcat:mediaType <https://www.visual-paradigm.com/vpp>;
     dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/bank-account2013/ontology.vpp>.

--- a/models/barcelos2024resiliont/metadata.ttl
+++ b/models/barcelos2024resiliont/metadata.ttl
@@ -32,8 +32,8 @@
     dct:title "JSON distribution of \"Resilience Core Ontology\""@en;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
     dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/barcelos2024resiliont/ontology.json>.
-<https://w3id.org/ontouml-models/model/barcelos2024resiliont/> dcat:distribution <https://w3id.org/ontouml-models/model/barcelos2024resiliont/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/barcelos2024resiliont/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Resilience Core Ontology\""@en;
+<https://w3id.org/ontouml-models/model/barcelos2024resiliont/> dcat:distribution <https://w3id.org/ontouml-models/model/barcelos2024resiliont/distribution/vpp>.
+<https://w3id.org/ontouml-models/model/barcelos2024resiliont/distribution/vpp> a dcat:Distribution;
+    dct:title "Visual Paradigm distribution of \"Resilience Core Ontology\""@en;
     dcat:mediaType <https://www.visual-paradigm.com/vpp>;
     dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/barcelos2024resiliont/ontology.vpp>.

--- a/models/blums2024ccf/metadata.ttl
+++ b/models/blums2024ccf/metadata.ttl
@@ -30,7 +30,7 @@
     dct:title "JSON distribution of \"Ontology of Converged Conceptual Frameworks for Financial Reporting\""@en;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
     dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/blums2024ccf/ontology.json>.
-<https://w3id.org/ontouml-models/model/blums2024ccf/> dcat:distribution <https://w3id.org/ontouml-models/model/blums2024ccf/distribution/ttl>.
+<https://w3id.org/ontouml-models/model/blums2024ccf/> dcat:distribution <https://w3id.org/ontouml-models/model/blums2024ccf/distribution/vpp>.
 <https://w3id.org/ontouml-models/model/blums2024ccf/distribution/vpp> a dcat:Distribution;
     dct:title "Visual Paradigm distribution of \"Ontology of Converged Conceptual Frameworks for Financial Reporting\""@en;
     dcat:mediaType <https://www.visual-paradigm.com/vpp>;

--- a/models/demori2023miscon/metadata.ttl
+++ b/models/demori2023miscon/metadata.ttl
@@ -31,8 +31,8 @@
     dct:title "JSON distribution of \"Military Scenario Ontology\""@en;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
     dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/demori2023miscon/ontology.json>.
-<https://w3id.org/ontouml-models/model/demori2023miscon/> dcat:distribution <https://w3id.org/ontouml-models/model/demori2023miscon/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/demori2023miscon/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Military Scenario Ontology\""@en;
+<https://w3id.org/ontouml-models/model/demori2023miscon/> dcat:distribution <https://w3id.org/ontouml-models/model/demori2023miscon/distribution/vpp>.
+<https://w3id.org/ontouml-models/model/demori2023miscon/distribution/vpp> a dcat:Distribution;
+    dct:title "Visual Paradigm distribution of \"Military Scenario Ontology\""@en;
     dcat:mediaType <https://www.visual-paradigm.com/vpp>;
     dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/demori2023miscon/ontology.vpp>.

--- a/models/elghosh2024eucaim/metadata.ttl
+++ b/models/elghosh2024eucaim/metadata.ttl
@@ -31,8 +31,8 @@
     dct:title "JSON distribution of \"EUCAIM's Hyper-Ontology (Core Layer)\""@en;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
     dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/elghosh2024eucaim/ontology.json>.
-<https://w3id.org/ontouml-models/model/elghosh2024eucaim/> dcat:distribution <https://w3id.org/ontouml-models/model/elghosh2024eucaim/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/elghosh2024eucaim/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"EUCAIM's Hyper-Ontology (Core Layer)\""@en;
+<https://w3id.org/ontouml-models/model/elghosh2024eucaim/> dcat:distribution <https://w3id.org/ontouml-models/model/elghosh2024eucaim/distribution/vpp>.
+<https://w3id.org/ontouml-models/model/elghosh2024eucaim/distribution/vpp> a dcat:Distribution;
+    dct:title "Visual Paradigm distribution of \"EUCAIM's Hyper-Ontology (Core Layer)\""@en;
     dcat:mediaType <https://www.visual-paradigm.com/vpp>;
     dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/elghosh2024eucaim/ontology.vpp>.

--- a/models/formula-one2023/metadata.ttl
+++ b/models/formula-one2023/metadata.ttl
@@ -28,8 +28,8 @@
     dct:title "JSON distribution of \"Formula One Example Ontology\""@en;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
     dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/formula-one2023/ontology.json>.
-<https://w3id.org/ontouml-models/model/formula-one2023/> dcat:distribution <https://w3id.org/ontouml-models/model/formula-one2023/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/formula-one2023/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Formula One Example Ontology\""@en;
+<https://w3id.org/ontouml-models/model/formula-one2023/> dcat:distribution <https://w3id.org/ontouml-models/model/formula-one2023/distribution/vpp>.
+<https://w3id.org/ontouml-models/model/formula-one2023/distribution/vpp> a dcat:Distribution;
+    dct:title "Visual Paradigm distribution of \"Formula One Example Ontology\""@en;
     dcat:mediaType <https://www.visual-paradigm.com/vpp>;
     dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/formula-one2023/ontology.vpp>.

--- a/models/genealogy2013/metadata.ttl
+++ b/models/genealogy2013/metadata.ttl
@@ -28,8 +28,8 @@
     dct:title "JSON distribution of \"Simple Genealogy Ontology\""@en;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
     dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/genealogy2013/ontology.json>.
-<https://w3id.org/ontouml-models/model/genealogy2013/> dcat:distribution <https://w3id.org/ontouml-models/model/genealogy2013/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/genealogy2013/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Simple Genealogy Ontology\""@en;
+<https://w3id.org/ontouml-models/model/genealogy2013/> dcat:distribution <https://w3id.org/ontouml-models/model/genealogy2013/distribution/vpp>.
+<https://w3id.org/ontouml-models/model/genealogy2013/distribution/vpp> a dcat:Distribution;
+    dct:title "Visual Paradigm distribution of \"Simple Genealogy Ontology\""@en;
     dcat:mediaType <https://www.visual-paradigm.com/vpp>;
     dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/genealogy2013/ontology.vpp>.

--- a/models/heirbrant2023boekbazaar/metadata.ttl
+++ b/models/heirbrant2023boekbazaar/metadata.ttl
@@ -31,8 +31,8 @@
     dct:title "JSON distribution of \"Boekbazaar Ontology\""@en;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
     dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/heirbrant2023boekbazaar/ontology.json>.
-<https://w3id.org/ontouml-models/model/heirbrant2023boekbazaar/> dcat:distribution <https://w3id.org/ontouml-models/model/heirbrant2023boekbazaar/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/heirbrant2023boekbazaar/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Boekbazaar Ontology\""@en;
+<https://w3id.org/ontouml-models/model/heirbrant2023boekbazaar/> dcat:distribution <https://w3id.org/ontouml-models/model/heirbrant2023boekbazaar/distribution/vpp>.
+<https://w3id.org/ontouml-models/model/heirbrant2023boekbazaar/distribution/vpp> a dcat:Distribution;
+    dct:title "Visual Paradigm distribution of \"Boekbazaar Ontology\""@en;
     dcat:mediaType <https://www.visual-paradigm.com/vpp>;
     dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/heirbrant2023boekbazaar/ontology.vpp>.

--- a/models/lindeberg2022full-ontorights/metadata.ttl
+++ b/models/lindeberg2022full-ontorights/metadata.ttl
@@ -33,8 +33,8 @@
     dct:title "JSON distribution of \"Full OntoRights\""@en;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
     dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/lindeberg2022full-ontorights/ontology.json>.
-<https://w3id.org/ontouml-models/model/lindeberg2022full-ontorights/> dcat:distribution <https://w3id.org/ontouml-models/model/lindeberg2022full-ontorights/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/lindeberg2022full-ontorights/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Full OntoRights\""@en;
+<https://w3id.org/ontouml-models/model/lindeberg2022full-ontorights/> dcat:distribution <https://w3id.org/ontouml-models/model/lindeberg2022full-ontorights/distribution/vpp>.
+<https://w3id.org/ontouml-models/model/lindeberg2022full-ontorights/distribution/vpp> a dcat:Distribution;
+    dct:title "Visual Paradigm distribution of \"Full OntoRights\""@en;
     dcat:mediaType <https://www.visual-paradigm.com/vpp>;
     dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/lindeberg2022full-ontorights/ontology.vpp>.

--- a/models/lindeberg2024legal-enforcement/metadata.ttl
+++ b/models/lindeberg2024legal-enforcement/metadata.ttl
@@ -30,7 +30,7 @@
     dct:title "JSON distribution of \"Legal Enforcement Meta-Model\""@en;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
     dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/lindeberg2024legal-enforcement/ontology.json>.
-<https://w3id.org/ontouml-models/model/lindeberg2024legal-enforcement/> dcat:distribution <https://w3id.org/ontouml-models/model/lindeberg2024legal-enforcement/distribution/ttl>.
+<https://w3id.org/ontouml-models/model/lindeberg2024legal-enforcement/> dcat:distribution <https://w3id.org/ontouml-models/model/lindeberg2024legal-enforcement/distribution/vpp>.
 <https://w3id.org/ontouml-models/model/lindeberg2024legal-enforcement/distribution/vpp> a dcat:Distribution;
     dct:title "Visual Paradigm distribution of \"Legal Enforcement Meta-Model\""@en;
     dcat:mediaType <https://www.visual-paradigm.com/vpp>;

--- a/models/machacova2023gym/metadata.ttl
+++ b/models/machacova2023gym/metadata.ttl
@@ -29,8 +29,8 @@
     dct:title "JSON distribution of \"Example Ontology for Gym Products\""@en;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
     dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/machacova2023gym/ontology.json>.
-<https://w3id.org/ontouml-models/model/machacova2023gym/> dcat:distribution <https://w3id.org/ontouml-models/model/machacova2023gym/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/machacova2023gym/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Example Ontology for Gym Products\""@en;
+<https://w3id.org/ontouml-models/model/machacova2023gym/> dcat:distribution <https://w3id.org/ontouml-models/model/machacova2023gym/distribution/vpp>.
+<https://w3id.org/ontouml-models/model/machacova2023gym/distribution/vpp> a dcat:Distribution;
+    dct:title "Visual Paradigm distribution of \"Example Ontology for Gym Products\""@en;
     dcat:mediaType <https://www.visual-paradigm.com/vpp>;
     dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/machacova2023gym/ontology.vpp>.

--- a/models/meirelles2024credit-operations/metadata.ttl
+++ b/models/meirelles2024credit-operations/metadata.ttl
@@ -29,7 +29,7 @@
     dct:title "JSON distribution of \"Ontologia de Referência para o Domínio de Operações de Crédito\""@en;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
     dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/meirelles2024credit-operations/ontology.json>.
-<https://w3id.org/ontouml-models/model/meirelles2024credit-operations/> dcat:distribution <https://w3id.org/ontouml-models/model/meirelles2024credit-operations/distribution/ttl>.
+<https://w3id.org/ontouml-models/model/meirelles2024credit-operations/> dcat:distribution <https://w3id.org/ontouml-models/model/meirelles2024credit-operations/distribution/vpp>.
 <https://w3id.org/ontouml-models/model/meirelles2024credit-operations/distribution/vpp> a dcat:Distribution;
     dct:title "Visual Paradigm distribution of \"Ontologia de Referência para o Domínio de Operações de Crédito\""@en;
     dcat:mediaType <https://www.visual-paradigm.com/vpp>;

--- a/models/melo2024onto-educational/metadata.ttl
+++ b/models/melo2024onto-educational/metadata.ttl
@@ -30,7 +30,7 @@
     dct:title "JSON distribution of \"Ontologia para Integração de Dados de Evasão Escolar, Desempenho Acadêmico e Concessão de Auxílios Socioeconômicos\""@en;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
     dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/melo2024onto-educational/ontology.json>.
-<https://w3id.org/ontouml-models/model/melo2024onto-educational/> dcat:distribution <https://w3id.org/ontouml-models/model/melo2024onto-educational/distribution/ttl>.
+<https://w3id.org/ontouml-models/model/melo2024onto-educational/> dcat:distribution <https://w3id.org/ontouml-models/model/melo2024onto-educational/distribution/vpp>.
 <https://w3id.org/ontouml-models/model/melo2024onto-educational/distribution/vpp> a dcat:Distribution;
     dct:title "Visual Paradigm distribution of \"Ontologia para Integração de Dados de Evasão Escolar, Desempenho Acadêmico e Concessão de Auxílios Socioeconômicos\""@en;
     dcat:mediaType <https://www.visual-paradigm.com/vpp>;

--- a/models/mgic-antt2011/metadata.ttl
+++ b/models/mgic-antt2011/metadata.ttl
@@ -30,8 +30,8 @@
     dct:title "JSON distribution of \"National Agency of Terrestrial Transportation (ANTT) Ontology\""@en;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
     dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/mgic-antt2011/ontology.json>.
-<https://w3id.org/ontouml-models/model/mgic-antt2011/> dcat:distribution <https://w3id.org/ontouml-models/model/mgic-antt2011/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/mgic-antt2011/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"National Agency of Terrestrial Transportation (ANTT) Ontology\""@en;
+<https://w3id.org/ontouml-models/model/mgic-antt2011/> dcat:distribution <https://w3id.org/ontouml-models/model/mgic-antt2011/distribution/vpp>.
+<https://w3id.org/ontouml-models/model/mgic-antt2011/distribution/vpp> a dcat:Distribution;
+    dct:title "Visual Paradigm distribution of \"National Agency of Terrestrial Transportation (ANTT) Ontology\""@en;
     dcat:mediaType <https://www.visual-paradigm.com/vpp>;
     dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/mgic-antt2011/ontology.vpp>.

--- a/models/nascimento2023spacecon/metadata.ttl
+++ b/models/nascimento2023spacecon/metadata.ttl
@@ -31,8 +31,8 @@
     dct:title "JSON distribution of \"Smart Spaces Context Ontology\""@en;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
     dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/nascimento2023spacecon/ontology.json>.
-<https://w3id.org/ontouml-models/model/nascimento2023spacecon/> dcat:distribution <https://w3id.org/ontouml-models/model/nascimento2023spacecon/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/nascimento2023spacecon/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Smart Spaces Context Ontology\""@en;
+<https://w3id.org/ontouml-models/model/nascimento2023spacecon/> dcat:distribution <https://w3id.org/ontouml-models/model/nascimento2023spacecon/distribution/vpp>.
+<https://w3id.org/ontouml-models/model/nascimento2023spacecon/distribution/vpp> a dcat:Distribution;
+    dct:title "Visual Paradigm distribution of \"Smart Spaces Context Ontology\""@en;
     dcat:mediaType <https://www.visual-paradigm.com/vpp>;
     dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/nascimento2023spacecon/ontology.vpp>.

--- a/models/o3ontology2015/metadata.ttl
+++ b/models/o3ontology2015/metadata.ttl
@@ -28,8 +28,8 @@
     dct:title "JSON distribution of \"O3 Ontology\""@en;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
     dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/o3ontology2015/ontology.json>.
-<https://w3id.org/ontouml-models/model/o3ontology2015/> dcat:distribution <https://w3id.org/ontouml-models/model/o3ontology2015/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/o3ontology2015/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"O3 Ontology\""@en;
+<https://w3id.org/ontouml-models/model/o3ontology2015/> dcat:distribution <https://w3id.org/ontouml-models/model/o3ontology2015/distribution/vpp>.
+<https://w3id.org/ontouml-models/model/o3ontology2015/distribution/vpp> a dcat:Distribution;
+    dct:title "Visual Paradigm distribution of \"O3 Ontology\""@en;
     dcat:mediaType <https://www.visual-paradigm.com/vpp>;
     dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/o3ontology2015/ontology.vpp>.

--- a/models/parking-business2013/metadata.ttl
+++ b/models/parking-business2013/metadata.ttl
@@ -28,8 +28,8 @@
     dct:title "JSON distribution of \"Parking Business Ontology\""@en;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
     dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/parking-business2013/ontology.json>.
-<https://w3id.org/ontouml-models/model/parking-business2013/> dcat:distribution <https://w3id.org/ontouml-models/model/parking-business2013/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/parking-business2013/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Parking Business Ontology\""@en;
+<https://w3id.org/ontouml-models/model/parking-business2013/> dcat:distribution <https://w3id.org/ontouml-models/model/parking-business2013/distribution/vpp>.
+<https://w3id.org/ontouml-models/model/parking-business2013/distribution/vpp> a dcat:Distribution;
+    dct:title "Visual Paradigm distribution of \"Parking Business Ontology\""@en;
     dcat:mediaType <https://www.visual-paradigm.com/vpp>;
     dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/parking-business2013/ontology.vpp>.

--- a/models/piest2024dsr-kb/metadata.ttl
+++ b/models/piest2024dsr-kb/metadata.ttl
@@ -31,8 +31,8 @@
     dct:title "JSON distribution of \"Domain Reference Ontology for Design Science Research Knowledge Bases\""@en;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
     dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/piest2024dsr-kb/ontology.json>.
-<https://w3id.org/ontouml-models/model/piest2024dsr-kb/> dcat:distribution <https://w3id.org/ontouml-models/model/piest2024dsr-kb/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/piest2024dsr-kb/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Domain Reference Ontology for Design Science Research Knowledge Bases\""@en;
+<https://w3id.org/ontouml-models/model/piest2024dsr-kb/> dcat:distribution <https://w3id.org/ontouml-models/model/piest2024dsr-kb/distribution/vpp>.
+<https://w3id.org/ontouml-models/model/piest2024dsr-kb/distribution/vpp> a dcat:Distribution;
+    dct:title "Visual Paradigm distribution of \"Domain Reference Ontology for Design Science Research Knowledge Bases\""@en;
     dcat:mediaType <https://www.visual-paradigm.com/vpp>;
     dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/piest2024dsr-kb/ontology.vpp>.

--- a/models/pinheiro2024api/metadata.ttl
+++ b/models/pinheiro2024api/metadata.ttl
@@ -29,8 +29,8 @@
     dct:title "JSON distribution of \"Reference Ontology for Enterprise Architecture Mining from APIs\""@en;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
     dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/pinheiro2024api/ontology.json>.
-<https://w3id.org/ontouml-models/model/pinheiro2024api/> dcat:distribution <https://w3id.org/ontouml-models/model/pinheiro2024api/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/pinheiro2024api/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Reference Ontology for Enterprise Architecture Mining from APIs\""@en;
+<https://w3id.org/ontouml-models/model/pinheiro2024api/> dcat:distribution <https://w3id.org/ontouml-models/model/pinheiro2024api/distribution/vpp>.
+<https://w3id.org/ontouml-models/model/pinheiro2024api/distribution/vpp> a dcat:Distribution;
+    dct:title "Visual Paradigm distribution of \"Reference Ontology for Enterprise Architecture Mining from APIs\""@en;
     dcat:mediaType <https://www.visual-paradigm.com/vpp>;
     dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/pinheiro2024api/ontology.vpp>.

--- a/models/project-assets2013/metadata.ttl
+++ b/models/project-assets2013/metadata.ttl
@@ -28,8 +28,8 @@
     dct:title "JSON distribution of \"Project Assets\""@en;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
     dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/project-assets2013/ontology.json>.
-<https://w3id.org/ontouml-models/model/project-assets2013/> dcat:distribution <https://w3id.org/ontouml-models/model/project-assets2013/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/project-assets2013/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Project Assets\""@en;
+<https://w3id.org/ontouml-models/model/project-assets2013/> dcat:distribution <https://w3id.org/ontouml-models/model/project-assets2013/distribution/vpp>.
+<https://w3id.org/ontouml-models/model/project-assets2013/distribution/vpp> a dcat:Distribution;
+    dct:title "Visual Paradigm distribution of \"Project Assets\""@en;
     dcat:mediaType <https://www.visual-paradigm.com/vpp>;
     dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/project-assets2013/ontology.vpp>.

--- a/models/public-organization2013/metadata.ttl
+++ b/models/public-organization2013/metadata.ttl
@@ -28,8 +28,8 @@
     dct:title "JSON distribution of \"Ecology Public Organization\""@en;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
     dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/public-organization2013/ontology.json>.
-<https://w3id.org/ontouml-models/model/public-organization2013/> dcat:distribution <https://w3id.org/ontouml-models/model/public-organization2013/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/public-organization2013/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Ecology Public Organization\""@en;
+<https://w3id.org/ontouml-models/model/public-organization2013/> dcat:distribution <https://w3id.org/ontouml-models/model/public-organization2013/distribution/vpp>.
+<https://w3id.org/ontouml-models/model/public-organization2013/distribution/vpp> a dcat:Distribution;
+    dct:title "Visual Paradigm distribution of \"Ecology Public Organization\""@en;
     dcat:mediaType <https://www.visual-paradigm.com/vpp>;
     dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/public-organization2013/ontology.vpp>.

--- a/models/road-accident2013/metadata.ttl
+++ b/models/road-accident2013/metadata.ttl
@@ -28,8 +28,8 @@
     dct:title "JSON distribution of \"Road Traffic Accident Ontology\""@en;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
     dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/road-accident2013/ontology.json>.
-<https://w3id.org/ontouml-models/model/road-accident2013/> dcat:distribution <https://w3id.org/ontouml-models/model/road-accident2013/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/road-accident2013/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Road Traffic Accident Ontology\""@en;
+<https://w3id.org/ontouml-models/model/road-accident2013/> dcat:distribution <https://w3id.org/ontouml-models/model/road-accident2013/distribution/vpp>.
+<https://w3id.org/ontouml-models/model/road-accident2013/distribution/vpp> a dcat:Distribution;
+    dct:title "Visual Paradigm distribution of \"Road Traffic Accident Ontology\""@en;
     dcat:mediaType <https://www.visual-paradigm.com/vpp>;
     dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/road-accident2013/ontology.vpp>.

--- a/models/rocha2023ciencia-aberta/metadata.ttl
+++ b/models/rocha2023ciencia-aberta/metadata.ttl
@@ -29,8 +29,8 @@
     dct:title "JSON distribution of \"Ciência Aberta\""@en;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
     dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/rocha2023ciencia-aberta/ontology.json>.
-<https://w3id.org/ontouml-models/model/rocha2023ciencia-aberta/> dcat:distribution <https://w3id.org/ontouml-models/model/rocha2023ciencia-aberta/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/rocha2023ciencia-aberta/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Ciência Aberta\""@en;
+<https://w3id.org/ontouml-models/model/rocha2023ciencia-aberta/> dcat:distribution <https://w3id.org/ontouml-models/model/rocha2023ciencia-aberta/distribution/vpp>.
+<https://w3id.org/ontouml-models/model/rocha2023ciencia-aberta/distribution/vpp> a dcat:Distribution;
+    dct:title "Visual Paradigm distribution of \"Ciência Aberta\""@en;
     dcat:mediaType <https://www.visual-paradigm.com/vpp>;
     dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/rocha2023ciencia-aberta/ontology.vpp>.

--- a/models/sariev2024maritime/metadata.ttl
+++ b/models/sariev2024maritime/metadata.ttl
@@ -29,8 +29,8 @@
     dct:title "JSON distribution of \"Ontology for Digital Twin Development in Maritime Logistics\""@en;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
     dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/sariev2024maritime/ontology.json>.
-<https://w3id.org/ontouml-models/model/sariev2024maritime/> dcat:distribution <https://w3id.org/ontouml-models/model/sariev2024maritime/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/sariev2024maritime/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Ontology for Digital Twin Development in Maritime Logistics\""@en;
+<https://w3id.org/ontouml-models/model/sariev2024maritime/> dcat:distribution <https://w3id.org/ontouml-models/model/sariev2024maritime/distribution/vpp>.
+<https://w3id.org/ontouml-models/model/sariev2024maritime/distribution/vpp> a dcat:Distribution;
+    dct:title "Visual Paradigm distribution of \"Ontology for Digital Twin Development in Maritime Logistics\""@en;
     dcat:mediaType <https://www.visual-paradigm.com/vpp>;
     dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/sariev2024maritime/ontology.vpp>.

--- a/models/schoonderbeek2024eamon/metadata.ttl
+++ b/models/schoonderbeek2024eamon/metadata.ttl
@@ -30,8 +30,8 @@
     dct:title "JSON distribution of \"Enterprise Architecture Modeling Ontology\""@en;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
     dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/schoonderbeek2024eamon/ontology.json>.
-<https://w3id.org/ontouml-models/model/schoonderbeek2024eamon/> dcat:distribution <https://w3id.org/ontouml-models/model/schoonderbeek2024eamon/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/schoonderbeek2024eamon/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Enterprise Architecture Modeling Ontology\""@en;
+<https://w3id.org/ontouml-models/model/schoonderbeek2024eamon/> dcat:distribution <https://w3id.org/ontouml-models/model/schoonderbeek2024eamon/distribution/vpp>.
+<https://w3id.org/ontouml-models/model/schoonderbeek2024eamon/distribution/vpp> a dcat:Distribution;
+    dct:title "Visual Paradigm distribution of \"Enterprise Architecture Modeling Ontology\""@en;
     dcat:mediaType <https://www.visual-paradigm.com/vpp>;
     dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/schoonderbeek2024eamon/ontology.vpp>.

--- a/models/scientific-experiment2013/metadata.ttl
+++ b/models/scientific-experiment2013/metadata.ttl
@@ -28,8 +28,8 @@
     dct:title "JSON distribution of \"Scientific Experiment Ontology\""@en;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
     dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/scientific-experiment2013/ontology.json>.
-<https://w3id.org/ontouml-models/model/scientific-experiment2013/> dcat:distribution <https://w3id.org/ontouml-models/model/scientific-experiment2013/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/scientific-experiment2013/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Scientific Experiment Ontology\""@en;
+<https://w3id.org/ontouml-models/model/scientific-experiment2013/> dcat:distribution <https://w3id.org/ontouml-models/model/scientific-experiment2013/distribution/vpp>.
+<https://w3id.org/ontouml-models/model/scientific-experiment2013/distribution/vpp> a dcat:Distribution;
+    dct:title "Visual Paradigm distribution of \"Scientific Experiment Ontology\""@en;
     dcat:mediaType <https://www.visual-paradigm.com/vpp>;
     dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/scientific-experiment2013/ontology.vpp>.

--- a/models/scientific-publication2013/metadata.ttl
+++ b/models/scientific-publication2013/metadata.ttl
@@ -28,8 +28,8 @@
     dct:title "JSON distribution of \"Scientific Publication Ontology\""@en;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
     dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/scientific-publication2013/ontology.json>.
-<https://w3id.org/ontouml-models/model/scientific-publication2013/> dcat:distribution <https://w3id.org/ontouml-models/model/scientific-publication2013/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/scientific-publication2013/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Scientific Publication Ontology\""@en;
+<https://w3id.org/ontouml-models/model/scientific-publication2013/> dcat:distribution <https://w3id.org/ontouml-models/model/scientific-publication2013/distribution/vpp>.
+<https://w3id.org/ontouml-models/model/scientific-publication2013/distribution/vpp> a dcat:Distribution;
+    dct:title "Visual Paradigm distribution of \"Scientific Publication Ontology\""@en;
     dcat:mediaType <https://www.visual-paradigm.com/vpp>;
     dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/scientific-publication2013/ontology.vpp>.

--- a/models/services2015/metadata.ttl
+++ b/models/services2015/metadata.ttl
@@ -28,8 +28,8 @@
     dct:title "JSON distribution of \"Services Ontology\""@en;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
     dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/services2015/ontology.json>.
-<https://w3id.org/ontouml-models/model/services2015/> dcat:distribution <https://w3id.org/ontouml-models/model/services2015/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/services2015/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Services Ontology\""@en;
+<https://w3id.org/ontouml-models/model/services2015/> dcat:distribution <https://w3id.org/ontouml-models/model/services2015/distribution/vpp>.
+<https://w3id.org/ontouml-models/model/services2015/distribution/vpp> a dcat:Distribution;
+    dct:title "Visual Paradigm distribution of \"Services Ontology\""@en;
     dcat:mediaType <https://www.visual-paradigm.com/vpp>;
     dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/services2015/ontology.vpp>.

--- a/models/short-examples2013/metadata.ttl
+++ b/models/short-examples2013/metadata.ttl
@@ -28,8 +28,8 @@
     dct:title "JSON distribution of \"Short Examples of OntoUML Ontologies\""@en;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
     dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/short-examples2013/ontology.json>.
-<https://w3id.org/ontouml-models/model/short-examples2013/> dcat:distribution <https://w3id.org/ontouml-models/model/short-examples2013/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/short-examples2013/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Short Examples of OntoUML Ontologies\""@en;
+<https://w3id.org/ontouml-models/model/short-examples2013/> dcat:distribution <https://w3id.org/ontouml-models/model/short-examples2013/distribution/vpp>.
+<https://w3id.org/ontouml-models/model/short-examples2013/distribution/vpp> a dcat:Distribution;
+    dct:title "Visual Paradigm distribution of \"Short Examples of OntoUML Ontologies\""@en;
     dcat:mediaType <https://www.visual-paradigm.com/vpp>;
     dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/short-examples2013/ontology.vpp>.

--- a/models/silva2021sebim/metadata.ttl
+++ b/models/silva2021sebim/metadata.ttl
@@ -33,8 +33,8 @@
     dct:title "JSON distribution of \"Semantic BIM\""@en;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
     dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/silva2021sebim/ontology.json>.
-<https://w3id.org/ontouml-models/model/silva2021sebim/> dcat:distribution <https://w3id.org/ontouml-models/model/silva2021sebim/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/silva2021sebim/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Semantic BIM\""@en;
+<https://w3id.org/ontouml-models/model/silva2021sebim/> dcat:distribution <https://w3id.org/ontouml-models/model/silva2021sebim/distribution/vpp>.
+<https://w3id.org/ontouml-models/model/silva2021sebim/distribution/vpp> a dcat:Distribution;
+    dct:title "Visual Paradigm distribution of \"Semantic BIM\""@en;
     dcat:mediaType <https://www.visual-paradigm.com/vpp>;
     dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/silva2021sebim/ontology.vpp>.

--- a/models/silva2023onto4caal/metadata.ttl
+++ b/models/silva2023onto4caal/metadata.ttl
@@ -31,8 +31,8 @@
     dct:title "JSON distribution of \"Requirements Ontology for AAL Systems\""@en;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
     dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/silva2023onto4caal/ontology.json>.
-<https://w3id.org/ontouml-models/model/silva2023onto4caal/> dcat:distribution <https://w3id.org/ontouml-models/model/silva2023onto4caal/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/silva2023onto4caal/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Requirements Ontology for AAL Systems\""@en;
+<https://w3id.org/ontouml-models/model/silva2023onto4caal/> dcat:distribution <https://w3id.org/ontouml-models/model/silva2023onto4caal/distribution/vpp>.
+<https://w3id.org/ontouml-models/model/silva2023onto4caal/distribution/vpp> a dcat:Distribution;
+    dct:title "Visual Paradigm distribution of \"Requirements Ontology for AAL Systems\""@en;
     dcat:mediaType <https://www.visual-paradigm.com/vpp>;
     dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/silva2023onto4caal/ontology.vpp>.

--- a/models/silva2023onto4elev/metadata.ttl
+++ b/models/silva2023onto4elev/metadata.ttl
@@ -31,8 +31,8 @@
     dct:title "JSON distribution of \"Requirements Ontology for Vertical Lifting Platform\""@en;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
     dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/silva2023onto4elev/ontology.json>.
-<https://w3id.org/ontouml-models/model/silva2023onto4elev/> dcat:distribution <https://w3id.org/ontouml-models/model/silva2023onto4elev/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/silva2023onto4elev/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Requirements Ontology for Vertical Lifting Platform\""@en;
+<https://w3id.org/ontouml-models/model/silva2023onto4elev/> dcat:distribution <https://w3id.org/ontouml-models/model/silva2023onto4elev/distribution/vpp>.
+<https://w3id.org/ontouml-models/model/silva2023onto4elev/distribution/vpp> a dcat:Distribution;
+    dct:title "Visual Paradigm distribution of \"Requirements Ontology for Vertical Lifting Platform\""@en;
     dcat:mediaType <https://www.visual-paradigm.com/vpp>;
     dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/silva2023onto4elev/ontology.vpp>.

--- a/models/soares2024fair/metadata.ttl
+++ b/models/soares2024fair/metadata.ttl
@@ -30,7 +30,7 @@
     dct:title "JSON distribution of \"Conceptual Model of a FAIR Metadata Schema\""@en;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
     dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/soares2024fair/ontology.json>.
-<https://w3id.org/ontouml-models/model/soares2024fair/> dcat:distribution <https://w3id.org/ontouml-models/model/soares2024fair/distribution/ttl>.
+<https://w3id.org/ontouml-models/model/soares2024fair/> dcat:distribution <https://w3id.org/ontouml-models/model/soares2024fair/distribution/vpp>.
 <https://w3id.org/ontouml-models/model/soares2024fair/distribution/vpp> a dcat:Distribution;
     dct:title "Visual Paradigm distribution of \"Conceptual Model of a FAIR Metadata Schema\""@en;
     dcat:mediaType <https://www.visual-paradigm.com/vpp>;

--- a/models/social-contracts2013/metadata.ttl
+++ b/models/social-contracts2013/metadata.ttl
@@ -28,8 +28,8 @@
     dct:title "JSON distribution of \"State and Social Contracts Ontology\""@en;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
     dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/social-contracts2013/ontology.json>.
-<https://w3id.org/ontouml-models/model/social-contracts2013/> dcat:distribution <https://w3id.org/ontouml-models/model/social-contracts2013/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/social-contracts2013/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"State and Social Contracts Ontology\""@en;
+<https://w3id.org/ontouml-models/model/social-contracts2013/> dcat:distribution <https://w3id.org/ontouml-models/model/social-contracts2013/distribution/vpp>.
+<https://w3id.org/ontouml-models/model/social-contracts2013/distribution/vpp> a dcat:Distribution;
+    dct:title "Visual Paradigm distribution of \"State and Social Contracts Ontology\""@en;
     dcat:mediaType <https://www.visual-paradigm.com/vpp>;
     dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/social-contracts2013/ontology.vpp>.

--- a/models/telecom-equipment2013/metadata.ttl
+++ b/models/telecom-equipment2013/metadata.ttl
@@ -28,8 +28,8 @@
     dct:title "JSON distribution of \"Telecommunications Equipment\""@en;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
     dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/telecom-equipment2013/ontology.json>.
-<https://w3id.org/ontouml-models/model/telecom-equipment2013/> dcat:distribution <https://w3id.org/ontouml-models/model/telecom-equipment2013/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/telecom-equipment2013/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Telecommunications Equipment\""@en;
+<https://w3id.org/ontouml-models/model/telecom-equipment2013/> dcat:distribution <https://w3id.org/ontouml-models/model/telecom-equipment2013/distribution/vpp>.
+<https://w3id.org/ontouml-models/model/telecom-equipment2013/distribution/vpp> a dcat:Distribution;
+    dct:title "Visual Paradigm distribution of \"Telecommunications Equipment\""@en;
     dcat:mediaType <https://www.visual-paradigm.com/vpp>;
     dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/telecom-equipment2013/ontology.vpp>.

--- a/models/tender2013/metadata.ttl
+++ b/models/tender2013/metadata.ttl
@@ -28,8 +28,8 @@
     dct:title "JSON distribution of \"Tender Ontology\""@en;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
     dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/tender2013/ontology.json>.
-<https://w3id.org/ontouml-models/model/tender2013/> dcat:distribution <https://w3id.org/ontouml-models/model/tender2013/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/tender2013/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Tender Ontology\""@en;
+<https://w3id.org/ontouml-models/model/tender2013/> dcat:distribution <https://w3id.org/ontouml-models/model/tender2013/distribution/vpp>.
+<https://w3id.org/ontouml-models/model/tender2013/distribution/vpp> a dcat:Distribution;
+    dct:title "Visual Paradigm distribution of \"Tender Ontology\""@en;
     dcat:mediaType <https://www.visual-paradigm.com/vpp>;
     dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/tender2013/ontology.vpp>.

--- a/models/tesolin2023hint/metadata.ttl
+++ b/models/tesolin2023hint/metadata.ttl
@@ -31,8 +31,8 @@
     dct:title "JSON distribution of \"Heterogeneous wIreless Network onTology\""@en;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
     dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/tesolin2023hint/ontology.json>.
-<https://w3id.org/ontouml-models/model/tesolin2023hint/> dcat:distribution <https://w3id.org/ontouml-models/model/tesolin2023hint/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/tesolin2023hint/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Heterogeneous wIreless Network onTology\""@en;
+<https://w3id.org/ontouml-models/model/tesolin2023hint/> dcat:distribution <https://w3id.org/ontouml-models/model/tesolin2023hint/distribution/vpp>.
+<https://w3id.org/ontouml-models/model/tesolin2023hint/distribution/vpp> a dcat:Distribution;
+    dct:title "Visual Paradigm distribution of \"Heterogeneous wIreless Network onTology\""@en;
     dcat:mediaType <https://www.visual-paradigm.com/vpp>;
     dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/tesolin2023hint/ontology.vpp>.

--- a/models/xhani2023xmlpo/metadata.ttl
+++ b/models/xhani2023xmlpo/metadata.ttl
@@ -32,8 +32,8 @@
     dct:title "JSON distribution of \"Explainable Machine Learning Pipeline Ontology\""@en;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
     dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/xhani2023xmlpo/ontology.json>.
-<https://w3id.org/ontouml-models/model/xhani2023xmlpo/> dcat:distribution <https://w3id.org/ontouml-models/model/xhani2023xmlpo/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/xhani2023xmlpo/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Explainable Machine Learning Pipeline Ontology\""@en;
+<https://w3id.org/ontouml-models/model/xhani2023xmlpo/> dcat:distribution <https://w3id.org/ontouml-models/model/xhani2023xmlpo/distribution/vpp>.
+<https://w3id.org/ontouml-models/model/xhani2023xmlpo/distribution/vpp> a dcat:Distribution;
+    dct:title "Visual Paradigm distribution of \"Explainable Machine Learning Pipeline Ontology\""@en;
     dcat:mediaType <https://www.visual-paradigm.com/vpp>;
     dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/xhani2023xmlpo/ontology.vpp>.


### PR DESCRIPTION
Replace Turtle distribution entries with Visual Paradigm distribution:
- Update dcat:distribution IRIs from `/distribution/ttl` → `/distribution/vpp`
- Change dct:title from "Turtle distribution of …" → "Visual Paradigm distribution of …"
- Keep dcat:mediaType to Visual Paradigm and point dcat:downloadURL to corresponding `.vpp`

Affected models:
alkhalaf2024, bank-account2013, barcelos2024resiliont, blums2024ccf,
demori2023miscon, elghosh2024eucaim, formula-one2023, genealogy2013,
heirbrant2023boekbazaar, lindeberg2022full-ontorights,
lindeberg2024legal-enforcement, machacova2023gym,
meirelles2024credit-operations, melo2024onto-educational, mgic-antt2011,
nascimento2023spacecon, o3ontology2015, parking-business2013,
piest2024dsr-kb, pinheiro2024api, project-assets2013,
public-organization2013, road-accident2013, rocha2023ciencia-aberta,
sariev2024maritime, schoonderbeek2024eamon, scientific-experiment2013,
scientific-publication2013, services2015, short-examples2013,
silva2021sebim, silva2023onto4caal, silva2023onto4elev, soares2024fair,
telecom-equipment2013, tender2013, tesolin2023hint, xhani2023xmlpo