### PR TITLE
Normalize metadata.yaml files with validator fixer

### DIFF
--- a/models/alkhalaf2024/metadata.yaml
+++ b/models/alkhalaf2024/metadata.yaml
@@ -1,7 +1,7 @@
 title: Ontology to Explain SARS-CoV-2 Variants' Effects
 acronym: OntoEffect
 issued: 2023
-modified: 
+modified:
 contributor:
  - https://dblp.org/pid/292/3745
  - https://dblp.org/pid/25/929-2
@@ -10,8 +10,8 @@ keyword:
  - genetic mutations
  - viral fitness
  - host-virus interaction
-theme: Class Q - Science 
-editorialNote: 
+theme: Class Q - Science
+editorialNote:
 ontologyType:
  - domain
 language: en
@@ -26,5 +26,4 @@ source:
 representationStyle:
  - ontouml
 landingPage:
-license: 
- - https://creativecommons.org/licenses/by/4.0/
+license: https://creativecommons.org/licenses/by/4.0/

--- a/models/bank-account2013/metadata.yaml
+++ b/models/bank-account2013/metadata.yaml
@@ -20,5 +20,4 @@ source:
 representationStyle:
  - ontouml
 landingPage:
-license:
- - https://creativecommons.org/licenses/by/4.0/
+license: https://creativecommons.org/licenses/by/4.0/

--- a/models/barcelos2024resiliont/metadata.yaml
+++ b/models/barcelos2024resiliont/metadata.yaml
@@ -30,5 +30,4 @@ representationStyle:
  - ontouml
 landingPage:
  - https://w3id.org/resiliont/git
-license:
- - https://www.apache.org/licenses/LICENSE-2.0
+license: https://www.apache.org/licenses/LICENSE-2.0

--- a/models/bernasconi2023fair-principles/metadata.yaml
+++ b/models/bernasconi2023fair-principles/metadata.yaml
@@ -32,5 +32,4 @@ source:
 representationStyle:
  - ontouml
 landingPage:
-license:
- - https://creativecommons.org/licenses/by/4.0/
+license: https://creativecommons.org/licenses/by/4.0/

--- a/models/blums2024ccf/metadata.yaml
+++ b/models/blums2024ccf/metadata.yaml
@@ -9,7 +9,7 @@ keyword:
  - accounting
  - financial reporting
 theme: Class H - Social Sciences
-editorialNote: 
+editorialNote:
 ontologyType:
  - core
 language: en
@@ -25,5 +25,4 @@ source:
 representationStyle:
  - ontouml
 landingPage:
-license: 
- - https://creativecommons.org/licenses/by/4.0/
+license: https://creativecommons.org/licenses/by/4.0/

--- a/models/calhau2024capabilities/metadata.yaml
+++ b/models/calhau2024capabilities/metadata.yaml
@@ -1,5 +1,5 @@
 title: Capabilities Ontology
-acronym: 
+acronym:
 issued: 2024
 modified:
 contributor:
@@ -29,5 +29,4 @@ source:
 representationStyle:
  - ontouml
 landingPage:
-license:
- - https://creativecommons.org/licenses/by/4.0/
+license: https://creativecommons.org/licenses/by/4.0/

--- a/models/core-o2023/metadata.yaml
+++ b/models/core-o2023/metadata.yaml
@@ -12,6 +12,7 @@ keyword:
  - skill
  - human resource
 theme: Class H - Social Sciences
+editorialNote:
 ontologyType:
  - core
 language: en
@@ -30,5 +31,4 @@ landingPage:
  - https://core-o.github.io/ontology/
  - https://github.com/core-o
  - https://purl.org/coreo
-license:
- - https://creativecommons.org/licenses/by/4.0/
+license: https://creativecommons.org/licenses/by/4.0/

--- a/models/dcat-mlt-ufo2023/metadata.yaml
+++ b/models/dcat-mlt-ufo2023/metadata.yaml
@@ -11,7 +11,7 @@ keyword:
  - repository
  - catalogued resource
 theme: Class Z - Bibliography, Library Science, and General Information Resources
