### PR TITLE
Update metadata.ttl converter timestamp handling

### DIFF
--- a/scripts/metadata_yaml_to_ttl.md
+++ b/scripts/metadata_yaml_to_ttl.md
@@ -82,7 +82,7 @@ Generate `metadata.ttl` for all datasets under `models/`:
 python scripts/metadata_yaml_to_ttl.py --all --models-dir models
 ```
 
-If some existing or new datasets do not have `fdpo:metadataIssued` in `metadata.ttl`, provide an explicit deterministic timestamp for the generation run:
+If some existing or new datasets do not have `fdpo:metadataIssued` in `metadata.ttl`, or if existing `metadata.ttl` files may be modified and therefore need a new `fdpo:metadataModified` value, provide an explicit deterministic timestamp for the generation run:
 
 ```bash
 python scripts/metadata_yaml_to_ttl.py --all --models-dir models --metadata-timestamp 2026-01-31T12:00:00Z
@@ -148,14 +148,17 @@ When `metadata.ttl` already exists, the converter reads it to preserve values th
 - the model IRI form used for `dcat:distribution` links;
 - the catalog IRI used in `dct:isPartOf`;
 - existing `ocmv:storageUrl`;
-- existing `fdpo:metadataIssued` and `fdpo:metadataModified` timestamps;
+- existing `fdpo:metadataIssued`;
+- existing `fdpo:metadataModified` when the regenerated file is unchanged;
 - existing `dcat:distribution` links.
 
 The converter also discovers distribution IRIs from distribution-specific metadata files already present in the dataset folder, such as `metadata-vpp.ttl`, `metadata-json.ttl`, `metadata-turtle.ttl`, and `metadata-png-*.ttl`.
 
 The remaining model-level descriptive metadata is regenerated from `metadata.yaml`.
 
-This behavior allows safe regeneration of existing datasets without replacing stable catalog identifiers or distribution links.
+When the regenerated `metadata.ttl` content differs from the current file, including formatting-only differences, the converter preserves existing `fdpo:metadataIssued` but updates `fdpo:metadataModified` to the explicit run timestamp provided through `--metadata-timestamp`. If `fdpo:metadataIssued` is missing, it is initialized with the same explicit run timestamp.
+
+This behavior allows safe regeneration of existing datasets without replacing stable catalog identifiers or distribution links, while keeping FDP modification metadata aligned with the actual regeneration outcome.
 
 ## New datasets
 
