### PR TITLE
Add PNG metadata generator

### DIFF
--- a/scripts/generate-png-metadata.md
+++ b/scripts/generate-png-metadata.md
@@ -1,0 +1,349 @@
+# Generate PNG distribution metadata
+
+This repository contains one RDF/Turtle metadata file for each PNG diagram distribution of a model.
+
+The generator implemented in `scripts/generate_png_metadata.py` scans one or more model dataset folders and creates these files:
+
+| Source PNG folder | Generated metadata file |
+| --- | --- |
+| `original-diagrams/<diagram>.png` | `metadata-png-o-<diagram>.ttl` |
+| `new-diagrams/<diagram>.png` | `metadata-png-n-<diagram>.ttl` |
+
+`<diagram>` is the PNG filename stem, i.e., the filename without the `.png` extension. For example:
+
+```text
+models/example/new-diagrams/main-diagram.png
+models/example/metadata-png-n-main-diagram.ttl
+```
+
+## Generated RDF semantics
+
+For each PNG file, the script creates a `dcat:Distribution` metadata file following the same RDF pattern used by existing generated distribution files such as `metadata-json.ttl`, `metadata-turtle.ttl`, and `metadata-vpp.ttl`.
+
+The generated distribution includes:
+
+- `rdf:type dcat:Distribution`
+- `dct:isPartOf`, pointing to the model dataset
+- `dct:issued`, derived from the model-level `metadata.yaml`
+- `dct:license`, copied from existing PNG metadata or derived from model-level `metadata.yaml` when available
+- `dct:title`
+- `skos:editorialNote`
+- `dcat:mediaType <https://www.iana.org/assignments/media-types/image/png>`
+- `dcat:downloadURL`, pointing to the raw GitHub URL of the PNG file
+- `ocmv:isComplete false`, because PNG diagrams are not complete materializations of the model
+- `fdpo:metadataIssued`
+- `fdpo:metadataModified`
+
+The script does **not** read or update `metadata.ttl`, and it does **not** add model-level `dcat:distribution` triples. Distribution metadata files point back to the model with `dct:isPartOf`; the separate `metadata.ttl` generation step should read the generated `metadata-png-*.ttl` files and add the corresponding model-level `dcat:distribution` links.
+
+## Pipeline role
+
+The intended generation pipeline is:
+
+```text
+metadata.yaml + PNG files
+  -> metadata-png-*.ttl
+
+metadata.yaml + metadata-png-*.ttl + other distribution metadata
+  -> metadata.ttl
+```
+
+In this pipeline, `metadata.yaml` is the canonical input file. The `metadata-png-*.ttl` files are generated distribution metadata files. The model-level `metadata.ttl` file is a later aggregation product and should not be used as an input by this PNG generator.
+
+## Existing metadata preservation
+
+When regenerating an existing PNG metadata file, the script preserves curated values that should not be changed accidentally:
+
+- the existing distribution URI;
+- `dct:title`;
+- `skos:editorialNote`;
+- `dcat:downloadURL`;
+- `dct:license`;
+- the exact lexical values of `fdpo:metadataIssued` and `fdpo:metadataModified`.
+
+Preserving the exact timestamp lexical values avoids changes such as nanosecond truncation or conversion from `Z` to `+00:00` when existing `xsd:dateTime` literals are parsed.
+
+For existing files, the script still regenerates the remaining triples from the model metadata and script defaults, including `dct:isPartOf`, `dct:issued`, `dcat:mediaType`, and `ocmv:isComplete`. The script preserves an existing PNG-level `dct:license`; if none exists, it copies the model-level `dct:license` when available.
+
+## Defaults for new PNG metadata files
+
+For new files, the script generates a catalog-style title:
+
+```text
+PNG distribution of diagram '<diagram label>' from the <model title> (<version>)
+```
+
+The diagram label is derived from the filename stem by replacing spaces, underscores, and hyphens with spaces. For example:
+
+| PNG filename | Diagram label |
+| --- | --- |
+| `petroleum-system.png` | `petroleum system` |
+| `lifts,-ski-slopes,-and-snowparks.png` | `lifts, ski slopes, and snowparks` |
+
+The version suffix is determined by the source folder:
+
+| Source folder | Version label |
+| --- | --- |
+| `original-diagrams` | `original version` |
+| `new-diagrams` | `Visual Paradigm version` |
+
+The default editorial notes are:
+
+| Source folder | Default `skos:editorialNote` |
+| --- | --- |
+| `original-diagrams` | `This image depicts the diagram as originally represented by its author(s).` |
+| `new-diagrams` | `This image depicts a version of the original diagram re-created in the Visual Paradigm editor.` |
+
+## Distribution identifiers
+
+Existing target metadata files keep their current distribution URI. This avoids changing already published W3IDs. Existing catalog PNG distribution identifiers were historically generated as opaque UUIDs, and many of them are UUIDv4 values. The script treats all existing distribution identifiers as persistent opaque identifiers and never replaces them during regeneration.
+
+For new PNG metadata files, the script creates a deterministic UUIDv5 distribution URI under:
+
+```text
+https://w3id.org/ontouml-models/distribution/<uuid>/
+```
+
+The deterministic UUID input is:
+
+```text
+<model-uri>|<diagram-folder>/<png-filename>
+```
+
+For example, if the same PNG filename exists in both `original-diagrams` and `new-diagrams`, the generated UUIDs differ because the diagram folder is part of the UUID input.
+
+This differs from the catalog's likely original JavaScript generation approach, which appears to have generated UUIDv4 identifiers for new distribution metadata. This is not a compatibility problem because the URI pattern remains the same and UUIDs are treated as opaque identifiers. The compatibility rule is: preserve existing distribution URIs; use deterministic UUIDv5 only when creating metadata for PNG diagrams that do not already have a metadata file.
+
+The UUIDv5 approach makes new-file generation reproducible while preserving the catalog's established UUID-based distribution URI pattern.
+
+## Download URLs
+
+For new metadata files, `dcat:downloadURL` values are generated as raw GitHub URLs using:
+
+- `--repository`
+- `--branch`
+- `--models-dir-name`
+- the dataset folder name
+- the diagram source folder
+- the PNG filename
+
+By default, generated URLs point to:
+
+```text
+https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/<model-directory>/<diagram-folder>/<png-filename>
+```
+
+Existing `dcat:downloadURL` values are preserved when regenerating existing metadata files.
+
+When generating new URLs, path segments are URL-quoted where needed, but commas are left unescaped to match the existing catalog style. For example, the script generates:
+
+```text
+lifts,-ski-slopes,-and-snowparks.png
+```
+
+not:
+
+```text
+lifts%2C-ski-slopes%2C-and-snowparks.png
+```
+
+## Optional file-derived metadata
+
+By default, the script does not add image dimensions, file size, or checksum metadata because these are not part of the current required distribution metadata shape. Use `--include-file-metadata` to emit optional file-derived triples:
+
+- `dcat:byteSize`
+- `schema:width`
+- `schema:height`
+- `spdx:checksum` with SHA-256
+
+PNG validation always checks the PNG signature, IHDR chunk, chunk boundaries, CRC values, and IEND chunk before any metadata is written. This validation uses only the Python standard library.
+
+## Requirements
+
+Install the automation dependencies:
+
+```bash
+python -m pip install -r scripts/requirements.txt
+```
+
+The PNG metadata generator requires `rdflib` and `PyYAML`. Tests require `pytest`. All are listed in `scripts/requirements.txt`.
+
+## Usage
+
+Run from the repository root.
+
+Generate metadata for one dataset folder:
+
+```bash
+python scripts/generate_png_metadata.py models/<model-directory>
+```
+
+Generate metadata for multiple dataset folders:
+
+```bash
+python scripts/generate_png_metadata.py models/<model-1> models/<model-2>
+```
+
+Generate metadata for all dataset folders under `models/`:
+
+```bash
+python scripts/generate_png_metadata.py --all --models-dir models
+```
+
+Preview generation without writing files:
+
+```bash
+python scripts/generate_png_metadata.py models/<model-directory> --dry-run
+```
+
+Fail when a generated file already exists. This check is atomic at dataset level: no metadata files are written if any target already exists:
+
+```bash
+python scripts/generate_png_metadata.py models/<model-directory> --no-overwrite
+```
+
+Use a different repository or branch in generated `dcat:downloadURL` values:
+
+```bash
+python scripts/generate_png_metadata.py models/<model-directory> \
+  --repository pedropaulofb/ontouml-models-dev \
+  --branch master
+```
+
+Use a different repository-relative models path in generated `dcat:downloadURL` values:
+
+```bash
+python scripts/generate_png_metadata.py models/<model-directory> \
+  --models-dir-name models
+```
+
+Use a fixed timestamp for new metadata files, or for existing metadata files that do not already contain `fdpo:metadataIssued` or `fdpo:metadataModified`. The value must use an `xsd:dateTime` lexical form such as `2024-01-02T03:04:05Z`:
+
+```bash
+python scripts/generate_png_metadata.py models/<model-directory> \
+  --metadata-timestamp 2024-01-02T03:04:05Z
+```
+
+Add optional file-derived metadata:
+
+```bash
+python scripts/generate_png_metadata.py models/<model-directory> --include-file-metadata
+```
+
+Require model-level license metadata:
+
+```bash
+python scripts/generate_png_metadata.py models/<model-directory> --require-license
+```
+
+Run from inside a dataset folder that contains `metadata.yaml`:
+
+```bash
+python ../../scripts/generate_png_metadata.py
+```
+
+## Command-line arguments
+
+| Argument | Required | Default | Meaning |
+| --- | --- | --- | --- |
+| `datasets` | No | current directory if it contains `metadata.yaml` | One or more model dataset folders to process. |
+| `--all` | No | off | Process all dataset folders below `--models-dir`. Cannot be combined with explicit dataset folders. |
+| `--models-dir PATH` | No | `models` | Models directory used with `--all`. |
+| `--repository OWNER/REPO` | No | `OntoUML/ontouml-models` | GitHub repository used for generated `dcat:downloadURL` values. |
+| `--branch BRANCH` | No | `master` | Git branch used for generated `dcat:downloadURL` values. |
+| `--models-dir-name PATH` | No | `models` | Repository-relative models path used inside generated `dcat:downloadURL` values. |
+| `--no-overwrite` | No | overwrite enabled | Fail if a target metadata file already exists. |
+| `--strict` | No | off | Fail if an expected diagram folder is missing or empty. |
+| `--dry-run` | No | off | Validate inputs and report files that would be generated without writing them. |
+| `--include-file-metadata` | No | off | Also add optional byte size, SHA-256 checksum, width, and height triples. |
+| `--metadata-timestamp VALUE` | No | current UTC timestamp | `xsd:dateTime` value used for `fdpo:metadataIssued` and `fdpo:metadataModified` on new files, or on existing files where those values are missing. |
+| `--require-license` | No | off | Fail if model-level `metadata.yaml` does not provide a usable license. By default, missing licenses are tolerated and `dct:license` is omitted unless an existing PNG metadata file already has one. |
+
+## Input assumptions
+
+Each dataset folder must contain:
+
+```text
+metadata.yaml
+```
+
+The model-level `metadata.yaml` must provide enough information for the script to determine:
+
+- the model title;
+- the model issued date;
+- the model URI, or an identifier/slug from which the standard catalog model URI can be derived.
+
+A model-level license is recommended and is copied to generated PNG metadata when available. It is tolerated as missing by default so batch generation can still process catalog entries without model-level license metadata. Use `--require-license` to make a missing or unusable model-level license a fatal error.
+
+Each dataset must contain at least one PNG file in one of these folders:
+
+```text
+original-diagrams/
+new-diagrams/
+```
+
+In normal mode, a missing or empty `original-diagrams` or `new-diagrams` folder is tolerated as long as at least one PNG diagram is found. Use `--strict` to fail if either expected diagram folder is missing or empty.
+
+Only direct PNG files inside these folders are processed. The `.png` extension is matched case-insensitively. Nested files are not scanned.
+
+## Error handling
+
+The script fails with a non-zero exit code for critical problems, including:
+
+- missing dataset folder;
+- missing or unparsable `metadata.yaml`;
+- missing model title in `metadata.yaml`;
+- missing model issued date in `metadata.yaml`;
+- missing or unusable model license in `metadata.yaml`, only when `--require-license` is used;
+- no PNG diagrams found;
+- unsupported PNG filenames with control characters;
+- unreadable, invalid, or truncated PNG files;
+- duplicate generated metadata paths;
+- duplicate generated distribution URIs;
+- invalid `--metadata-timestamp` values;
+- malformed existing PNG metadata files;
+- existing target files when `--no-overwrite` is used.
+
+## Atomicity
+
+For each processed dataset, the script completes input validation and builds all RDF graphs before writing any target file. This prevents partial generation when a later diagram is invalid, when `--strict` fails, when `--no-overwrite` detects an existing target, or when optional file-derived metadata cannot be computed.
+
+## Serialization notes
+
+RDFLib serializes Turtle using its own formatting. Regenerated files may therefore differ from older manually generated files in non-semantic ways, such as:
+
+- prefix order;
+- whitespace before `;` and `.`;
+- omission of unused prefixes;
+- predicate order;
+- compact boolean syntax, e.g., `ocmv:isComplete false`, which is Turtle shorthand for an `xsd:boolean` false literal.
+
+These are Turtle serialization differences and do not change the RDF graph.
+
+## Terminal output
+
+For each generated file, the script prints:
+
+```text
+generated: <metadata-file> <- <png-file>
+```
+
+In dry-run mode, it prints:
+
+```text
+would generate: <metadata-file> <- <png-file>
+```
+
+## Run tests
+
+Run the PNG metadata generator tests:
+
+```bash
+python -m pytest -q scripts/tests/test_generate_png_metadata.py
+```
+
+Optional syntax check:
+
+```bash
+python -m py_compile scripts/generate_png_metadata.py scripts/tests/test_generate_png_metadata.py
+```