-editorialNote: The model was designed using the Visual Paradigm tool, version 16.3, with the OntoUML plugin. The original file contained classes and relationships duplicated in different packages; they were merged and removed whenever possible. 
+editorialNote: The model was designed using the Visual Paradigm tool, version 16.3, with the OntoUML plugin. The original file contained classes and relationships duplicated in different packages; they were merged and removed whenever possible.
 ontologyType:
  - core
 language: en
@@ -26,5 +26,4 @@ source:
 representationStyle:
  - ontouml
 landingPage:
-license:
- - https://creativecommons.org/licenses/by/4.0/
+license: https://creativecommons.org/licenses/by/4.0/

--- a/models/demori2023miscon/metadata.yaml
+++ b/models/demori2023miscon/metadata.yaml
@@ -31,5 +31,4 @@ source:
 representationStyle:
  - ontouml
 landingPage:
-license:
- - https://creativecommons.org/licenses/by/4.0/
+license: https://creativecommons.org/licenses/by/4.0/

--- a/models/elghosh2024eucaim/metadata.yaml
+++ b/models/elghosh2024eucaim/metadata.yaml
@@ -1,7 +1,7 @@
 title: EUCAIM's Hyper-Ontology (Core Layer)
-acronym: 
+acronym:
 issued: 2024
-modified: 
+modified:
 contributor:
  - https://dblp.org/pid/199/9510.html
  - https://dblp.org/pid/118/0942.html
@@ -34,5 +34,4 @@ representationStyle:
  - ontouml
 landingPage:
  - https://doi.org/10.5281/zenodo.11109765
-license: 
- - https://creativecommons.org/licenses/by/4.0/
+license: https://creativecommons.org/licenses/by/4.0/

--- a/models/elghosh2025crimonto/metadata.yaml
+++ b/models/elghosh2025crimonto/metadata.yaml
@@ -28,5 +28,4 @@ source:
 representationStyle:
  - ontouml
 landingPage:
-license:
- - https://creativecommons.org/licenses/by/4.0/
+license: https://creativecommons.org/licenses/by/4.0/

--- a/models/ferreira2024ontopix/metadata.yaml
+++ b/models/ferreira2024ontopix/metadata.yaml
@@ -30,5 +30,4 @@ source:
 representationStyle:
  - ontouml
 landingPage:
-license:
- - https://creativecommons.org/licenses/by/4.0/
+license: https://creativecommons.org/licenses/by/4.0/

--- a/models/formula-one2023/metadata.yaml
+++ b/models/formula-one2023/metadata.yaml
@@ -20,5 +20,4 @@ source:
 representationStyle:
  - ontouml
 landingPage:
-license:
- - https://creativecommons.org/licenses/by/4.0/
+license: https://creativecommons.org/licenses/by/4.0/

--- a/models/freshbz2023/metadata.yaml
+++ b/models/freshbz2023/metadata.yaml
@@ -15,6 +15,7 @@ designedForTask:
  - software engineering
 context:
  - classroom
+source:
 representationStyle:
  - ontouml
 landingPage:

--- a/models/genealogy2013/metadata.yaml
+++ b/models/genealogy2013/metadata.yaml
@@ -20,5 +20,4 @@ source:
 representationStyle:
  - ontouml
 landingPage:
-license:
- - https://creativecommons.org/licenses/by/4.0/
+license: https://creativecommons.org/licenses/by/4.0/

--- a/models/heirbrant2023boekbazaar/metadata.yaml
+++ b/models/heirbrant2023boekbazaar/metadata.yaml
@@ -29,5 +29,4 @@ representationStyle:
  - ontouml
 landingPage:
  - https://boekbazaar.be/home
-license:
- - https://creativecommons.org/licenses/by/4.0/
+license: https://creativecommons.org/licenses/by/4.0/