@@ -172,7 +175,7 @@ New datasets must be generated with an explicit metadata timestamp unless one is
 python scripts/metadata_yaml_to_ttl.py models/new-dataset --metadata-timestamp 2026-01-31T12:00:00Z
 ```
 
-Use `--metadata-timestamp now` only when non-deterministic current timestamps are intentionally acceptable. Existing datasets keep their current `fdpo:metadataIssued` and `fdpo:metadataModified` values by default. Existing datasets that currently lack FDP metadata timestamps require `--metadata-timestamp`; this avoids silently inventing catalog metadata timestamps.
+Use `--metadata-timestamp now` only when non-deterministic current timestamps are intentionally acceptable. Existing datasets preserve their current `fdpo:metadataIssued` value by default. Existing `fdpo:metadataModified` values are preserved only when the regenerated file is unchanged; if the file changes, `fdpo:metadataModified` is updated to the explicit run timestamp. Existing datasets that currently lack FDP metadata timestamps, or that need to be modified, require `--metadata-timestamp`; this avoids silently inventing catalog metadata timestamps.
 
 ## Exit codes
 

--- a/scripts/metadata_yaml_to_ttl.py
+++ b/scripts/metadata_yaml_to_ttl.py
@@ -370,32 +370,6 @@ def scalar_text(value: Any) -> str:
     return str(value).strip()
 
 
-def first_text(value: Any) -> Optional[str]:
-    """Extract a display text from common scalar, list, or language-map values."""
-
-    if value is None:
-        return None
-    if isinstance(value, Mapping):
-        for key in ("value", "en", "eng", "english", "label", "title", "name"):
-            nested = mapping_get_normalized(value, key)
-            text = first_text(nested)
-            if text:
-                return text
-        for nested in value.values():
-            text = first_text(nested)
-            if text:
-                return text
-        return None
-    if isinstance(value, list):
-        for item in value:
-            text = first_text(item)
-            if text:
-                return text
-        return None
-    text = scalar_text(value)
-    return text or None
-
-
 def is_http_uri(value: Any) -> bool:
     if not isinstance(value, str):
         return False
@@ -614,11 +588,6 @@ def language_values(value: Any) -> list[str]:
     return values
 
 
-def first_language(data: Mapping[str, Any]) -> Optional[str]:
-    languages = language_values(canonical_value(data, "language"))
-    return languages[0] if languages else None
-
-
 def normalize_enum(value: Any, allowed: dict[str, URIRef], field_name: str) -> URIRef:
     if not isinstance(value, str) or not value.strip():
         raise MetadataConversionError(
@@ -782,33 +751,55 @@ def read_existing_metadata(ttl_path: Path) -> ExistingMetadata:
     )
 
 
+def configured_run_timestamp_literal(config: Config, ttl_path: Path) -> Literal:
+    """Return the explicit run timestamp used for newly changed metadata records."""
+
+    if config.metadata_timestamp == "now":
+        return current_datetime_literal()
+    if config.metadata_timestamp:
+        return configured_datetime_literal(
+            config.metadata_timestamp, "--metadata-timestamp"
+        )
+    raise MetadataConversionError(
+        f"No run timestamp is available to initialize fdpo:metadataIssued or update "
+        f"fdpo:metadataModified in {ttl_path}. "
+        "Provide --metadata-timestamp, for example --metadata-timestamp 2026-01-31T12:00:00Z. "
+        "Use --metadata-timestamp now only when a non-deterministic execution timestamp is acceptable."
+    )
+
+
 def metadata_timestamp_literals(
-    existing: ExistingMetadata, config: Config, ttl_path: Path
+    existing: ExistingMetadata,
+    config: Config,
+    ttl_path: Path,
+    *,
+    update_metadata_modified: bool,
 ) -> tuple[Literal, Literal]:
+    """Return FDP metadata timestamps for the generated metadata.ttl file.
+
+    metadataIssued is preserved whenever it already exists. Missing metadataIssued
+    values are initialized with the explicit run timestamp. metadataModified is
+    preserved only when the file is not changing; when the generated file differs
+    from the current file, it is updated to the explicit run timestamp.
+    """
+
+    run_timestamp: Optional[Literal] = None
+
+    def get_run_timestamp() -> Literal:
+        nonlocal run_timestamp
+        if run_timestamp is None:
+            run_timestamp = configured_run_timestamp_literal(config, ttl_path)
+        return run_timestamp
+
     if existing.metadata_issued is not None:
         metadata_issued = existing.metadata_issued
-    elif config.metadata_timestamp == "now":
-        metadata_issued = current_datetime_literal()
-    elif config.metadata_timestamp:
-        metadata_issued = configured_datetime_literal(
-            config.metadata_timestamp, "--metadata-timestamp"
-        )
     else:
-        raise MetadataConversionError(
-            f"No fdpo:metadataIssued value is available for {ttl_path}. "
-            "Existing metadata.ttl files that lack FDP metadata timestamps and new metadata.ttl files "
-            "must be regenerated with --metadata-timestamp, for example "
-            "--metadata-timestamp 2026-01-31T12:00:00Z."
-        )
+        metadata_issued = get_run_timestamp()
 
-    if existing.metadata_modified is not None:
+    if update_metadata_modified:
+        metadata_modified = get_run_timestamp()
+    elif existing.metadata_modified is not None:
         metadata_modified = existing.metadata_modified
-    elif config.metadata_timestamp == "now":
-        metadata_modified = metadata_issued
-    elif config.metadata_timestamp:
-        metadata_modified = configured_datetime_literal(
-            config.metadata_timestamp, "--metadata-timestamp"
-        )
     else:
         metadata_modified = metadata_issued
 
@@ -1029,6 +1020,8 @@ def build_turtle(
     dataset_folder: Path,
     existing: ExistingMetadata,
     config: Config,
+    *,
+    update_metadata_modified: bool = False,
 ) -> tuple[str, int, list[str]]:
     validate_supported_yaml_fields(data)
     validate_minimum_convertible_fields(
@@ -1056,6 +1049,7 @@ def build_turtle(
         existing if config.preserve_existing else ExistingMetadata(),
         config,
         dataset_folder / OUTPUT_FILE_NAME,
+        update_metadata_modified=update_metadata_modified,
     )
     storage_url = (
         existing.storage_url
@@ -1284,6 +1278,15 @@ def convert_dataset(dataset_folder: Path, config: Config) -> ConversionResult:
 
     old_text = ttl_path.read_text(encoding="utf-8") if ttl_path.exists() else None
     changed = old_text != turtle
+    if changed:
+        turtle, triple_count, warnings = build_turtle(
+            data,
+            dataset_folder,
+            existing,
+            config,
+            update_metadata_modified=True,
+        )
+        changed = old_text != turtle
     written = False
 
     if config.dry_run:

--- a/scripts/tests/test_metadata_yaml_to_ttl.py
+++ b/scripts/tests/test_metadata_yaml_to_ttl.py
@@ -105,7 +105,9 @@ def test_regeneration_preserves_existing_catalog_managed_values(tmp_path: Path):
     write_metadata_yaml(dataset)
     write_existing_metadata_ttl(dataset)
 
-    result = module.convert_dataset(dataset, module.Config())
+    result = module.convert_dataset(
+        dataset, module.Config(metadata_timestamp="2026-01-31T12:00:00Z")
+    )
 
     generated = (dataset / "metadata.ttl").read_text(encoding="utf-8")
     assert result.written is True
@@ -121,7 +123,11 @@ def test_regeneration_preserves_existing_catalog_managed_values(tmp_path: Path):
         in generated
     )
     assert "https://w3id.org/ontouml-models/distribution/one/" in generated
-    assert "2023-04-14T17:35:28.608937306Z" in generated
+    assert (
+        'fdpo:metadataIssued "2023-04-14T17:35:28.608937306Z"^^xsd:dateTime'
+        in generated
+    )
+    assert 'fdpo:metadataModified "2026-01-31T12:00:00Z"^^xsd:dateTime' in generated
     assert (
         "https://github.com/OntoUML/ontouml-models/tree/master/models/amaral2019rot"
         in generated
@@ -299,7 +305,9 @@ def test_check_mode_reports_needed_update_without_writing(
     write_existing_metadata_ttl(dataset)
     before = (dataset / "metadata.ttl").read_text(encoding="utf-8")
 
-    exit_code = module.main([str(dataset), "--check"])
+    exit_code = module.main(
+        [str(dataset), "--check", "--metadata-timestamp", "2026-01-31T12:00:00Z"]
+    )
     after = (dataset / "metadata.ttl").read_text(encoding="utf-8")
     captured = capsys.readouterr()
 
@@ -407,7 +415,16 @@ def test_json_check_mode_outputs_clean_json_without_diff(
     write_metadata_yaml(dataset)
     write_existing_metadata_ttl(dataset)
 
-    exit_code = module.main([str(dataset), "--check", "--format", "json"])
+    exit_code = module.main(
+        [
+            str(dataset),
+            "--check",
+            "--format",
+            "json",
+            "--metadata-timestamp",
+            "2026-01-31T12:00:00Z",
+        ]
+    )
     captured = capsys.readouterr()
     payload = json.loads(captured.out)
 
@@ -486,7 +503,9 @@ def test_language_maps_are_supported_for_literal_fields(tmp_path: Path):
     )
     (dataset / "metadata.yaml").write_text(yaml_text, encoding="utf-8")
 
-    module.convert_dataset(dataset, module.Config())
+    module.convert_dataset(
+        dataset, module.Config(metadata_timestamp="2026-01-31T12:00:00Z")
+    )
 
     generated = (dataset / "metadata.ttl").read_text(encoding="utf-8")
     assert 'dct:title "Reference Ontology of Trust"@en' in generated
@@ -833,7 +852,9 @@ def test_existing_catalog_metadata_ttl_cases_preserve_legacy_catalog_values(
     dataset = tmp_path / "models" / folder
     write_catalog_metadata_pair(dataset, yaml_text, old_ttl)
 
-    module.convert_dataset(dataset, module.Config())
+    module.convert_dataset(
+        dataset, module.Config(metadata_timestamp="2026-01-31T12:00:00Z")
+    )
 
     generated = (dataset / "metadata.ttl").read_text(encoding="utf-8")
     assert f"https://w3id.org/ontouml-models/model/{model_uuid}/" in generated
@@ -842,7 +863,8 @@ def test_existing_catalog_metadata_ttl_cases_preserve_legacy_catalog_values(
         in generated
     )
     assert expected_theme in generated
-    assert expected_timestamp in generated
+    assert f'fdpo:metadataIssued "{expected_timestamp}"^^xsd:dateTime' in generated
+    assert 'fdpo:metadataModified "2026-01-31T12:00:00Z"^^xsd:dateTime' in generated
     assert f"models/{folder}" in generated
     assert "metadata-turtle.ttl" not in generated
     assert_parseable_turtle(dataset / "metadata.ttl")
@@ -1001,3 +1023,81 @@ def test_comma_separated_language_scalar_matches_validator_behavior(tmp_path: Pa
     assert 'dct:language "en",\n                 "pt-BR"' in generated
     assert 'dcat:keyword "trust"@en' in generated
     assert_parseable_turtle(dataset / "metadata.ttl")
+
+
+def test_unchanged_file_preserves_existing_metadata_modified_with_new_timestamp(
+    tmp_path: Path,
+):
+    module = load_module()
+    dataset = tmp_path / "models" / "unchanged-timestamps"
+    write_metadata_yaml(dataset)
+
+    module.convert_dataset(
+        dataset,
+        module.Config(metadata_timestamp="2026-01-31T12:00:00Z"),
+    )
+    first_text = (dataset / "metadata.ttl").read_text(encoding="utf-8")
+
+    result = module.convert_dataset(
+        dataset,
+        module.Config(metadata_timestamp="2026-02-01T12:00:00Z"),
+    )
+    second_text = (dataset / "metadata.ttl").read_text(encoding="utf-8")
+
+    assert result.changed is False
+    assert result.written is False
+    assert first_text == second_text
+    assert 'fdpo:metadataIssued "2026-01-31T12:00:00Z"^^xsd:dateTime' in second_text
+    assert 'fdpo:metadataModified "2026-01-31T12:00:00Z"^^xsd:dateTime' in second_text
+    assert "2026-02-01T12:00:00Z" not in second_text
+
+
+def test_changed_file_preserves_metadata_issued_and_updates_metadata_modified(
+    tmp_path: Path,
+):
+    module = load_module()
+    dataset = tmp_path / "models" / "changed-timestamps"
+    write_metadata_yaml(dataset)
+
+    module.convert_dataset(
+        dataset,
+        module.Config(metadata_timestamp="2026-01-31T12:00:00Z"),
+    )
+    yaml_text = (dataset / "metadata.yaml").read_text(encoding="utf-8")
+    (dataset / "metadata.yaml").write_text(
+        yaml_text.replace("Reference Ontology of Trust", "Updated Trust Ontology"),
+        encoding="utf-8",
+    )
+
+    result = module.convert_dataset(
+        dataset,
+        module.Config(metadata_timestamp="2026-02-01T12:00:00Z"),
+    )
+
+    generated = (dataset / "metadata.ttl").read_text(encoding="utf-8")
+    assert result.changed is True
+    assert result.written is True
+    assert 'dct:title "Updated Trust Ontology"' in generated
+    assert 'fdpo:metadataIssued "2026-01-31T12:00:00Z"^^xsd:dateTime' in generated
+    assert 'fdpo:metadataModified "2026-02-01T12:00:00Z"^^xsd:dateTime' in generated
+
+
+def test_changed_existing_file_requires_timestamp_to_update_metadata_modified(
+    tmp_path: Path,
+):
+    module = load_module()
+    dataset = tmp_path / "models" / "changed-without-timestamp"
+    write_metadata_yaml(dataset)
+
+    module.convert_dataset(
+        dataset,
+        module.Config(metadata_timestamp="2026-01-31T12:00:00Z"),
+    )
+    yaml_text = (dataset / "metadata.yaml").read_text(encoding="utf-8")
+    (dataset / "metadata.yaml").write_text(
+        yaml_text.replace("Reference Ontology of Trust", "Updated Trust Ontology"),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(module.MetadataConversionError, match="metadataModified"):
+        module.convert_dataset(dataset, module.Config())


### PR DESCRIPTION
## Summary

This PR updates the `metadata.yaml` → `metadata.ttl` converter only.

It is intentionally limited to:

- `scripts/metadata_yaml_to_ttl.py`
- `scripts/metadata_yaml_to_ttl.md`
- `scripts/tests/test_metadata_yaml_to_ttl.py`

It does **not** regenerate existing catalog metadata files.

## Motivation

This update refines how the converter handles FDP metadata timestamps before applying it to repository-wide `metadata.ttl` regeneration.

The main goal is to ensure that:

- `fdpo:metadataIssued` represents when the metadata record was first issued;
- `fdpo:metadataModified` represents when the metadata record was last changed.

## Timestamp behavior

The converter now follows this policy:

- preserve existing `fdpo:metadataIssued` values whenever they are available;
- initialize missing `fdpo:metadataIssued` values from an explicit run timestamp;
- update `fdpo:metadataModified` only when the generated `metadata.ttl` content changes;
- preserve `fdpo:metadataModified` when regenerated output is unchanged;
- require `--metadata-timestamp` when a file needs to be created or modified and no suitable timestamp is available.

This applies even when the change is formatting-only.

## Recommended usage

For repository-wide regeneration, a fixed UTC timestamp should be used instead of `now`, so the resulting changes are deterministic and easier to review.

Example:

```bash
python scripts/metadata_yaml_to_ttl.py --all --models-dir models --allow-missing-license --metadata-timestamp 2026-06-23T12:00:00Z
```

Then the same timestamp can be used for idempotence checking:

```bash
python scripts/metadata_yaml_to_ttl.py --all --models-dir models --allow-missing-license --metadata-timestamp 2026-06-23T12:00:00Z --check
```

## Scope

This PR updates the converter implementation, documentation, and tests only.

It does not modify:

- `models/**/metadata.ttl`;
- `models/**/metadata.yaml`;
- distribution-specific metadata files;
- model artifacts.

A separate PR can later apply the converter to regenerate existing catalog metadata.

## Verification

```bash
python -m pytest -q scripts/tests/test_metadata_yaml_to_ttl.py
python scripts/metadata_yaml_to_ttl.py --help
```