--- a/scripts/generate_png_metadata.py
+++ b/scripts/generate_png_metadata.py
@@ -1,0 +1,1175 @@
+"""Generate RDF/Turtle metadata for OntoUML catalog PNG diagram distributions.
+
+The script scans one or more model dataset folders and creates one metadata file
+for each PNG diagram found in these source folders:
+
+- original-diagrams/<diagram>.png -> metadata-png-o-<diagram>.ttl
+- new-diagrams/<diagram>.png      -> metadata-png-n-<diagram>.ttl
+
+Run from the repository root, for example:
+
+    python scripts/generate_png_metadata.py models/amaral2019rot
+    python scripts/generate_png_metadata.py --all --models-dir models
+
+The generated RDF follows the distribution metadata pattern already used in the
+catalog for JSON, Turtle, VPP, and PNG distributions:
+
+- the distribution is typed as dcat:Distribution;
+- the distribution points back to the model with dct:isPartOf;
+- model-level dct:issued is copied from metadata.yaml to the distribution;
+- model-level dct:license is copied from metadata.yaml when available;
+- the distribution receives dcat:mediaType, dcat:downloadURL, dct:title,
+  skos:editorialNote, ocmv:isComplete, fdpo:metadataIssued, and
+  fdpo:metadataModified.
+
+The model-level source of truth is metadata.yaml. Existing metadata-png-*.ttl
+files are read only to preserve stable distribution identifiers and curated
+PNG-level values during regeneration. The script does not read or update
+metadata.ttl.
+
+RDFLib is used for RDF graph creation and Turtle serialization. PyYAML is used
+for metadata.yaml parsing. PNG validation and dimension extraction are performed
+with the Python standard library so that no image-processing dependency is
+needed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import os
+import re
+import struct
+import sys
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from decimal import Decimal
+from pathlib import Path
+from typing import Any, List, Mapping, Optional, Sequence, Tuple
+from urllib.parse import quote
+
+import yaml
+from rdflib import BNode, Graph, Literal, Namespace, URIRef
+from rdflib.namespace import DCTERMS as DCT, RDF, SKOS, XSD
+
+DCAT = Namespace("http://www.w3.org/ns/dcat#")
+FDPO = Namespace("https://w3id.org/fdp/fdp-o#")
+OCMV = Namespace("https://w3id.org/ontouml-models/vocabulary#")
+SPDX = Namespace("http://spdx.org/rdf/terms#")
+SCHEMA = Namespace("https://schema.org/")
+
+PNG_MEDIA_TYPE = URIRef("https://www.iana.org/assignments/media-types/image/png")
+DISTRIBUTION_BASE = "https://w3id.org/ontouml-models/distribution/"
+
+DIAGRAM_SOURCES = {
+    "original-diagrams": "o",
+    "new-diagrams": "n",
+}
+
+SOURCE_VERSION_LABELS = {
+    "o": "original version",
+    "n": "Visual Paradigm version",
+}
+
+EDITORIAL_NOTES = {
+    "o": "This image depicts the diagram as originally represented by its author(s).",
+    "n": "This image depicts a version of the original diagram re-created in the Visual Paradigm editor.",
+}
+
+CONTROL_CHARS = re.compile(r"[\x00-\x1f\x7f]")
+XSD_DATETIME = re.compile(
+    r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})?$"
+)
+
+
+class MetadataGenerationError(RuntimeError):
+    """Raised when a dataset cannot be processed safely."""
+
+
+@dataclass(frozen=True)
+class Config:
+    """Configuration for PNG metadata generation."""
+
+    repository: str = "OntoUML/ontouml-models"
+    branch: str = "master"
+    models_dir_name: str = "models"
+    overwrite: bool = True
+    strict: bool = False
+    dry_run: bool = False
+    include_file_metadata: bool = False
+    metadata_timestamp: Optional[str] = None
+    require_license: bool = False
+
+
+@dataclass(frozen=True)
+class ModelMetadata:
+    """Minimum model metadata required to describe its PNG distributions."""
+
+    uri: URIRef
+    title: str
+    license_uri: Optional[URIRef]
+    issued: Literal
+
+
+@dataclass(frozen=True)
+class ExistingDistributionMetadata:
+    """Reusable metadata found in an existing distribution metadata file."""
+
+    uri: Optional[URIRef]
+    title: Optional[Literal]
+    editorial_note: Optional[Literal]
+    download_url: Optional[URIRef]
+    license_uri: Optional[URIRef]
+    metadata_issued: Optional[Literal]
+    metadata_modified: Optional[Literal]
+
+
+@dataclass(frozen=True)
+class DiagramFile:
+    """A discovered PNG diagram and the catalog naming data derived from it."""
+
+    source_dir: str
+    prefix: str
+    path: Path
+    stem: str
+    output_path: Path
+    distribution_uri: URIRef
+    download_url: URIRef
+    existing_metadata: ExistingDistributionMetadata
+
+
+@dataclass(frozen=True)
+class GeneratedFile:
+    """Result of generating one metadata file."""
+
+    diagram_path: Path
+    metadata_path: Path
+    distribution_uri: URIRef
+
+
+def bind_prefixes(graph: Graph) -> None:
+    """Bind prefixes used by catalog distribution metadata."""
+
+    graph.bind("dcat", DCAT)
+    graph.bind("dct", DCT)
+    graph.bind("fdpo", FDPO)
+    graph.bind("ocmv", OCMV)
+    graph.bind("skos", SKOS)
+    graph.bind("xsd", XSD)
+    graph.bind("spdx", SPDX)
+    graph.bind("schema", SCHEMA)
+
+
+def validate_dataset_folder(dataset_folder: Path) -> Path:
+    """Return a normalized dataset folder path or raise a clear error."""
+
+    dataset_folder = dataset_folder.resolve()
+    if not dataset_folder.exists():
+        raise MetadataGenerationError(
+            f"Dataset folder does not exist: {dataset_folder}"
+        )
+    if not dataset_folder.is_dir():
+        raise MetadataGenerationError(
+            f"Dataset path is not a directory: {dataset_folder}"
+        )
+    return dataset_folder
+
+
+def normalize_model_uri(uri: URIRef) -> URIRef:
+    """Normalize model URIs for distribution metadata.
+
+    Some catalog metadata files contain the model subject with a trailing slash,
+    while existing distribution metadata files use dct:isPartOf with the same URI
+    without that trailing slash. Distribution files generated here follow the
+    existing distribution-file convention.
+    """
+
+    return URIRef(str(uri).rstrip("/"))
+
+
+def load_model_metadata(dataset_folder: Path, config: Config) -> ModelMetadata:
+    """Load model URI, title, issued date, and optional license from metadata.yaml."""
+
+    metadata_path = dataset_folder / "metadata.yaml"
+    if not metadata_path.exists():
+        raise MetadataGenerationError(
+            f"Missing required canonical metadata file: {metadata_path}"
+        )
+
+    data = load_yaml_mapping(metadata_path)
+
+    title_value = yaml_first_value(
+        data,
+        paths=(
+            ("title",),
+            ("model", "title"),
+            ("metadata", "title"),
+            ("resource", "title"),
+            ("ontology", "title"),
+            ("name",),
+        ),
+        recursive_keys=("title", "name"),
+    )
+    title = yaml_text(title_value)
+    if not title:
+        raise MetadataGenerationError(f"Missing required title in {metadata_path}")
+
+    issued_value = yaml_first_value(
+        data,
+        paths=(
+            ("issued",),
+            ("dateIssued",),
+            ("issuedDate",),
+            ("issued_date",),
+            ("date",),
+            ("metadata", "issued"),
+            ("metadata", "dateIssued"),
+            ("metadata", "date"),
+            ("model", "issued"),
+            ("model", "dateIssued"),
+            ("resource", "issued"),
+            ("resource", "dateIssued"),
+            ("publication", "issued"),
+            ("publication", "date"),
+            ("publicationDate",),
+        ),
+        recursive_keys=("issued", "dateIssued", "issuedDate", "publicationDate"),
+    )
+    issued_literal = yaml_issued_literal(issued_value)
+    if issued_literal is None:
+        raise MetadataGenerationError(
+            f"Missing required issued date in {metadata_path}"
+        )
+
+    uri_value = yaml_first_value(
+        data,
+        paths=(
+            ("uri",),
+            ("modelUri",),
+            ("model", "uri"),
+            ("model", "id"),
+            ("metadata", "uri"),
+            ("resource", "uri"),
+            ("id",),
+        ),
+        recursive_keys=("modelUri", "uri"),
+    )
+    model_uri = yaml_model_uri(uri_value, dataset_folder.name)
+
+    license_value = yaml_first_value(
+        data,
+        paths=(
+            ("license",),
+            ("licenseUrl",),
+            ("licenseUri",),
+            ("metadata", "license"),
+            ("metadata", "licenseUrl"),
+            ("metadata", "licenseUri"),
+            ("model", "license"),
+            ("resource", "license"),
+            ("rights", "license"),
+            ("rights", "licenseUrl"),
+            ("rights", "licenseUri"),
+        ),
+        recursive_keys=("license", "licenseUrl", "licenseUri"),
+    )
+    license_ref = yaml_license_uri(license_value)
+    if license_ref is None and config.require_license:
+        raise MetadataGenerationError(f"Missing required license in {metadata_path}")
+
+    return ModelMetadata(
+        uri=model_uri,
+        title=title,
+        license_uri=license_ref,
+        issued=issued_literal,
+    )
+
+
+def load_yaml_mapping(path: Path) -> Mapping[str, Any]:
+    """Load a YAML file and ensure its root node is a mapping."""
+
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        raise MetadataGenerationError(f"Could not parse {path}: {exc}") from exc
+    except OSError as exc:
+        raise MetadataGenerationError(f"Could not read {path}: {exc}") from exc
+
+    if data is None:
+        raise MetadataGenerationError(f"Canonical metadata file is empty: {path}")
+    if not isinstance(data, Mapping):
+        raise MetadataGenerationError(
+            f"Canonical metadata file must contain a YAML mapping: {path}"
+        )
+    return data
+
+
+def canonical_yaml_key(value: object) -> str:
+    """Return a normalized key for permissive YAML field matching."""
+
+    return re.sub(r"[^a-z0-9]", "", str(value).lower())
+
+
+def yaml_mapping_get(mapping: Mapping[str, Any], key: str) -> Any:
+    """Return a mapping value using case-insensitive, punctuation-insensitive key matching."""
+
+    wanted = canonical_yaml_key(key)
+    for candidate, value in mapping.items():
+        if canonical_yaml_key(candidate) == wanted:
+            return value
+    return None
+
+
+def yaml_value_at_path(data: Any, path: Sequence[str]) -> Any:
+    """Return a YAML value by a normalized key path, or None when absent."""
+
+    current = data
+    for key in path:
+        if not isinstance(current, Mapping):
+            return None
+        current = yaml_mapping_get(current, key)
+        if current is None:
+            return None
+    return current
+
+
+def yaml_recursive_find(data: Any, keys: Sequence[str]) -> Any:
+    """Return the first scalar-like value found recursively for one of the given keys."""
+
+    wanted = {canonical_yaml_key(key) for key in keys}
+    if isinstance(data, Mapping):
+        for key, value in data.items():
+            if canonical_yaml_key(key) in wanted and value is not None:
+                return value
+        for value in data.values():
+            found = yaml_recursive_find(value, keys)
+            if found is not None:
+                return found
+    elif isinstance(data, list):
+        for value in data:
+            found = yaml_recursive_find(value, keys)
+            if found is not None:
+                return found
+    return None
+
+
+def yaml_first_value(
+    data: Mapping[str, Any],
+    *,
+    paths: Sequence[Sequence[str]],
+    recursive_keys: Sequence[str] = (),
+) -> Any:
+    """Return the first matching value from explicit paths, then from recursive key search."""
+
+    for path in paths:
+        value = yaml_value_at_path(data, path)
+        if value is not None:
+            return value
+    if recursive_keys:
+        return yaml_recursive_find(data, recursive_keys)
+    return None
+
+
+def yaml_text(value: Any) -> Optional[str]:
+    """Extract human-readable text from common YAML scalar or language-map forms."""
+
+    if value is None:
+        return None
+    if isinstance(value, Mapping):
+        for key in ("en", "eng", "english", "value", "label", "title", "name"):
+            nested = yaml_mapping_get(value, key)
+            text = yaml_text(nested)
+            if text:
+                return text
+        for nested in value.values():
+            text = yaml_text(nested)
+            if text:
+                return text
+        return None
+    if isinstance(value, list):
+        for item in value:
+            text = yaml_text(item)
+            if text:
+                return text
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def yaml_issued_literal(value: Any) -> Optional[Literal]:
+    """Convert a YAML issued-date value to the RDF literal used for dct:issued."""
+
+    text = yaml_text(value)
+    if not text:
+        return None
+    if re.fullmatch(r"\d{4}", text):
+        return Literal(text, datatype=XSD.gYear)
+    if re.fullmatch(r"\d{4}-\d{2}-\d{2}", text):
+        return Literal(text, datatype=XSD.date)
+    if XSD_DATETIME.match(text):
+        return Literal(text, datatype=XSD.dateTime, normalize=False)
+    return Literal(text)
+
+
+def yaml_model_uri(value: Any, dataset_slug: str) -> URIRef:
+    """Return the model URI from YAML, falling back to the dataset folder name."""
+
+    text = yaml_text(value)
+    if text and re.match(r"https?://", text):
+        return normalize_model_uri(URIRef(text))
+    if text and "/ontouml-models/model/" in text:
+        return normalize_model_uri(URIRef(text))
+
+    # If the canonical YAML does not expose the full IRI, the catalog folder name
+    # is the stable model slug used in the standard model URI pattern.
+    slug = text or dataset_slug
+    slug = str(slug).strip().strip("/")
+    if not slug:
+        slug = dataset_slug
+    return normalize_model_uri(URIRef(f"https://w3id.org/ontouml-models/model/{slug}/"))
+
+
+def yaml_license_uri(value: Any) -> Optional[URIRef]:
+    """Extract a license URI from common YAML license forms."""
+
+    text = yaml_license_text(value)
+    if not text:
+        return None
+    text = text.strip()
+    if re.match(r"https?://", text):
+        return URIRef(text)
+
+    licenses = {
+        "ccby40": "https://creativecommons.org/licenses/by/4.0/",
+        "creativecommonsattribution40international": "https://creativecommons.org/licenses/by/4.0/",
+        "ccbysa40": "https://creativecommons.org/licenses/by-sa/4.0/",
+        "creativecommonsattributionsharealike40international": "https://creativecommons.org/licenses/by-sa/4.0/",
+        "ccbysa30": "https://creativecommons.org/licenses/by-sa/3.0/",
+        "creativecommonsattributionsharealike30unported": "https://creativecommons.org/licenses/by-sa/3.0/",
+        "cc010": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "creativecommonszero10universaldomainpublicdedication": "https://creativecommons.org/publicdomain/zero/1.0/",
+        "mit": "http://spdx.org/licenses/MIT",
+    }
+    return (
+        URIRef(licenses[canonical_yaml_key(text)])
+        if canonical_yaml_key(text) in licenses
+        else None
+    )
+
+
+def yaml_license_text(value: Any) -> Optional[str]:
+    """Extract a license string, preferring URI/URL fields over labels."""
+
+    if value is None:
+        return None
+    if isinstance(value, Mapping):
+        for key in (
+            "uri",
+            "url",
+            "licenseUri",
+            "licenseUrl",
+            "id",
+            "identifier",
+            "spdx",
+            "value",
+        ):
+            text = yaml_license_text(yaml_mapping_get(value, key))
+            if text:
+                return text
+        for nested in value.values():
+            text = yaml_license_text(nested)
+            if text:
+                return text
+        return None
+    if isinstance(value, list):
+        for item in value:
+            text = yaml_license_text(item)
+            if text:
+                return text
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def first_literal(
+    graph: Graph, subject: URIRef, predicate: URIRef
+) -> Optional[Literal]:
+    """Return the first literal object for subject/predicate, if present."""
+
+    for value in graph.objects(subject, predicate):
+        if isinstance(value, Literal):
+            return value
+    return None
+
+
+def first_uri(graph: Graph, subject: URIRef, predicate: URIRef) -> Optional[URIRef]:
+    """Return the first URIRef object for subject/predicate, if present."""
+
+    for value in graph.objects(subject, predicate):
+        if isinstance(value, URIRef):
+            return value
+    return None
+
+
+def validate_png_name(path: Path) -> str:
+    """Validate a PNG filename and return the stem used in metadata names."""
+
+    if path.suffix.lower() != ".png":
+        raise MetadataGenerationError(
+            f"Unsupported diagram file extension; expected .png: {path}"
+        )
+
+    name = path.name
+    stem = path.stem
+    if not stem:
+        raise MetadataGenerationError(
+            f"Unsupported PNG filename with empty stem: {path}"
+        )
+    if CONTROL_CHARS.search(name):
+        raise MetadataGenerationError(
+            f"Unsupported PNG filename with control characters: {path}"
+        )
+    if name in {".", ".."} or stem in {".", ".."}:
+        raise MetadataGenerationError(f"Unsupported PNG filename: {path}")
+    return stem
+
+
+def read_png_dimensions(path: Path) -> Tuple[int, int]:
+    """Return PNG width and height after validating PNG chunk structure.
+
+    The validator checks the PNG signature, IHDR chunk, chunk boundaries, chunk
+    CRC values, and the presence of the terminal IEND chunk. It does not decode
+    the compressed image payload; the goal is to reject unreadable or truncated
+    files without adding an image-processing dependency.
+    """
+
+    signature = b"\x89PNG\r\n\x1a\n"
+
+    try:
+        with path.open("rb") as stream:
+            if stream.read(8) != signature:
+                raise MetadataGenerationError(f"Unreadable or invalid PNG file: {path}")
+
+            chunk_type, chunk_data = read_png_chunk(stream, path)
+            if chunk_type != b"IHDR" or len(chunk_data) != 13:
+                raise MetadataGenerationError(
+                    f"PNG file does not contain a valid IHDR chunk: {path}"
+                )
+
+            width, height = struct.unpack(">II", chunk_data[:8])
+            if width <= 0 or height <= 0:
+                raise MetadataGenerationError(
+                    f"PNG file has invalid dimensions {width}x{height}: {path}"
+                )
+
+            while True:
+                chunk_type, _chunk_data = read_png_chunk(stream, path)
+                if chunk_type == b"IEND":
+                    break
+
+    except OSError as exc:
+        raise MetadataGenerationError(f"Could not read PNG file {path}: {exc}") from exc
+
+    return width, height
+
+
+def read_png_chunk(stream, path: Path) -> Tuple[bytes, bytes]:
+    """Read one PNG chunk and validate its CRC."""
+
+    length_bytes = stream.read(4)
+    if len(length_bytes) != 4:
+        raise MetadataGenerationError(f"Unreadable or truncated PNG file: {path}")
+
+    length = struct.unpack(">I", length_bytes)[0]
+    chunk_type = stream.read(4)
+    if len(chunk_type) != 4:
+        raise MetadataGenerationError(
+            f"Unreadable or truncated PNG chunk header: {path}"
+        )
+
+    chunk_data = stream.read(length)
+    if len(chunk_data) != length:
+        raise MetadataGenerationError(f"Unreadable or truncated PNG chunk data: {path}")
+
+    crc_bytes = stream.read(4)
+    if len(crc_bytes) != 4:
+        raise MetadataGenerationError(f"Unreadable or truncated PNG chunk CRC: {path}")
+
+    stored_crc = struct.unpack(">I", crc_bytes)[0]
+    computed_crc = crc32(chunk_type + chunk_data)
+    if stored_crc != computed_crc:
+        raise MetadataGenerationError(f"Invalid PNG chunk CRC in {path}")
+
+    return chunk_type, chunk_data
+
+
+def crc32(data: bytes) -> int:
+    """Return an unsigned PNG CRC-32 value."""
+
+    import zlib
+
+    return zlib.crc32(data) & 0xFFFFFFFF
+
+
+def sha256_hex(path: Path) -> str:
+    """Compute a SHA-256 checksum for a file."""
+
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def quoted_path(*segments: str) -> str:
+    """Quote URL path segments while preserving path separators.
+
+    Commas are left unescaped because they are valid path characters and existing
+    catalog raw GitHub URLs use them unescaped in diagram filenames.
+    """
+
+    return "/".join(quote(segment, safe=",") for segment in segments)
+
+
+def split_repository_path(path: str) -> List[str]:
+    """Split a repository-relative path option into URL path segments."""
+
+    return [segment for segment in path.replace("\\", "/").split("/") if segment]
+
+
+def new_distribution_uri(model_uri: URIRef, source_dir: str, filename: str) -> URIRef:
+    """Create a deterministic distribution URI for a PNG diagram.
+
+    Existing catalog distribution URIs use UUIDs under
+    https://w3id.org/ontouml-models/distribution/. For new PNG metadata files,
+    a UUIDv5 value makes generation reproducible. If a target metadata file
+    already exists, its distribution URI is preserved instead.
+    """
+
+    name = f"{model_uri}|{source_dir}/{filename}"
+    return URIRef(f"{DISTRIBUTION_BASE}{uuid.uuid5(uuid.NAMESPACE_URL, name)}/")
+
+
+def download_url(
+    config: Config, dataset_folder: Path, source_dir: str, filename: str
+) -> URIRef:
+    """Create the raw GitHub download URL for a diagram file."""
+
+    model_slug = dataset_folder.name
+    path = quoted_path(
+        *split_repository_path(config.models_dir_name), model_slug, source_dir, filename
+    )
+    return URIRef(
+        f"https://raw.githubusercontent.com/{config.repository}/{config.branch}/{path}"
+    )
+
+
+def read_existing_distribution_metadata(path: Path) -> ExistingDistributionMetadata:
+    """Read reusable metadata from an existing target file, if present.
+
+    RDFLib normalizes xsd:dateTime values when parsing, which can shorten
+    nanosecond timestamps such as 2023-04-14T17:33:22.898648451Z. The catalog
+    already contains such lexical forms, so timestamp literals are extracted from
+    the original Turtle text and reinserted with normalize=False.
+    """
+
+    if not path.exists():
+        return ExistingDistributionMetadata(
+            uri=None,
+            title=None,
+            editorial_note=None,
+            download_url=None,
+            license_uri=None,
+            metadata_issued=None,
+            metadata_modified=None,
+        )
+
+    graph = Graph()
+    try:
+        graph.parse(path)
+    except Exception as exc:  # noqa: BLE001 - surface RDFLib parse errors clearly
+        raise MetadataGenerationError(
+            f"Could not parse existing metadata file {path}: {exc}"
+        ) from exc
+
+    subjects = [
+        subject
+        for subject in graph.subjects(RDF.type, DCAT.Distribution)
+        if isinstance(subject, URIRef)
+    ]
+    if len(subjects) > 1:
+        raise MetadataGenerationError(
+            f"Expected at most one dcat:Distribution in {path}, found {len(subjects)}"
+        )
+
+    distribution = subjects[0] if subjects else None
+    if distribution and not str(distribution).startswith(DISTRIBUTION_BASE):
+        raise MetadataGenerationError(
+            f"Existing distribution URI does not follow catalog distribution URI pattern in {path}: {distribution}"
+        )
+
+    text = path.read_text(encoding="utf-8")
+    title = first_literal(graph, distribution, DCT.title) if distribution else None
+    editorial = (
+        first_literal(graph, distribution, SKOS.editorialNote) if distribution else None
+    )
+    download = (
+        first_uri(graph, distribution, DCAT.downloadURL) if distribution else None
+    )
+    license_uri = first_uri(graph, distribution, DCT.license) if distribution else None
+    metadata_issued = existing_datetime_literal(text, "metadataIssued")
+    metadata_modified = existing_datetime_literal(text, "metadataModified")
+
+    return ExistingDistributionMetadata(
+        uri=distribution,
+        title=title,
+        editorial_note=editorial,
+        download_url=download,
+        license_uri=license_uri,
+        metadata_issued=metadata_issued,
+        metadata_modified=metadata_modified,
+    )
+
+
+def existing_datetime_literal(turtle_text: str, local_name: str) -> Optional[Literal]:
+    """Return an existing fdpo dateTime literal while preserving its lexical form."""
+
+    patterns = [
+        rf"\bfdpo:{re.escape(local_name)}\s+\"([^\"]+)\"\^\^xsd:dateTime",
+        rf"<https://w3id\.org/fdp/fdp-o#{re.escape(local_name)}>\s+\"([^\"]+)\"\^\^<http://www\.w3\.org/2001/XMLSchema#dateTime>",
+    ]
+    for pattern in patterns:
+        match = re.search(pattern, turtle_text)
+        if match:
+            return Literal(match.group(1), datatype=XSD.dateTime, normalize=False)
+    return None
+
+
+def collect_diagrams(
+    dataset_folder: Path, model: ModelMetadata, config: Config
+) -> List[DiagramFile]:
+    """Collect diagram files in catalog-supported diagram folders.
+
+    All diagram-level validation is completed before any output file is written.
+    This prevents partial generation when a later diagram is invalid, when strict
+    mode fails, or when duplicate metadata targets/URIs are detected.
+    """
+
+    seen_outputs: dict[Path, Path] = {}
+    seen_uris: dict[URIRef, Path] = {}
+    missing_or_empty: List[str] = []
+    diagrams: List[DiagramFile] = []
+
+    for source_dir, prefix in DIAGRAM_SOURCES.items():
+        folder = dataset_folder / source_dir
+        if not folder.exists():
+            missing_or_empty.append(f"missing folder: {folder}")
+            continue
+        if not folder.is_dir():
+            raise MetadataGenerationError(
+                f"Diagram path exists but is not a directory: {folder}"
+            )
+
+        png_files = sorted(
+            path
+            for path in folder.iterdir()
+            if path.is_file() and path.suffix.lower() == ".png"
+        )
+        if not png_files:
+            missing_or_empty.append(f"empty folder: {folder}")
+            continue
+
+        for png_path in png_files:
+            stem = validate_png_name(png_path)
+            # Validate PNG before generating metadata; dimensions can optionally
+            # be emitted with --include-file-metadata.
+            read_png_dimensions(png_path)
+
+            output_path = dataset_folder / f"metadata-png-{prefix}-{stem}.ttl"
+            if output_path.exists() and not config.overwrite:
+                existing = ExistingDistributionMetadata(
+                    uri=None,
+                    title=None,
+                    editorial_note=None,
+                    download_url=None,
+                    license_uri=None,
+                    metadata_issued=None,
+                    metadata_modified=None,
+                )
+                dist_uri = new_distribution_uri(model.uri, source_dir, png_path.name)
+            else:
+                existing = read_existing_distribution_metadata(output_path)
+                dist_uri = existing.uri or new_distribution_uri(
+                    model.uri, source_dir, png_path.name
+                )
+            generated_download_url = download_url(
+                config, dataset_folder, source_dir, png_path.name
+            )
+            dload = existing.download_url or generated_download_url
+
+            existing_output = seen_outputs.get(output_path)
+            if existing_output is not None:
+                raise MetadataGenerationError(
+                    f"Duplicate metadata target {output_path} for {existing_output} and {png_path}"
+                )
+            seen_outputs[output_path] = png_path
+
+            existing_uri = seen_uris.get(dist_uri)
+            if existing_uri is not None:
+                raise MetadataGenerationError(
+                    f"Duplicate distribution URI {dist_uri} for {existing_uri} and {png_path}"
+                )
+            seen_uris[dist_uri] = png_path
+
+            diagrams.append(
+                DiagramFile(
+                    source_dir=source_dir,
+                    prefix=prefix,
+                    path=png_path,
+                    stem=stem,
+                    output_path=output_path,
+                    distribution_uri=dist_uri,
+                    download_url=dload,
+                    existing_metadata=existing,
+                )
+            )
+
+    if not diagrams:
+        details = (
+            "; ".join(missing_or_empty) if missing_or_empty else "no PNG files found"
+        )
+        raise MetadataGenerationError(
+            f"No PNG diagrams found in {dataset_folder} ({details})"
+        )
+
+    if config.strict and missing_or_empty:
+        raise MetadataGenerationError(
+            f"Strict mode failed for {dataset_folder}: " + "; ".join(missing_or_empty)
+        )
+
+    return diagrams
+
+
+def current_metadata_timestamp() -> Literal:
+    """Return the current UTC timestamp as xsd:dateTime."""
+
+    value = (
+        datetime.now(timezone.utc)
+        .isoformat(timespec="microseconds")
+        .replace("+00:00", "Z")
+    )
+    return Literal(value, datatype=XSD.dateTime, normalize=False)
+
+
+def configured_metadata_timestamp(config: Config) -> Literal:
+    """Return a configured or current fdpo metadata timestamp."""
+
+    if config.metadata_timestamp:
+        if not XSD_DATETIME.match(config.metadata_timestamp):
+            raise MetadataGenerationError(
+                "--metadata-timestamp must be an xsd:dateTime lexical value, "
+                "for example 2024-01-02T03:04:05Z"
+            )
+        return Literal(
+            config.metadata_timestamp, datatype=XSD.dateTime, normalize=False
+        )
+    return current_metadata_timestamp()
+
+
+def build_distribution_graph(
+    model: ModelMetadata, diagram: DiagramFile, config: Config
+) -> Graph:
+    """Build RDF metadata for one PNG diagram distribution."""
+
+    graph = Graph()
+    bind_prefixes(graph)
+
+    title = diagram_title(model, diagram)
+    metadata_timestamp = configured_metadata_timestamp(config)
+    metadata_issued = diagram.existing_metadata.metadata_issued or metadata_timestamp
+    # Preserve existing metadataModified by default to make regeneration stable.
+    # Pass --metadata-timestamp with a new value after intentional changes if a
+    # maintained modified timestamp is required.
+    metadata_modified = (
+        diagram.existing_metadata.metadata_modified or metadata_timestamp
+    )
+
+    graph.add((diagram.distribution_uri, RDF.type, DCAT.Distribution))
+    graph.add((diagram.distribution_uri, DCT.isPartOf, model.uri))
+    graph.add((diagram.distribution_uri, DCT.issued, model.issued))
+    license_uri = diagram.existing_metadata.license_uri or model.license_uri
+    if license_uri is not None:
+        graph.add((diagram.distribution_uri, DCT.license, license_uri))
+    graph.add((diagram.distribution_uri, DCAT.mediaType, PNG_MEDIA_TYPE))
+    graph.add(
+        (
+            diagram.distribution_uri,
+            OCMV.isComplete,
+            Literal(False, datatype=XSD.boolean),
+        )
+    )
+    graph.add(
+        (
+            diagram.distribution_uri,
+            DCT.title,
+            diagram.existing_metadata.title or Literal(title, lang="en"),
+        )
+    )
+    graph.add((diagram.distribution_uri, DCAT.downloadURL, diagram.download_url))
+    graph.add(
+        (
+            diagram.distribution_uri,
+            SKOS.editorialNote,
+            diagram.existing_metadata.editorial_note
+            or Literal(editorial_note(diagram.prefix), lang="en"),
+        )
+    )
+    graph.add((diagram.distribution_uri, FDPO.metadataIssued, metadata_issued))
+    graph.add((diagram.distribution_uri, FDPO.metadataModified, metadata_modified))
+
+    if config.include_file_metadata:
+        width, height = read_png_dimensions(diagram.path)
+        graph.add(
+            (
+                diagram.distribution_uri,
+                DCAT.byteSize,
+                Literal(Decimal(os.path.getsize(diagram.path)), datatype=XSD.decimal),
+            )
+        )
+        graph.add(
+            (
+                diagram.distribution_uri,
+                SCHEMA.width,
+                Literal(width, datatype=XSD.integer),
+            )
+        )
+        graph.add(
+            (
+                diagram.distribution_uri,
+                SCHEMA.height,
+                Literal(height, datatype=XSD.integer),
+            )
+        )
+        checksum = BNode()
+        graph.add((diagram.distribution_uri, SPDX.checksum, checksum))
+        graph.add((checksum, RDF.type, SPDX.Checksum))
+        graph.add((checksum, SPDX.algorithm, SPDX.checksumAlgorithm_sha256))
+        graph.add((checksum, SPDX.checksumValue, Literal(sha256_hex(diagram.path))))
+
+    return graph
+
+
+def diagram_title(model: ModelMetadata, diagram: DiagramFile) -> str:
+    """Return a catalog-style title for a PNG diagram distribution."""
+
+    label = diagram_label(diagram.stem)
+    version = source_version_label(diagram.prefix)
+    return f"PNG distribution of diagram '{label}' from the {model.title} ({version})"
+
+
+def diagram_label(stem: str) -> str:
+    """Return a human-readable diagram label derived from a filename stem."""
+
+    return re.sub(r"[\s_-]+", " ", stem).strip()
+
+
+def source_version_label(prefix: str) -> str:
+    """Return the catalog label used for the source diagram version."""
+
+    return SOURCE_VERSION_LABELS.get(prefix, prefix)
+
+
+def editorial_note(prefix: str) -> str:
+    """Return the catalog editorial note used for the source diagram version."""
+
+    return EDITORIAL_NOTES.get(
+        prefix, "This image depicts a diagram distribution of the model."
+    )
+
+
+def write_graph(graph: Graph, target: Path, config: Config) -> None:
+    """Serialize a graph to Turtle."""
+
+    if target.exists() and not config.overwrite:
+        raise MetadataGenerationError(
+            f"Metadata file already exists and overwrite is disabled: {target}"
+        )
+    if config.dry_run:
+        return
+
+    target.write_text(graph.serialize(format="turtle"), encoding="utf-8")
+
+
+def process_dataset(dataset_folder: Path, config: Config) -> List[GeneratedFile]:
+    """Generate PNG distribution metadata files for one dataset folder.
+
+    The function validates all inputs and builds all RDF graphs before writing any
+    target file. This keeps generation atomic at dataset level for validation
+    errors and for --no-overwrite failures.
+    """
+
+    dataset_folder = validate_dataset_folder(dataset_folder)
+    model = load_model_metadata(dataset_folder, config)
+    diagrams = collect_diagrams(dataset_folder, model, config)
+
+    existing_targets = [
+        diagram.output_path for diagram in diagrams if diagram.output_path.exists()
+    ]
+    if existing_targets and not config.overwrite:
+        joined = ", ".join(str(path) for path in existing_targets)
+        raise MetadataGenerationError(
+            f"Metadata file already exists and overwrite is disabled: {joined}"
+        )
+
+    planned = [
+        (diagram, build_distribution_graph(model, diagram, config))
+        for diagram in diagrams
+    ]
+
+    generated: List[GeneratedFile] = []
+    for diagram, graph in planned:
+        write_graph(graph, diagram.output_path, config)
+        generated.append(
+            GeneratedFile(
+                diagram_path=diagram.path,
+                metadata_path=diagram.output_path,
+                distribution_uri=diagram.distribution_uri,
+            )
+        )
+    return generated
+
+
+def discover_datasets(models_dir: Path) -> List[Path]:
+    """Discover model dataset folders under models_dir by metadata.yaml presence."""
+
+    if not models_dir.exists():
+        raise MetadataGenerationError(f"Models directory does not exist: {models_dir}")
+    if not models_dir.is_dir():
+        raise MetadataGenerationError(f"Models path is not a directory: {models_dir}")
+    return sorted(
+        path
+        for path in models_dir.iterdir()
+        if path.is_dir() and (path / "metadata.yaml").exists()
+    )
+
+
+def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate metadata-png-o-*.ttl and metadata-png-n-*.ttl files from diagram PNG files.",
+    )
+    parser.add_argument(
+        "datasets",
+        nargs="*",
+        type=Path,
+        help="Dataset folder(s) to process. If omitted, the current directory is used when it contains metadata.yaml.",
+    )
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Process all dataset folders below --models-dir.",
+    )
+    parser.add_argument(
+        "--models-dir",
+        type=Path,
+        default=Path("models"),
+        help="Models directory used with --all. Default: models.",
+    )
+    parser.add_argument(
+        "--repository",
+        default="OntoUML/ontouml-models",
+        help="GitHub repository used for dcat:downloadURL. Default: OntoUML/ontouml-models.",
+    )
+    parser.add_argument(
+        "--branch",
+        default="master",
+        help="Git branch used for dcat:downloadURL. Default: master.",
+    )
+    parser.add_argument(
+        "--models-dir-name",
+        default="models",
+        help="Repository-relative models path used inside generated dcat:downloadURL values. Default: models.",
+    )
+    parser.add_argument(
+        "--no-overwrite",
+        action="store_true",
+        help="Fail if a target metadata file already exists.",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Fail if expected diagram folders are missing or empty.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Validate inputs and report files that would be generated without writing them.",
+    )
+    parser.add_argument(
+        "--include-file-metadata",
+        action="store_true",
+        help="Also add optional byte size, SHA-256 checksum, width, and height triples.",
+    )
+    parser.add_argument(
+        "--metadata-timestamp",
+        help="xsd:dateTime value used for fdpo:metadataIssued and fdpo:metadataModified on new files.",
+    )
+    parser.add_argument(
+        "--require-license",
+        action="store_true",
+        help="Fail if metadata.yaml does not provide a usable license. By default, missing licenses are tolerated and dct:license is omitted unless an existing PNG metadata file already has one.",
+    )
+    return parser.parse_args(argv)
+
+
+def resolve_targets(args: argparse.Namespace) -> List[Path]:
+    if args.all:
+        if args.datasets:
+            raise MetadataGenerationError(
+                "Use either --all or explicit dataset folders, not both."
+            )
+        return discover_datasets(args.models_dir)
+
+    if args.datasets:
+        return list(args.datasets)
+
+    cwd = Path.cwd()
+    if (cwd / "metadata.yaml").exists():
+        return [cwd]
+
+    raise MetadataGenerationError(
+        "No dataset folder provided. Pass one or more model folders, use --all, or run from a dataset folder."
+    )
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    args = parse_args(argv)
+    config = Config(
+        repository=args.repository,
+        branch=args.branch,
+        models_dir_name=args.models_dir_name,
+        overwrite=not args.no_overwrite,
+        strict=args.strict,
+        dry_run=args.dry_run,
+        include_file_metadata=args.include_file_metadata,
+        metadata_timestamp=args.metadata_timestamp,
+        require_license=args.require_license,
+    )
+
+    try:
+        targets = resolve_targets(args)
+        generated_all: List[GeneratedFile] = []
+        for target in targets:
+            generated_all.extend(process_dataset(target, config))
+    except MetadataGenerationError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    action = "would generate" if config.dry_run else "generated"
+    for item in generated_all:
+        print(f"{action}: {item.metadata_path} <- {item.diagram_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,0 +1,3 @@
+pytest>=7.0
+pyyaml>=6.0
+rdflib>=6.0

--- a/scripts/tests/test_generate_png_metadata.py
+++ b/scripts/tests/test_generate_png_metadata.py
@@ -1,0 +1,460 @@
+from __future__ import annotations
+
+import importlib.util
+import struct
+import sys
+import zlib
+from pathlib import Path
+
+import pytest
+
+
+def load_module():
+    script = None
+    for parent in Path(__file__).resolve().parents:
+        for candidate in (
+            parent / "generate_png_metadata.py",
+            parent / "scripts" / "generate_png_metadata.py",
+        ):
+            if candidate.exists():
+                script = candidate
+                break
+        if script is not None:
+            break
+    assert script is not None
+    spec = importlib.util.spec_from_file_location("generate_png_metadata", script)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def png_chunk(chunk_type: bytes, data: bytes) -> bytes:
+    return (
+        struct.pack(">I", len(data))
+        + chunk_type
+        + data
+        + struct.pack(">I", zlib.crc32(chunk_type + data) & 0xFFFFFFFF)
+    )
+
+
+def minimal_png() -> bytes:
+    signature = b"\x89PNG\r\n\x1a\n"
+    ihdr = struct.pack(">IIBBBBB", 1, 1, 8, 6, 0, 0, 0)
+    return (
+        signature
+        + png_chunk(b"IHDR", ihdr)
+        + png_chunk(b"IDAT", b"")
+        + png_chunk(b"IEND", b"")
+    )
+
+
+def write_metadata_yaml(
+    dataset: Path,
+    *,
+    slug: str = "example",
+    title: str = "Petroleum System Model",
+    issued: str = "2015",
+    license_value: str | None = "https://creativecommons.org/licenses/by/4.0/",
+) -> None:
+    license_line = f"license: {license_value}\n" if license_value is not None else ""
+    (dataset / "metadata.yaml").write_text(
+        f"""
+id: {slug}
+title: {title}
+issued: {issued}
+{license_line}""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def write_dataset(tmp_path: Path) -> Path:
+    dataset = tmp_path / "models" / "example-model"
+    (dataset / "original-diagrams").mkdir(parents=True)
+    (dataset / "new-diagrams").mkdir()
+    (dataset / "original-diagrams" / "petroleum-system.png").write_bytes(minimal_png())
+    (dataset / "new-diagrams" / "petroleum-system.png").write_bytes(minimal_png())
+    write_metadata_yaml(dataset)
+    (dataset / "metadata-png-o-petroleum-system.ttl").write_text(
+        """
+@prefix dcat: <http://www.w3.org/ns/dcat#>.
+@prefix dct: <http://purl.org/dc/terms/>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
+@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+
+<https://w3id.org/ontouml-models/distribution/original-existing> a dcat:Distribution;
+    dct:title "Existing original PNG title"@en;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/example-model/original-diagrams/petroleum-system.png>;
+    skos:editorialNote "Existing original editorial note."@en;
+    fdpo:metadataIssued "2023-04-14T17:33:24.802284319Z"^^xsd:dateTime;
+    fdpo:metadataModified "2023-04-14T17:33:25.802284319Z"^^xsd:dateTime .
+""".strip(),
+        encoding="utf-8",
+    )
+    return dataset
+
+
+def test_png_metadata_regeneration_preserves_existing_catalog_values(tmp_path: Path):
+    module = load_module()
+    dataset = write_dataset(tmp_path)
+
+    generated = module.process_dataset(dataset, module.Config())
+
+    assert len(generated) == 2
+    original = (dataset / "metadata-png-o-petroleum-system.ttl").read_text(
+        encoding="utf-8"
+    )
+
+    assert "ocmv:isComplete false" in original
+    assert "Existing original PNG title" in original
+    assert "Existing original editorial note." in original
+    assert "2023-04-14T17:33:24.802284319Z" in original
+    assert "2023-04-14T17:33:25.802284319Z" in original
+    assert "https://w3id.org/ontouml-models/distribution/original-existing" in original
+    assert "original-diagrams/petroleum-system.png" in original
+
+
+def test_png_metadata_generation_uses_yaml_defaults_for_new_files(tmp_path: Path):
+    module = load_module()
+    dataset = write_dataset(tmp_path)
+
+    module.process_dataset(dataset, module.Config())
+
+    new = (dataset / "metadata-png-n-petroleum-system.ttl").read_text(encoding="utf-8")
+
+    assert "ocmv:isComplete false" in new
+    assert "dct:isPartOf <https://w3id.org/ontouml-models/model/example>" in new
+    assert 'dct:issued "2015"^^xsd:gYear' in new
+    assert (
+        'skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en'
+        in new
+    )
+    assert (
+        "PNG distribution of diagram 'petroleum system' from the Petroleum System Model (Visual Paradigm version)"
+        in new
+    )
+
+
+def test_png_metadata_generation_does_not_require_metadata_ttl(tmp_path: Path):
+    module = load_module()
+    dataset = write_dataset(tmp_path)
+
+    assert not (dataset / "metadata.ttl").exists()
+
+    module.process_dataset(
+        dataset, module.Config(metadata_timestamp="2024-01-02T03:04:05Z")
+    )
+
+    assert (dataset / "metadata-png-n-petroleum-system.ttl").exists()
+
+
+def test_png_metadata_regeneration_preserves_existing_download_url_with_comma(
+    tmp_path: Path,
+):
+    module = load_module()
+    dataset = tmp_path / "models" / "alpinebits2022"
+    (dataset / "original-diagrams").mkdir(parents=True)
+    (
+        dataset / "original-diagrams" / "lifts,-ski-slopes,-and-snowparks.png"
+    ).write_bytes(minimal_png())
+    write_metadata_yaml(
+        dataset,
+        slug="alpinebits",
+        title="AlpineBits DestinationData Ontology",
+        issued="2020",
+        license_value="https://creativecommons.org/licenses/by-sa/3.0/",
+    )
+    (dataset / "metadata-png-o-lifts,-ski-slopes,-and-snowparks.ttl").write_text(
+        """
+@prefix dcat: <http://www.w3.org/ns/dcat#>.
+@prefix dct: <http://purl.org/dc/terms/>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
+@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+
+<https://w3id.org/ontouml-models/distribution/comma-existing> a dcat:Distribution;
+    dct:title "PNG distribution of diagram 'lifts, ski slopes, and snowparks' from the AlpineBits DestinationData Ontology (original version)"@en;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/alpinebits2022/original-diagrams/lifts,-ski-slopes,-and-snowparks.png>;
+    skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en;
+    fdpo:metadataIssued "2023-04-14T17:35:15.384682094Z"^^xsd:dateTime;
+    fdpo:metadataModified "2023-04-14T17:35:15.384682094Z"^^xsd:dateTime .
+""".strip(),
+        encoding="utf-8",
+    )
+
+    module.process_dataset(dataset, module.Config())
+
+    regenerated = (
+        dataset / "metadata-png-o-lifts,-ski-slopes,-and-snowparks.ttl"
+    ).read_text(encoding="utf-8")
+    assert "lifts,-ski-slopes,-and-snowparks.png" in regenerated
+    assert "lifts%2C-ski-slopes%2C-and-snowparks.png" not in regenerated
+
+
+def test_png_metadata_generation_keeps_commas_unescaped_in_new_download_urls(
+    tmp_path: Path,
+):
+    module = load_module()
+    dataset = tmp_path / "models" / "new-comma-model"
+    (dataset / "original-diagrams").mkdir(parents=True)
+    (
+        dataset / "original-diagrams" / "lifts,-ski-slopes,-and-snowparks.png"
+    ).write_bytes(minimal_png())
+    write_metadata_yaml(
+        dataset, slug="new-comma", title="New Comma Model", issued="2024"
+    )
+
+    module.process_dataset(
+        dataset, module.Config(metadata_timestamp="2024-01-02T03:04:05Z")
+    )
+
+    generated = (
+        dataset / "metadata-png-o-lifts,-ski-slopes,-and-snowparks.ttl"
+    ).read_text(encoding="utf-8")
+    assert "lifts,-ski-slopes,-and-snowparks.png" in generated
+    assert "lifts%2C-ski-slopes%2C-and-snowparks.png" not in generated
+
+
+def test_png_metadata_generation_tolerates_missing_model_license(tmp_path: Path):
+    module = load_module()
+    dataset = tmp_path / "models" / "missing-license-model"
+    (dataset / "original-diagrams").mkdir(parents=True)
+    (dataset / "original-diagrams" / "diagram.png").write_bytes(minimal_png())
+    write_metadata_yaml(
+        dataset,
+        slug="missing-license",
+        title="Missing License Model",
+        issued="2024",
+        license_value=None,
+    )
+
+    module.process_dataset(
+        dataset, module.Config(metadata_timestamp="2024-01-02T03:04:05Z")
+    )
+
+    generated = (dataset / "metadata-png-o-diagram.ttl").read_text(encoding="utf-8")
+    assert "dct:license" not in generated
+    assert "Missing License Model" in generated
+
+
+def test_png_metadata_generation_can_require_model_license(tmp_path: Path):
+    module = load_module()
+    dataset = tmp_path / "models" / "missing-license-model"
+    (dataset / "original-diagrams").mkdir(parents=True)
+    (dataset / "original-diagrams" / "diagram.png").write_bytes(minimal_png())
+    write_metadata_yaml(
+        dataset,
+        slug="missing-license",
+        title="Missing License Model",
+        issued="2024",
+        license_value=None,
+    )
+
+    with pytest.raises(
+        module.MetadataGenerationError, match="Missing required license"
+    ):
+        module.process_dataset(dataset, module.Config(require_license=True))
+
+
+def test_discover_datasets_uses_metadata_yaml(tmp_path: Path):
+    module = load_module()
+    models = tmp_path / "models"
+    with_yaml = models / "with-yaml"
+    without_yaml = models / "without-yaml"
+    with_yaml.mkdir(parents=True)
+    without_yaml.mkdir()
+    write_metadata_yaml(with_yaml, slug="with-yaml", title="With YAML", issued="2024")
+    (without_yaml / "metadata.ttl").write_text("", encoding="utf-8")
+
+    assert module.discover_datasets(models) == [with_yaml]
+
+
+def test_yaml_metadata_loader_accepts_nested_language_map_and_license_id(
+    tmp_path: Path,
+):
+    module = load_module()
+    dataset = tmp_path / "models" / "nested-yaml-model"
+    (dataset / "original-diagrams").mkdir(parents=True)
+    (dataset / "original-diagrams" / "diagram.png").write_bytes(minimal_png())
+    (dataset / "metadata.yaml").write_text(
+        """
+model:
+  uri: https://w3id.org/ontouml-models/model/nested-yaml/
+  title:
+    en: Nested YAML Model
+metadata:
+  issued: 2024-01-31
+rights:
+  license:
+    id: CC-BY-4.0
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    module.process_dataset(
+        dataset, module.Config(metadata_timestamp="2024-01-02T03:04:05Z")
+    )
+
+    generated = (dataset / "metadata-png-o-diagram.ttl").read_text(encoding="utf-8")
+    assert "Nested YAML Model" in generated
+    assert 'dct:issued "2024-01-31"^^xsd:date' in generated
+    assert "https://creativecommons.org/licenses/by/4.0/" in generated
+
+
+def test_cli_all_dry_run_processes_metadata_yaml_datasets(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+):
+    module = load_module()
+    models = tmp_path / "models"
+    first = models / "first-model"
+    second = models / "second-model"
+    for dataset, slug, title in (
+        (first, "first-model", "First Model"),
+        (second, "second-model", "Second Model"),
+    ):
+        (dataset / "original-diagrams").mkdir(parents=True)
+        (dataset / "original-diagrams" / "diagram.png").write_bytes(minimal_png())
+        write_metadata_yaml(dataset, slug=slug, title=title, issued="2024")
+
+    exit_code = module.main(["--all", "--models-dir", str(models), "--dry-run"])
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "would generate:" in captured.out
+    assert "first-model" in captured.out
+    assert "second-model" in captured.out
+    assert not (first / "metadata-png-o-diagram.ttl").exists()
+    assert not (second / "metadata-png-o-diagram.ttl").exists()
+
+
+def test_png_metadata_generation_url_quotes_spaces_and_apostrophes_but_not_commas(
+    tmp_path: Path,
+):
+    module = load_module()
+    dataset = tmp_path / "models" / "special-name-model"
+    (dataset / "original-diagrams").mkdir(parents=True)
+    filename = "AUX - Object at Risk's Vulnerability, Manifestation.png"
+    (dataset / "original-diagrams" / filename).write_bytes(minimal_png())
+    write_metadata_yaml(
+        dataset, slug="special-name-model", title="Special Name Model", issued="2024"
+    )
+
+    module.process_dataset(
+        dataset, module.Config(metadata_timestamp="2024-01-02T03:04:05Z")
+    )
+
+    generated = (
+        dataset
+        / "metadata-png-o-AUX - Object at Risk's Vulnerability, Manifestation.ttl"
+    ).read_text(encoding="utf-8")
+    assert (
+        "AUX%20-%20Object%20at%20Risk%27s%20Vulnerability,%20Manifestation.png"
+        in generated
+    )
+    assert "%2C" not in generated
+
+
+def test_existing_png_license_is_preserved_when_model_license_is_missing(
+    tmp_path: Path,
+):
+    module = load_module()
+    dataset = tmp_path / "models" / "existing-license-model"
+    (dataset / "original-diagrams").mkdir(parents=True)
+    (dataset / "original-diagrams" / "diagram.png").write_bytes(minimal_png())
+    write_metadata_yaml(
+        dataset,
+        slug="existing-license-model",
+        title="Existing License Model",
+        issued="2024",
+        license_value=None,
+    )
+    (dataset / "metadata-png-o-diagram.ttl").write_text(
+        """
+@prefix dcat: <http://www.w3.org/ns/dcat#>.
+@prefix dct: <http://purl.org/dc/terms/>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+
+<https://w3id.org/ontouml-models/distribution/existing-license> a dcat:Distribution;
+    dct:license <https://example.org/custom-license>;
+    fdpo:metadataIssued "2023-04-14T17:33:24.802284319Z"^^xsd:dateTime;
+    fdpo:metadataModified "2023-04-14T17:33:25.802284319Z"^^xsd:dateTime .
+""".strip(),
+        encoding="utf-8",
+    )
+
+    module.process_dataset(dataset, module.Config())
+
+    generated = (dataset / "metadata-png-o-diagram.ttl").read_text(encoding="utf-8")
+    assert "https://example.org/custom-license" in generated
+
+
+def test_existing_full_iri_timestamps_are_preserved(tmp_path: Path):
+    module = load_module()
+    dataset = tmp_path / "models" / "full-iri-timestamp-model"
+    (dataset / "original-diagrams").mkdir(parents=True)
+    (dataset / "original-diagrams" / "diagram.png").write_bytes(minimal_png())
+    write_metadata_yaml(
+        dataset, slug="full-iri-timestamp-model", title="Timestamp Model", issued="2024"
+    )
+    (dataset / "metadata-png-o-diagram.ttl").write_text(
+        """
+@prefix dcat: <http://www.w3.org/ns/dcat#>.
+
+<https://w3id.org/ontouml-models/distribution/full-iri-time> a dcat:Distribution;
+    <https://w3id.org/fdp/fdp-o#metadataIssued> "2023-04-14T17:33:24.802284319Z"^^<http://www.w3.org/2001/XMLSchema#dateTime>;
+    <https://w3id.org/fdp/fdp-o#metadataModified> "2023-04-14T17:33:25.802284319Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> .
+""".strip(),
+        encoding="utf-8",
+    )
+
+    module.process_dataset(dataset, module.Config())
+
+    generated = (dataset / "metadata-png-o-diagram.ttl").read_text(encoding="utf-8")
+    assert "2023-04-14T17:33:24.802284319Z" in generated
+    assert "2023-04-14T17:33:25.802284319Z" in generated
+
+
+def test_include_file_metadata_emits_dimensions_byte_size_and_checksum(tmp_path: Path):
+    module = load_module()
+    dataset = tmp_path / "models" / "file-metadata-model"
+    (dataset / "original-diagrams").mkdir(parents=True)
+    (dataset / "original-diagrams" / "diagram.png").write_bytes(minimal_png())
+    write_metadata_yaml(
+        dataset, slug="file-metadata-model", title="File Metadata Model", issued="2024"
+    )
+
+    module.process_dataset(
+        dataset,
+        module.Config(
+            metadata_timestamp="2024-01-02T03:04:05Z", include_file_metadata=True
+        ),
+    )
+
+    generated = (dataset / "metadata-png-o-diagram.ttl").read_text(encoding="utf-8")
+    assert "dcat:byteSize" in generated
+    assert "schema:width 1" in generated
+    assert "schema:height 1" in generated
+    assert "spdx:checksumValue" in generated
+
+
+def test_invalid_png_fails_before_any_metadata_file_is_written(tmp_path: Path):
+    module = load_module()
+    dataset = tmp_path / "models" / "invalid-png-model"
+    (dataset / "original-diagrams").mkdir(parents=True)
+    (dataset / "original-diagrams" / "a-valid.png").write_bytes(minimal_png())
+    (dataset / "original-diagrams" / "z-invalid.png").write_bytes(b"not a png")
+    write_metadata_yaml(
+        dataset, slug="invalid-png-model", title="Invalid PNG Model", issued="2024"
+    )
+
+    with pytest.raises(module.MetadataGenerationError, match="invalid PNG"):
+        module.process_dataset(dataset, module.Config())
+
+    assert not (dataset / "metadata-png-o-a-valid.ttl").exists()
+    assert not (dataset / "metadata-png-o-z-invalid.ttl").exists()


### PR DESCRIPTION
## Summary

This PR adds a standalone PNG distribution metadata generator for the OntoUML/UFO Catalog.

The generator creates RDF/Turtle metadata files for PNG diagram distributions stored under model dataset folders:

| Source PNG folder | Generated metadata file |
| --- | --- |
| `original-diagrams/<diagram>.png` | `metadata-png-o-<diagram>.ttl` |
| `new-diagrams/<diagram>.png` | `metadata-png-n-<diagram>.ttl` |

The script reads model-level metadata from the canonical `metadata.yaml` file and does **not** read or update `metadata.ttl`.

## Added files

This PR intentionally adds only the files required for PNG metadata generation:

- `scripts/generate_png_metadata.py`
- `scripts/generate-png-metadata.md`
- `scripts/tests/test_generate_png_metadata.py`
- `scripts/requirements.txt`

No pre-commit configuration or GitHub Actions workflow is included in this PR.

## Motivation

The catalog contains PNG diagram files for many models. Their distribution metadata should be generated consistently instead of being maintained manually.

This script supports the intended generation pipeline:

```text
metadata.yaml + PNG files
  -> metadata-png-*.ttl

metadata.yaml + metadata-png-*.ttl + other distribution metadata
  -> metadata.ttl
```

In this pipeline:

- `metadata.yaml` remains the canonical model-level metadata source;
- `metadata-png-*.ttl` files are generated distribution-level metadata files;
- model-level `metadata.ttl` aggregation remains a separate step.

## Behavior

For each PNG file, the script generates a `dcat:Distribution` with the expected catalog metadata shape, including:

- `rdf:type dcat:Distribution`
- `dct:isPartOf`
- `dct:issued`
- `dct:license`, when available
- `dct:title`
- `skos:editorialNote`
- `dcat:mediaType`
- `dcat:downloadURL`
- `ocmv:isComplete false`
- `fdpo:metadataIssued`
- `fdpo:metadataModified`

The generated `dcat:downloadURL` values point to the raw GitHub URL of the corresponding PNG file.

## Existing metadata preservation

When regenerating an existing PNG metadata file, the script preserves curated or stable values that should not be changed accidentally:

- the existing distribution URI;
- `dct:title`;
- `skos:editorialNote`;
- `dcat:downloadURL`;
- `dct:license`;
- the exact lexical values of `fdpo:metadataIssued` and `fdpo:metadataModified`.

This is important because existing catalog distribution identifiers are already published W3IDs and should be treated as persistent opaque identifiers.

## Identifier policy

Existing PNG metadata files keep their current distribution URI.

For new PNG metadata files, the script generates deterministic UUIDv5 distribution identifiers under:

```text
https://w3id.org/ontouml-models/distribution/<uuid>/
```

The UUIDv5 input is based on:

```text
<model-uri>|<diagram-folder>/<png-filename>
```

This makes new metadata generation reproducible while preserving all existing distribution identifiers.

## License handling

The script derives model-level license metadata from `metadata.yaml` when available.

A model-level license is recommended, but missing license metadata is tolerated by default so the generator can process catalog entries that do not currently expose license metadata in `metadata.yaml`.

If stricter behavior is desired, the script supports:

```bash
python scripts/generate_png_metadata.py models/<model-directory> --require-license
```

## PNG validation and atomicity

Before writing metadata, the script validates PNG files using only the Python standard library.

The validation checks include:

- PNG signature;
- IHDR chunk;
- chunk boundaries;
- CRC values;
- IEND chunk.

The script builds and validates all generated graphs for a dataset before writing any file. This prevents partial generation when a later PNG file is invalid or when another dataset-level error is detected.

## Optional file-derived metadata

By default, the script only emits the required distribution metadata shape.

Optional file-derived metadata can be included with:

```bash
python scripts/generate_png_metadata.py models/<model-directory> --include-file-metadata
```

This adds:

- `dcat:byteSize`;
- `schema:width`;
- `schema:height`;
- `spdx:checksum` with SHA-256.

## Automation readiness

The script is designed to be usable in a future automation workflow, although this PR does not add that workflow.

It is automation-ready because it:

- runs non-interactively from the command line;
- supports targeted execution for one or more dataset folders;
- supports repository-wide execution with `--all --models-dir models`;
- supports `--dry-run` validation without writing files;
- validates PNG files before writing metadata;
- writes atomically at dataset level;
- does not depend on `metadata.ttl`;
- centralizes dependencies in `scripts/requirements.txt`.

A future workflow can call the generator for newly submitted datasets and commit or otherwise handle the generated `metadata-png-*.ttl` files.

## Usage examples

Install dependencies:

```bash
python -m pip install -r scripts/requirements.txt
```

Generate metadata for one dataset:

```bash
python scripts/generate_png_metadata.py models/<model-directory>
```

Generate metadata for all datasets:

```bash
python scripts/generate_png_metadata.py --all --models-dir models
```

Preview generation without writing files:

```bash
python scripts/generate_png_metadata.py --all --models-dir models --dry-run
```

Run from inside a dataset folder containing `metadata.yaml`:

```bash
python ../../scripts/generate_png_metadata.py
```

## Tests

This PR adds regression tests for:

- generation from `metadata.yaml`;
- absence of dependency on `metadata.ttl`;
- preservation of existing distribution URIs;
- preservation of curated PNG metadata values;
- missing model-level license handling;
- strict license mode with `--require-license`;
- deterministic handling of generated download URLs;
- URL quoting for spaces and apostrophes while preserving commas;
- preservation of exact FDP timestamp lexical values;
- optional file-derived metadata;
- PNG validation;
- dataset-level atomicity;
- `--all --dry-run` execution.

## Validation

The following commands were used during development:

```bash
python -m pip install -r scripts/requirements.txt
python -m py_compile scripts/generate_png_metadata.py scripts/tests/test_generate_png_metadata.py
python -m pytest -q scripts/tests/test_generate_png_metadata.py
python scripts/generate_png_metadata.py --all --models-dir models --dry-run
```

Expected test result:

```text
15 passed
```

The full-catalog dry run validates parsing, PNG validation, and generation planning without writing metadata files.

## Out of scope

This PR does not:

- generate or commit PNG metadata files for the full catalog;
- add a GitHub Actions workflow;
- add pre-commit configuration;
- modify model-level `metadata.ttl` generation;
- add `dcat:distribution` links to model-level metadata files.

Those steps can be addressed separately after this generator is reviewed.