--- a/models/machacova2023gym/metadata.yaml
+++ b/models/machacova2023gym/metadata.yaml
@@ -23,5 +23,4 @@ source:
 representationStyle:
  - ontouml
 landingPage:
-license:
- - https://creativecommons.org/licenses/by/4.0/
+license: https://creativecommons.org/licenses/by/4.0/

--- a/models/meirelles2024credit-operations/metadata.yaml
+++ b/models/meirelles2024credit-operations/metadata.yaml
@@ -1,5 +1,5 @@
 title: Ontologia de Referência para o Domínio de Operações de Crédito
-acronym: 
+acronym:
 issued: 2024
 modified:
 contributor:
@@ -8,7 +8,7 @@ keyword:
  - credit operations
  - finance
 theme: Class H - Social Sciences
-editorialNote: 
+editorialNote:
 ontologyType:
  - domain
 language: pt-br
@@ -23,5 +23,4 @@ source:
 representationStyle:
  - ontouml
 landingPage:
-license: 
- - https://creativecommons.org/licenses/by/4.0/
+license: https://creativecommons.org/licenses/by/4.0/

--- a/models/melo2024onto-educational/metadata.yaml
+++ b/models/melo2024onto-educational/metadata.yaml
@@ -10,7 +10,7 @@ keyword:
  - socioeconomic aid
  - education
 theme: Class H - Social Sciences
-editorialNote: 
+editorialNote:
 ontologyType:
  - domain
 language: pt-br
@@ -25,5 +25,4 @@ source:
 representationStyle:
  - ontouml
 landingPage:
-license: 
- - https://creativecommons.org/licenses/by/4.0/
+license: https://creativecommons.org/licenses/by/4.0/

--- a/models/nascimento2023spacecon/metadata.yaml
+++ b/models/nascimento2023spacecon/metadata.yaml
@@ -10,7 +10,7 @@ keyword:
  - context-aware computing
  - quality of context
 theme: Class T - Technology
-editorialNote: 
+editorialNote:
 ontologyType:
  - core
 language: en
@@ -25,5 +25,4 @@ representationStyle:
  - ontouml
 landingPage:
  - https://github.com/lvnascimento/spacecon
-license: 
- - https://opensource.org/license/mit
+license: https://opensource.org/license/mit

--- a/models/nazar2024marchine-learning/metadata.yaml
+++ b/models/nazar2024marchine-learning/metadata.yaml
@@ -1,5 +1,5 @@
 title: Machine Learning Ontology
-acronym: 
+acronym:
 issued: 2024
 modified:
 contributor:
@@ -20,5 +20,4 @@ source:
 representationStyle:
  - ontouml
 landingPage:
-license: 
- - https://creativecommons.org/licenses/by/4.0/
+license: https://creativecommons.org/licenses/by/4.0/

--- a/models/o3ontology2015/metadata.yaml
+++ b/models/o3ontology2015/metadata.yaml
@@ -15,12 +15,11 @@ language: en
 designedForTask:
  - conceptual clarification
  - software engineering
-context: 
+context:
  - research
 source:
 representationStyle:
  - ufo
  - ontouml
 landingPage:
-license:
- - https://creativecommons.org/licenses/by/4.0/
+license: https://creativecommons.org/licenses/by/4.0/

--- a/models/oliveira2024phishing/metadata.yaml
+++ b/models/oliveira2024phishing/metadata.yaml
@@ -37,5 +37,4 @@ representationStyle:
  - ontouml
 landingPage:
  - http://w3id.org/phishing-process-ontology/git
-license:
- - https://www.apache.org/licenses/LICENSE-2.0
+license: https://www.apache.org/licenses/LICENSE-2.0

--- a/models/parking-business2013/metadata.yaml
+++ b/models/parking-business2013/metadata.yaml
@@ -21,5 +21,4 @@ source:
 representationStyle:
  - ontouml
 landingPage:
