### PR TITLE
Restrict metadata.yaml validator to official YAML fields

### DIFF
--- a/scripts/tests/test_validate_metadata_yaml.py
+++ b/scripts/tests/test_validate_metadata_yaml.py
@@ -273,16 +273,13 @@ def test_json_output_contains_structured_issues(
     assert payload[0]["errors"][0]["code"] in {"invalid_theme", "missing_field"}
 
 
-def test_iri_slug_and_full_ocmv_uri_are_accepted(
+def test_full_ocmv_uri_controlled_value_is_accepted(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    dataset = tmp_path / "models" / "aliases"
+    dataset = tmp_path / "models" / "controlled-uri"
     write_metadata(
         dataset,
         VALID_METADATA.replace(
-            "title: Reference Ontology of Trust",
-            "iri: local-slug\ntitle: Reference Ontology of Trust",
-        ).replace(
             "  - domain", "  - https://w3id.org/ontouml-models/vocabulary#Domain"
         ),
     )
@@ -292,6 +289,27 @@ def test_iri_slug_and_full_ocmv_uri_are_accepted(
     captured = capsys.readouterr()
     assert exit_code == 0
     assert "INVALID" not in captured.out
+
+
+def test_converter_only_fields_are_unexpected(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    dataset = tmp_path / "models" / "converter-only"
+    write_metadata(
+        dataset,
+        VALID_METADATA.replace(
+            "title: Reference Ontology of Trust",
+            "iri: local-slug\neditorial_note: Alias note\ntitle: Reference Ontology of Trust",
+        ),
+    )
+
+    exit_code = validator.main([str(dataset)])
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "unexpected_field" in captured.out
+    assert "iri" in captured.out
+    assert "editorial_note" in captured.out
 
 
 def test_boolean_literal_is_invalid(
@@ -629,3 +647,54 @@ def test_missing_license_remains_error_without_relaxing_argument(
     captured = capsys.readouterr()
     assert exit_code == 1
     assert "ERROR   license [missing_value]" in captured.out
+
+
+def test_contact_points_is_not_supported_metadata_yaml_field(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    dataset = tmp_path / "models" / "contact-points"
+    write_metadata(
+        dataset,
+        VALID_METADATA
+        + "contactPoints:\n"
+        + " - name: Pedro Paulo Favato Barcelos\n"
+        + "   email: pedro@example.org\n",
+    )
+
+    exit_code = validator.main([str(dataset)])
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "unexpected_field" in captured.out
+    assert "contactPoints" in captured.out
+
+
+def test_rdf_predicate_and_converter_alias_fields_are_rejected(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    dataset = tmp_path / "models" / "unsupported-fields"
+    unsupported_fields = """
+    dct:title: Wrong title field
+    dcat:keyword:
+     - wrong keyword field
+    landing_page: https://example.org/alias
+    storage_url: https://example.org/storage
+    distribution: https://example.org/distribution
+    dcat:contactPoint: https://example.org/contact
+    """
+    write_metadata(dataset, VALID_METADATA + textwrap.dedent(unsupported_fields))
+
+    exit_code = validator.main([str(dataset)])
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    for field in (
+        "dct:title",
+        "dcat:keyword",
+        "landing_page",
+        "storage_url",
+        "distribution",
+        "dcat:contactPoint",
+    ):
+        assert field in captured.out
+    assert captured.out.count("unexpected_field") >= 6

--- a/scripts/validate-metadata-yaml.md
+++ b/scripts/validate-metadata-yaml.md
@@ -44,19 +44,30 @@ Some older catalog datasets have no license value. This is semantically incomple
 
 ## Supported field spelling
 
-The repository currently contains metadata files using names such as:
+The validator only accepts the repository-facing `metadata.yaml` fields currently used by catalog datasets:
 
 ```yaml
+title:
+acronym:
+issued:
+modified:
+contributor:
+keyword:
+theme:
 editorialNote:
 ontologyType:
+language:
 designedForTask:
+context:
+source:
 representationStyle:
 landingPage:
+license:
 ```
 
-The converter also accepts snake_case aliases such as `editorial_note`, `ontology_type`, `designed_for_task`, `representation_style`, and `landing_page`. The validator accepts both forms. When `--fix` is used, it rewrites recognized aliases to the repository-preferred template spelling used above.
+RDF predicate names, converter-only aliases, and extension fields are intentionally treated as unexpected fields. For example, `dct:title`, `dcat:keyword`, `editorial_note`, `ontology_type`, `iri`, `storage_url`, `distribution`, and `contactPoints` are not accepted unless the official YAML format is explicitly extended later.
 
-The optional `iri` field may be either an absolute HTTP(S) IRI or a local slug accepted by the YAML-to-Turtle converter. A local slug must not contain a URI prefix.
+Although the RDF dataset shape includes `dcat:contactPoint`, contact-point metadata is not part of the supported `metadata.yaml` field set. This validator therefore treats `contact_points`, `contactPoints`, and `dcat:contactPoint` as unexpected YAML fields.
 
 `landingPage` may be empty, a single HTTP(S) URI, or a YAML list of HTTP(S) URIs. The underlying RDF property has no maximum-count constraint in the catalog SHACL shape, so multiple landing pages are allowed. `--fix` therefore does not unwrap `landingPage` lists.
 
@@ -85,7 +96,6 @@ Safe fixes include:
 - normalizing compact `theme` values such as `H`, `lcc:H`, or an LCC URI to the full catalog label, e.g. `Class H - Social Sciences`;
 - replacing known license shorthands such as `CC-BY-4.0` with their canonical URI;
 - trimming surrounding whitespace in scalar strings;
-- rewriting recognized aliases to repository-preferred field names.
 
 The fix mode rewrites YAML with PyYAML plus catalog-specific post-processing. It preserves the repository convention of one leading space before top-level list markers (` - value`) and empty values as `field:` rather than `field: null`. Comments and some hand-formatted spacing are not preserved. Run it only when this is acceptable.
 

--- a/scripts/validate_metadata_yaml.py
+++ b/scripts/validate_metadata_yaml.py
@@ -45,7 +45,6 @@ except (
 
 Severity = Literal["error", "warning"]
 UnknownPolicy = Literal["error", "warning", "ignore"]
-OutputFormat = Literal["text", "json"]
 
 
 class MetadataYamlError(RuntimeError):
@@ -172,60 +171,26 @@ MetadataYamlLoader.add_constructor(
 )
 
 
-# The current catalog examples still use these field names. The converter also
-# accepts snake_case aliases, but this script preserves the repository-facing
-# metadata.yaml template unless the source already uses a supported alias.
+# Supported metadata.yaml fields are restricted to the repository-facing
+# model-level metadata template currently used by catalog datasets. RDF predicate
+# names, converter-only aliases, and extension fields are treated as unexpected.
 FIELD_ALIASES: dict[str, tuple[str, ...]] = {
-    "iri": ("iri", "uri", "model_iri", "modelIri", "identifier", "id"),
-    "title": ("title", "dct:title"),
-    "alternative": (
-        "alternative",
-        "alternative_title",
-        "alternativeTitle",
-        "dct:alternative",
-    ),
-    "description": ("description", "dct:description"),
-    "issued": ("issued", "dct:issued"),
-    "modified": ("modified", "dct:modified"),
-    "license": ("license", "dct:license"),
-    "access_rights": ("access_rights", "accessRights", "dct:accessRights"),
-    "editorial_note": ("editorialNote", "editorial_note", "skos:editorialNote"),
-    "creator": ("creator", "creators", "dct:creator"),
-    "contributor": ("contributor", "contributors", "dct:contributor"),
-    "publisher": ("publisher", "dct:publisher"),
-    "metadata_issued": ("metadata_issued", "metadataIssued", "fdpo:metadataIssued"),
-    "metadata_modified": (
-        "metadata_modified",
-        "metadataModified",
-        "fdpo:metadataModified",
-    ),
-    "landing_page": ("landingPage", "landing_page", "dcat:landingPage"),
-    "bibliographic_citation": (
-        "bibliographic_citation",
-        "bibliographicCitation",
-        "dct:bibliographicCitation",
-    ),
-    "storage_url": ("storage_url", "storageUrl", "ocmv:storageUrl"),
-    "contact_points": ("contact_points", "contactPoints", "dcat:contactPoint"),
-    "keyword": ("keyword", "keywords", "dcat:keyword"),
-    "acronym": ("acronym", "mod:acronym"),
-    "source": ("source", "sources", "dct:source"),
-    "language": ("language", "languages", "dct:language"),
-    "theme": ("theme", "dcat:theme"),
-    "designed_for_task": (
-        "designedForTask",
-        "designed_for_task",
-        "mod:designedForTask",
-    ),
-    "context": ("context", "ocmv:context"),
-    "representation_style": (
-        "representationStyle",
-        "representation_style",
-        "ocmv:representationStyle",
-    ),
-    "ontology_type": ("ontologyType", "ontology_type", "ocmv:ontologyType"),
-    "is_part_of": ("is_part_of", "isPartOf", "dct:isPartOf"),
-    "distribution": ("distribution", "distributions", "dcat:distribution"),
+    "title": ("title",),
+    "acronym": ("acronym",),
+    "issued": ("issued",),
+    "modified": ("modified",),
+    "contributor": ("contributor",),
+    "keyword": ("keyword",),
+    "theme": ("theme",),
+    "editorial_note": ("editorialNote",),
+    "ontology_type": ("ontologyType",),
+    "language": ("language",),
+    "designed_for_task": ("designedForTask",),
+    "context": ("context",),
+    "source": ("source",),
+    "representation_style": ("representationStyle",),
+    "landing_page": ("landingPage",),
+    "license": ("license",),
 }
 
 PREFERRED_FIELD_NAME: dict[str, str] = {
@@ -253,8 +218,7 @@ EXPECTED_TEMPLATE_FIELDS: tuple[str, ...] = (
     "license",
 )
 
-# Minimum mandatory fields aligned with scripts/metadata_yaml_to_ttl.py and the
-# metadata YAML documentation.
+# Minimum mandatory fields aligned with the repository metadata.yaml documentation.
 REQUIRED_VALUE_FIELDS: tuple[str, ...] = (
     "title",
     "issued",
@@ -265,37 +229,28 @@ REQUIRED_VALUE_FIELDS: tuple[str, ...] = (
 
 LIST_FIELDS: set[str] = {
     "contributor",
-    "creator",
     "source",
     "keyword",
     "designed_for_task",
     "context",
     "representation_style",
     "ontology_type",
-    "distribution",
 }
 
 SINGLE_URI_FIELDS: set[str] = {
-    "iri",
     "license",
-    "publisher",
-    "storage_url",
-    "is_part_of",
 }
 
 LITERAL_FIELDS: set[str] = {
     "title",
-    "alternative",
-    "description",
     "editorial_note",
-    "bibliographic_citation",
     "keyword",
     "acronym",
 }
 
-DATE_FIELDS: set[str] = {"issued", "modified", "metadata_issued", "metadata_modified"}
+DATE_FIELDS: set[str] = {"issued", "modified"}
 
-URL_LIST_FIELDS: set[str] = {"contributor", "creator", "source", "landing_page"}
+URL_LIST_FIELDS: set[str] = {"contributor", "source", "landing_page"}
 
 DESIGNED_FOR_TASKS: dict[str, str] = {
     "conceptualclarification": "conceptual clarification",
@@ -951,7 +906,7 @@ class MetadataYamlValidator:
                 result,
                 "add_missing_optional_field",
                 preferred,
-                f"Added missing expected optional field {preferred!r} with null value.",
+                f"Added missing expected optional field {preferred!r} with an empty YAML value.",
             )
 
     def validate_field(
@@ -995,16 +950,6 @@ class MetadataYamlValidator:
             self.validate_theme_field(value, result)
         if canonical == "language":
             self.validate_language_field(value, result)
-        if canonical == "contact_points":
-            self.validate_contact_points(value, result)
-        if canonical == "publisher" and isinstance(value, list) and len(value) > 1:
-            self.add_issue(
-                result,
-                "error",
-                "too_many_values",
-                preferred,
-                "Publisher must have at most one URI.",
-            )
 
     def validate_literal_field(
         self, canonical: str, value: Any, result: ValidationResult
@@ -1128,20 +1073,6 @@ class MetadataYamlValidator:
                     f"Use the license URI {alias}.",
                 )
                 return
-        if canonical == "iri":
-            text = value.strip()
-            if is_http_uri(text):
-                return
-            if ":" in text or not re.fullmatch(r"[A-Za-z0-9._/-]+", text):
-                self.add_issue(
-                    result,
-                    "error",
-                    "invalid_uri_or_slug",
-                    preferred,
-                    "Expected an absolute HTTP(S) URI or a local slug without a URI prefix.",
-                    "Use a persistent HTTP(S) model IRI when available, or a simple dataset slug.",
-                )
-            return
         if not is_http_uri(value):
             self.add_issue(
                 result,
@@ -1328,31 +1259,6 @@ class MetadataYamlValidator:
                     "invalid_language",
                     field,
                     "Expected a BCP 47/IANA-like language tag such as 'en', 'pt-BR', or 'en-GB'. Multiple languages may be written as a comma-separated scalar, e.g. 'en, pt-br', or as a YAML list; --fix normalizes comma-separated multi-language scalars to lists when all tags are valid.",
-                )
-
-    def validate_contact_points(self, value: Any, result: ValidationResult) -> None:
-        preferred = PREFERRED_FIELD_NAME["contact_points"]
-        for index, item in enumerate(as_list(value)):
-            field = f"{preferred}[{index}]"
-            if not isinstance(item, Mapping):
-                self.add_issue(
-                    result,
-                    "error",
-                    "invalid_type",
-                    field,
-                    "Each contact point must be a mapping.",
-                )
-                continue
-            email = (
-                item.get("email") or item.get("hasEmail") or item.get("vcard:hasEmail")
-            )
-            if not isinstance(email, str) or not email.strip():
-                self.add_issue(
-                    result,
-                    "error",
-                    "missing_email",
-                    field,
-                    "Contact point is missing a non-empty email value.",
                 )
 
     def safe_fix_value(self, canonical: str, value: Any) -> tuple[Any, bool, str]:


### PR DESCRIPTION
## Summary

This PR updates the `metadata.yaml` validator/fixer so it only accepts the repository-facing fields currently defined for model-level YAML metadata files.

The supported top-level fields are now restricted to:

- `title`
- `acronym`
- `issued`
- `modified`
- `contributor`
- `keyword`
- `theme`
- `editorialNote`
- `ontologyType`
- `language`
- `designedForTask`
- `context`
- `source`
- `representationStyle`
- `landingPage`
- `license`

## Motivation

The previous validator version was still too permissive. It accepted converter-oriented aliases, RDF predicate-style field names, and extension fields that are not part of the official `metadata.yaml` authoring format.

Examples of fields that should not be accepted in `metadata.yaml` include:

- `iri`
- `dct:title`
- `dcat:keyword`
- `editorial_note`
- `ontology_type`
- `storage_url`
- `distribution`
- `contactPoints`
- `contact_points`
- `dcat:contactPoint`

These are now reported as unexpected fields.

## Changes

This PR:

- restricts accepted top-level YAML fields to the official metadata template fields;
- removes support for RDF predicate-style aliases and converter-only aliases;
- removes contact-point YAML support because contact points are not currently part of the supported `metadata.yaml` field set;
- updates documentation to describe the stricter supported field set;
- adds regression tests for unsupported fields.

## Verification

I verified the implementation with:

```bash
python -m py_compile scripts/validate_metadata_yaml.py scripts/tests/test_validate_metadata_yaml.py
python -m pytest -q scripts/tests/test_validate_metadata_yaml.py
```

## Scope

This PR only updates:

- `scripts/validate_metadata_yaml.py`
- `scripts/validate-metadata-yaml.md`
- `scripts/tests/test_validate_metadata_yaml.py`

It does not modify existing `models/*/metadata.yaml` files.