-license:
- - https://creativecommons.org/licenses/by/4.0/
+license: https://creativecommons.org/licenses/by/4.0/

--- a/models/peixoto2025anchorlogy/metadata.yaml
+++ b/models/peixoto2025anchorlogy/metadata.yaml
@@ -3,30 +3,29 @@ acronym: Anchorlogy
 issued: 2025
 modified:
 contributor:
-  - https://dblp.org/pid/0009-0005-4081-6615  # Mateus Peixoto
-  - https://dblp.org/pid/0000-0001-7932-7134  # Fernanda Araujo Baião
-  - https://dblp.org/pid/0000-0002-5804-5741  # Renata Guizzardi
-  - https://dblp.org/pid/0000-0002-3452-553X  # Giancarlo Guizzardi
+ - https://dblp.org/pid/0009-0005-4081-6615
+ - https://dblp.org/pid/0000-0001-7932-7134
+ - https://dblp.org/pid/0000-0002-5804-5741
+ - https://dblp.org/pid/0000-0002-3452-553X
 keyword:
-  - anchoring bias
-  - belief formation
-  - decision-making process
-  - human judgment
+ - anchoring bias
+ - belief formation
+ - decision-making process
+ - human judgment
 theme: Class H - Social Sciences
 editorialNote:
-  - This ontology aims to represent the context-dependent nature of anchoring bias in human and artificial forecasting decisions.
+ - This ontology aims to represent the context-dependent nature of anchoring bias in human and artificial forecasting decisions.
 ontologyType:
-  - domain
+ - domain
 language: en
 designedForTask:
-  - conceptual clarification
-  - ontological analysis
+ - conceptual clarification
+ - ontological analysis
 context:
-  - research
+ - research
 source:
-  - https://www.researchgate.net/profile/Giancarlo-Guizzardi-2/publication/390767962_Anchorlogy_An_ontology_for_anchoring_bias_detection_in_forecasting/links/67fd51bd60241d51400c4b0c/Anchorlogy-An-ontology-for-anchoring-bias-detection-in-forecasting.pdf
+ - https://www.researchgate.net/profile/Giancarlo-Guizzardi-2/publication/390767962_Anchorlogy_An_ontology_for_anchoring_bias_detection_in_forecasting/links/67fd51bd60241d51400c4b0c/Anchorlogy-An-ontology-for-anchoring-bias-detection-in-forecasting.pdf
 representationStyle:
-  - ontouml
+ - ontouml
 landingPage:
-license:
-  - https://creativecommons.org/licenses/by/4.0/
+license: https://creativecommons.org/licenses/by/4.0/

--- a/models/piest2024dsr-kb/metadata.yaml
+++ b/models/piest2024dsr-kb/metadata.yaml
@@ -1,7 +1,7 @@
-title: Domain Reference Ontology for Design Science Research Knowledge Bases 
+title: Domain Reference Ontology for Design Science Research Knowledge Bases
 acronym: DSR-KB
 issued: 2024
-modified: 
+modified:
 contributor:
  - https://dblp.org/pid/187/6481
  - https://dblp.org/pid/377/0420
@@ -26,5 +26,4 @@ representationStyle:
  - ontouml
 landingPage:
  - https://github.com/SebastianPiest/dsr-kb
-license: 
- - https://opensource.org/licenses/MIT
+license: https://opensource.org/licenses/MIT

--- a/models/pinheiro2024api/metadata.yaml
+++ b/models/pinheiro2024api/metadata.yaml
@@ -1,7 +1,7 @@
 title: Reference Ontology for Enterprise Architecture Mining from APIs
-acronym: 
+acronym:
 issued: 2024
-modified: 
+modified:
 contributor:
  - https://dblp.org/pid/306/9640
  - https://dblp.org/pid/38/10199
@@ -26,5 +26,4 @@ source:
 representationStyle:
  - ontouml
 landingPage:
-license:
- - https://creativecommons.org/licenses/by/4.0/
+license: https://creativecommons.org/licenses/by/4.0/

--- a/models/project-assets2013/metadata.yaml
+++ b/models/project-assets2013/metadata.yaml
@@ -20,5 +20,4 @@ source:
 representationStyle:
  - ontouml
 landingPage:
-license:
- - https://creativecommons.org/licenses/by/4.0/
+license: https://creativecommons.org/licenses/by/4.0/

--- a/models/public-organization2013/metadata.yaml
+++ b/models/public-organization2013/metadata.yaml
@@ -20,5 +20,4 @@ source:
 representationStyle:
  - ontouml
 landingPage:
-license:
- - https://creativecommons.org/licenses/by/4.0/
+license: https://creativecommons.org/licenses/by/4.0/

--- a/models/road-accident2013/metadata.yaml
+++ b/models/road-accident2013/metadata.yaml
@@ -21,5 +21,4 @@ source:
 representationStyle:
  - ontouml
 landingPage:
-license:
- - https://creativecommons.org/licenses/by/4.0/
+license: https://creativecommons.org/licenses/by/4.0/

--- a/models/rocha2023ciencia-aberta/metadata.yaml
+++ b/models/rocha2023ciencia-aberta/metadata.yaml
@@ -23,5 +23,4 @@ source:
 representationStyle:
  - ontouml
 landingPage:
-license:
- - https://creativecommons.org/licenses/by/4.0/
+license: https://creativecommons.org/licenses/by/4.0/

--- a/models/sariev2024maritime/metadata.yaml
+++ b/models/sariev2024maritime/metadata.yaml
@@ -1,7 +1,7 @@
 title: Ontology for Digital Twin Development in Maritime Logistics
-acronym: 
+acronym:
 issued: 2024
-modified: 
+modified:
 contributor:
  - https://www.linkedin.com/in/bekbolot-sariev-7bb6b0265/
 keyword:
@@ -9,8 +9,8 @@ keyword:
  - digital twin
  - port management
  - vessel traffic management
-theme: Class H – Social Sciences
-editorialNote: 
+theme: Class H - Social Sciences
+editorialNote:
 ontologyType:
  - domain
 language: en
@@ -25,5 +25,4 @@ source:
 representationStyle:
  - ontouml
 landingPage:
-license:
- - https://creativecommons.org/licenses/by/4.0/
+license: https://creativecommons.org/licenses/by/4.0/

--- a/models/schoonderbeek2024eamon/metadata.yaml
+++ b/models/schoonderbeek2024eamon/metadata.yaml
@@ -1,7 +1,7 @@
 title: Enterprise Architecture Modeling Ontology
 acronym: EAMOn
 issued: 2024
-modified: 
+modified:
 contributor:
  - https://dblp.org/pid/381/4970
  - https://dblp.org/pid/p/ErikProper
@@ -10,7 +10,7 @@ keyword:
  - model quality
  - architecture concept
 theme: Class T - Technology
-editorialNote: 
+editorialNote:
 ontologyType:
  - domain
 language: en
@@ -24,5 +24,4 @@ source:
 representationStyle:
  - ontouml
 landingPage:
-license: 
- - https://creativecommons.org/licenses/by/4.0/
+license: https://creativecommons.org/licenses/by/4.0/

--- a/models/scientific-experiment2013/metadata.yaml
+++ b/models/scientific-experiment2013/metadata.yaml
@@ -21,5 +21,4 @@ source:
 representationStyle:
  - ontouml
 landingPage:
-license:
- - https://creativecommons.org/licenses/by/4.0/
+license: https://creativecommons.org/licenses/by/4.0/

--- a/models/scientific-publication2013/metadata.yaml
+++ b/models/scientific-publication2013/metadata.yaml
@@ -21,5 +21,4 @@ source:
 representationStyle:
  - ontouml
 landingPage:
-license:
- - https://creativecommons.org/licenses/by/4.0/
+license: https://creativecommons.org/licenses/by/4.0/

--- a/models/services2015/metadata.yaml
+++ b/models/services2015/metadata.yaml
@@ -22,5 +22,4 @@ representationStyle:
  - ufo
  - ontouml
 landingPage:
-license:
- - https://creativecommons.org/licenses/by/4.0/
+license: https://creativecommons.org/licenses/by/4.0/

--- a/models/short-examples2013/metadata.yaml
+++ b/models/short-examples2013/metadata.yaml
@@ -19,5 +19,4 @@ source:
 representationStyle:
  - ontouml
 landingPage:
-license:
- - https://creativecommons.org/licenses/by/4.0/
+license: https://creativecommons.org/licenses/by/4.0/

--- a/models/silva2012itarchitecture/metadata.yaml
+++ b/models/silva2012itarchitecture/metadata.yaml
@@ -14,7 +14,9 @@ theme: Class T - Technology
 editorialNote:
 ontologyType:
  - domain
-language: en, pt-br
+language:
+ - en
+ - pt-br
 designedForTask:
  - interoperability
  - ontological analysis

--- a/models/silva2021sebim/metadata.yaml
+++ b/models/silva2021sebim/metadata.yaml
@@ -29,5 +29,4 @@ representationStyle:
  - ontouml
 landingPage:
  - https://github.com/cgtsbr/sebim
-license:
- - https://creativecommons.org/licenses/by/4.0/
+license: https://creativecommons.org/licenses/by/4.0/

--- a/models/silva2023onto4caal/metadata.yaml
+++ b/models/silva2023onto4caal/metadata.yaml
@@ -30,5 +30,4 @@ representationStyle:
 landingPage:
  - https://github.com/timoteogomes/Nota-o-UML-da-Onto4CAAL
  - https://github.com/timoteogomes/Notacao-UML-da-Onto4Elev
-license:
- - https://creativecommons.org/licenses/by-nc-nd/3.0/br/
+license: https://creativecommons.org/licenses/by-nc-nd/3.0/br/

--- a/models/silva2023onto4elev/metadata.yaml
+++ b/models/silva2023onto4elev/metadata.yaml
@@ -31,5 +31,4 @@ representationStyle:
 landingPage:
  - https://github.com/timoteogomes/Nota-o-UML-da-Onto4CAAL
  - https://github.com/timoteogomes/Notacao-UML-da-Onto4Elev
-license:
- - https://creativecommons.org/licenses/by-nc-nd/3.0/br/
+license: https://creativecommons.org/licenses/by-nc-nd/3.0/br/

--- a/models/silveira2021oap/metadata.yaml
+++ b/models/silveira2021oap/metadata.yaml
@@ -14,7 +14,9 @@ theme: Class L - Education
 editorialNote: The ontology was documented based on the authors' paper. Diagram 2 was included on authors' request specified in issue 177 of the GitHub repository.
 ontologyType:
  - domain
-language: pt-br, en
+language:
+ - pt-br
+ - en
 designedForTask:
  - conceptual clarification
 context:

--- a/models/soares2024fair/metadata.yaml
+++ b/models/soares2024fair/metadata.yaml
@@ -27,7 +27,7 @@ keyword:
  - fair principles
  - data schema
 theme: Class T - Technology
-editorialNote: 
+editorialNote:
 ontologyType:
  - domain
 language: en
@@ -41,5 +41,4 @@ source:
 representationStyle:
  - ontouml
 landingPage:
-license:
- - https://creativecommons.org/licenses/by/4.0/
+license: https://creativecommons.org/licenses/by/4.0/

--- a/models/social-contracts2013/metadata.yaml
+++ b/models/social-contracts2013/metadata.yaml
@@ -22,5 +22,4 @@ source:
 representationStyle:
  - ontouml
 landingPage:
-license:
- - https://creativecommons.org/licenses/by/4.0/
+license: https://creativecommons.org/licenses/by/4.0/

--- a/models/telecom-equipment2013/metadata.yaml
+++ b/models/telecom-equipment2013/metadata.yaml
@@ -20,5 +20,4 @@ source:
 representationStyle:
  - ontouml
 landingPage:
-license:
- - https://creativecommons.org/licenses/by/4.0/
+license: https://creativecommons.org/licenses/by/4.0/

--- a/models/tender2013/metadata.yaml
+++ b/models/tender2013/metadata.yaml
@@ -21,5 +21,4 @@ source:
 representationStyle:
  - ontouml
 landingPage:
-license:
- - https://creativecommons.org/licenses/by/4.0/
+license: https://creativecommons.org/licenses/by/4.0/

--- a/models/tesolin2023hint/metadata.yaml
+++ b/models/tesolin2023hint/metadata.yaml
@@ -28,5 +28,4 @@ source:
 representationStyle:
  - ontouml
 landingPage:
-license:
- - https://creativecommons.org/licenses/by/4.0/
+license: https://creativecommons.org/licenses/by/4.0/

--- a/models/van-ee2021modular/metadata.yaml
+++ b/models/van-ee2021modular/metadata.yaml
@@ -24,7 +24,9 @@ editorialNote: |
  Classes whose label joined multiple RDF elements were interpreted as "owl:sameAs" declarations. As such, each of the classes were reproduced into their namespaces/packages and the "owl:sameAs" declaration was translated as generalizations of each of them into a new class. No stereotype has been given to the introduced classes to avoid too many changes on the author's original intended model.
 ontologyType:
  - application
-language: en, nl
+language:
+ - en
+ - nl
 designedForTask:
  - interoperability
  - software engineering

--- a/models/xhani2023xmlpo/metadata.yaml
+++ b/models/xhani2023xmlpo/metadata.yaml
@@ -26,5 +26,4 @@ source:
 representationStyle:
  - ontouml
 landingPage:
-license: 
- - https://creativecommons.org/licenses/by/4.0/
+license: https://creativecommons.org/licenses/by/4.0/


### PR DESCRIPTION
## Summary

This PR normalizes existing model-level `metadata.yaml` files using the metadata YAML validator/fixer script.

The changes were produced by running:

```bash
python scripts/validate_metadata_yaml.py --fix --all --allow-missing-license
```

## Motivation

After introducing the metadata YAML validator/fixer, I used it to apply deterministic normalization fixes to the existing catalog metadata files.

The goal is to make the current `metadata.yaml` files more consistent with the repository metadata conventions and prepare them for future automation steps.

## Scope

This PR is intentionally limited to modified files matching:

```text
models/*/metadata.yaml
```

It does not modify:

- model source files;
- diagram files;
- generated RDF/Turtle metadata files;
- scripts;
- tests;
- documentation.

## Types of changes applied

The fixer applied deterministic metadata cleanups, including:

- converting single-item `license` lists into scalar URI values;
- trimming trailing whitespace in scalar fields;
- preserving empty YAML fields consistently;
- adding missing empty expected fields where appropriate;
- normalizing malformed `theme` text;
- converting comma-separated multi-language values into YAML lists.

Examples:

```yaml
license:
 - https://creativecommons.org/licenses/by/4.0/
```

was normalized to:

```yaml
license: https://creativecommons.org/licenses/by/4.0/
```

and:

```yaml
language: en, pt-br
```

was normalized to:

```yaml
language:
 - en
 - pt-br
```

## License handling

The command was run with:

```bash
--allow-missing-license
```

This means that legacy datasets without explicit license values were not assigned guessed license metadata. Missing licenses were treated as warnings rather than being automatically filled.

## Safety

The applied changes are deterministic and produced by the validator/fixer script. The script does not infer missing mandatory metadata values and does not invent licenses for datasets where the license is absent.

## Notes

This PR follows up on the metadata YAML validator work by applying the fixer to existing catalog metadata files only.