### PR TITLE
Regenerate model-level metadata.ttl files

### DIFF
--- a/models/abel2015petroleum-system/metadata.ttl
+++ b/models/abel2015petroleum-system/metadata.ttl
@@ -1,32 +1,39 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/7ed5893a-ead6-4de1-b9c1-635e7af3de00/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:title "Petroleum System Model";
     dct:issued "2015"^^xsd:gYear;
     dct:modified "2015"^^xsd:gYear;
     dcat:theme lcc:Q;
     skos:editorialNote "Despite being represented as simple attributes, some of the model's attributes represent enumerations - we decided to model them as enumerations for the correct representation. The attributes that do not represent enumerations were represented just like in its original version.";
     dct:language "en";
-    dct:contributor <https://dblp.org/pid/a/MaraAbel>, <https://dblp.org/pid/76/4608>, <https://dblp.org/pid/121/5033>;
-    dcat:keyword "geology"@en, "petroleum"@en;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    dct:contributor <https://dblp.org/pid/a/MaraAbel>,
+                    <https://dblp.org/pid/76/4608>,
+                    <https://dblp.org/pid/121/5033>;
+    dcat:keyword "geology"@en,
+                 "petroleum"@en;
+    dct:source <https://doi.org/10.1007/s12145-015-0211-9>;
     mod:designedForTask ocmv:ConceptualClarification;
     ocmv:context ocmv:Research;
-    dct:source <https://doi.org/10.1007/s12145-015-0211-9>;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/abel2015petroleum-system"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/abel2015petroleum-system"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:33:19.190667802Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:33:19.190667802Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/7ed5893a-ead6-4de1-b9c1-635e7af3de00> dcat:distribution <https://w3id.org/ontouml-models/distribution/f5c87f00-66fa-47a9-a0a8-07b88588b095/>, <https://w3id.org/ontouml-models/distribution/ccddedaa-6508-41ee-a621-9d7f56c06419/>, <https://w3id.org/ontouml-models/distribution/f9818d9f-291d-4938-9f3c-daa369604f24/>, <https://w3id.org/ontouml-models/distribution/7e48f61c-5004-4c94-9c9c-d78c6e0b5443>, <https://w3id.org/ontouml-models/distribution/8decbca5-511b-48a0-97a4-727bd60b36a3>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/7ed5893a-ead6-4de1-b9c1-635e7af3de00> dcat:distribution <https://w3id.org/ontouml-models/distribution/f5c87f00-66fa-47a9-a0a8-07b88588b095/>,
+                      <https://w3id.org/ontouml-models/distribution/ccddedaa-6508-41ee-a621-9d7f56c06419/>,
+                      <https://w3id.org/ontouml-models/distribution/f9818d9f-291d-4938-9f3c-daa369604f24/>,
+                      <https://w3id.org/ontouml-models/distribution/7e48f61c-5004-4c94-9c9c-d78c6e0b5443>,
+                      <https://w3id.org/ontouml-models/distribution/8decbca5-511b-48a0-97a4-727bd60b36a3> .

--- a/models/abrahao2018agriculture-operations/metadata.ttl
+++ b/models/abrahao2018agriculture-operations/metadata.ttl
@@ -1,30 +1,38 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/d07d44af-d127-4407-8d0f-72b9e17a6479/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:title "Agriculture Operations Task Ontology";
     dct:issued "2018"^^xsd:gYear;
     dcat:theme lcc:S;
     dct:language "en";
-    dct:contributor <https://dblp.org/pid/58/7513>, <https://dblp.org/pid/66/5960>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    dct:contributor <https://dblp.org/pid/58/7513>,
+                    <https://dblp.org/pid/66/5960>;
     dcat:keyword "agriculture"@en;
-    mod:designedForTask ocmv:ConceptualClarification, ocmv:Interoperability;
-    ocmv:context ocmv:Research;
     dct:source <https://doi.org/10.5220/0006956202870294>;
+    mod:designedForTask ocmv:ConceptualClarification,
+                        ocmv:Interoperability;
+    ocmv:context ocmv:Research;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/abrahao2018agriculture-operations"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/abrahao2018agriculture-operations"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:33:31.496875993Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:33:31.496875993Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/d07d44af-d127-4407-8d0f-72b9e17a6479> dcat:distribution <https://w3id.org/ontouml-models/distribution/f8b97967-0e4a-491c-8b3f-85e86d44cb5f/>, <https://w3id.org/ontouml-models/distribution/51727a95-2d6b-448c-ac1e-e7506bd5174b/>, <https://w3id.org/ontouml-models/distribution/804ee560-10fb-4ba9-a7a7-228b5adcb8b3/>, <https://w3id.org/ontouml-models/distribution/8b3255e7-b29e-4d72-8c43-f47b0b865944>, <https://w3id.org/ontouml-models/distribution/2649f247-8132-45ce-a6a9-e64f54443a38>, <https://w3id.org/ontouml-models/distribution/e9f630e6-013c-45b7-8f2b-4e5161f27217>, <https://w3id.org/ontouml-models/distribution/607d5cd1-4329-43fc-be52-f7e8dc9b4a6b>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/d07d44af-d127-4407-8d0f-72b9e17a6479> dcat:distribution <https://w3id.org/ontouml-models/distribution/f8b97967-0e4a-491c-8b3f-85e86d44cb5f/>,
+                      <https://w3id.org/ontouml-models/distribution/51727a95-2d6b-448c-ac1e-e7506bd5174b/>,
+                      <https://w3id.org/ontouml-models/distribution/804ee560-10fb-4ba9-a7a7-228b5adcb8b3/>,
+                      <https://w3id.org/ontouml-models/distribution/8b3255e7-b29e-4d72-8c43-f47b0b865944>,
+                      <https://w3id.org/ontouml-models/distribution/2649f247-8132-45ce-a6a9-e64f54443a38>,
+                      <https://w3id.org/ontouml-models/distribution/e9f630e6-013c-45b7-8f2b-4e5161f27217>,
+                      <https://w3id.org/ontouml-models/distribution/607d5cd1-4329-43fc-be52-f7e8dc9b4a6b> .

--- a/models/aguiar2018rdbs-o/metadata.ttl
+++ b/models/aguiar2018rdbs-o/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/1c0413cd-ce41-4822-a227-68cddf6074e6/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -19,14 +18,23 @@
     skos:editorialNote "The declared purpose of the ontology is \"to identify and represent key concepts of the relational database domain in the architectural scope, not covering control and execution details.\" and \"RDBS-O is being built in the context of a larger effort of building a network of ontologies on software development frameworks, in particular for object/relational frameworks [Bauer and King 2004]. Such ontologies will allow us to automate tasks such as migrating code from one framework to another or defining and detecting architectural smells in software projects\".";
     dct:language "en";
     dct:license <https://www.gnu.org/licenses/gpl-3.0.en.html>;
-    dct:contributor <https://dblp.org/pid/230/6733>, <https://dblp.org/pid/72/3662>, <https://dblp.org/pid/229/4259>;
-    dcat:keyword "relational databases"@en, "database structure"@en;
-    mod:designedForTask ocmv:ConceptualClarification, ocmv:SoftwareEngineering;
-    ocmv:context ocmv:Research;
+    dct:contributor <https://dblp.org/pid/230/6733>,
+                    <https://dblp.org/pid/72/3662>,
+                    <https://dblp.org/pid/229/4259>;
+    dcat:keyword "relational databases"@en,
+                 "database structure"@en;
     dct:source <https://dblp.org/rec/conf/ontobras/AguiarFS18>;
+    mod:designedForTask ocmv:ConceptualClarification,
+                        ocmv:SoftwareEngineering;
+    ocmv:context ocmv:Research;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/aguiar2018rdbs-o"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/aguiar2018rdbs-o"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:33:45.214914024Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:33:45.214914024Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/1c0413cd-ce41-4822-a227-68cddf6074e6> dcat:distribution <https://w3id.org/ontouml-models/distribution/20be03e0-f14f-41a4-bd63-4641247fd4e5/>, <https://w3id.org/ontouml-models/distribution/fd4de7bd-700d-4fb5-946d-eaab891acd97/>, <https://w3id.org/ontouml-models/distribution/b7e06b20-a92c-4ba0-87ab-6c8f5796d0ff/>, <https://w3id.org/ontouml-models/distribution/da38673e-deb3-499b-94d3-e7a36b72a86c>, <https://w3id.org/ontouml-models/distribution/66c4bf35-4102-45cd-841a-5ff2be8ac11c>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/1c0413cd-ce41-4822-a227-68cddf6074e6> dcat:distribution <https://w3id.org/ontouml-models/distribution/20be03e0-f14f-41a4-bd63-4641247fd4e5/>,
+                      <https://w3id.org/ontouml-models/distribution/fd4de7bd-700d-4fb5-946d-eaab891acd97/>,
+                      <https://w3id.org/ontouml-models/distribution/b7e06b20-a92c-4ba0-87ab-6c8f5796d0ff/>,
+                      <https://w3id.org/ontouml-models/distribution/da38673e-deb3-499b-94d3-e7a36b72a86c>,
+                      <https://w3id.org/ontouml-models/distribution/66c4bf35-4102-45cd-841a-5ff2be8ac11c> .

--- a/models/aguiar2019ooco/metadata.ttl
+++ b/models/aguiar2019ooco/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/0647761f-976f-41c4-94c0-a907ae1ed577/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -19,14 +18,26 @@
     skos:editorialNote "The authors state in their paper that the purpose of this ontology is to \"identify and represent the fundamental concepts present in OO source code\". I interpreted this as a conceptual clarification goal.";
     dct:language "en";
     dct:license <https://www.gnu.org/licenses/gpl-3.0.en.html>;
-    dct:contributor <https://dblp.org/pid/230/6733>, <https://dblp.org/pid/72/3662>, <https://dblp.org/pid/229/4259>;
-    dcat:keyword "object-oriented code"@en, "programming languages"@en;
+    dct:contributor <https://dblp.org/pid/230/6733>,
+                    <https://dblp.org/pid/72/3662>,
+                    <https://dblp.org/pid/229/4259>;
+    dcat:keyword "object-oriented code"@en,
+                 "programming languages"@en;
+    dct:source <https://doi.org/10.1007/978-3-030-33223-5_3>;
     mod:designedForTask ocmv:ConceptualClarification;
     ocmv:context ocmv:Research;
-    dct:source <https://doi.org/10.1007/978-3-030-33223-5_3>;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/aguiar2019ooco"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/aguiar2019ooco"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:33:55.174072672Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:33:55.174072672Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/0647761f-976f-41c4-94c0-a907ae1ed577> dcat:distribution <https://w3id.org/ontouml-models/distribution/e8511b6e-2606-46a1-85a9-13234dbaa1df/>, <https://w3id.org/ontouml-models/distribution/a34737aa-768a-4bf0-8aaa-b7a52f8f1226/>, <https://w3id.org/ontouml-models/distribution/e11c132e-5f2f-45e3-8ec4-c7ee94cae9ba/>, <https://w3id.org/ontouml-models/distribution/ccc688bb-f163-481e-bb42-f1183ca4cb4f>, <https://w3id.org/ontouml-models/distribution/a3df3168-bfe9-4068-8e76-7592fba06862>, <https://w3id.org/ontouml-models/distribution/15b09781-f3ab-44fe-a384-fcb83b8c9b7a>, <https://w3id.org/ontouml-models/distribution/675cb39f-f1bc-4c00-9c7b-c84242912e32>, <https://w3id.org/ontouml-models/distribution/0428fa33-0df7-406c-931b-f7a3fbacdc7a>, <https://w3id.org/ontouml-models/distribution/bd170ec1-3e06-4b5e-989e-ccbefcfe12f8>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/0647761f-976f-41c4-94c0-a907ae1ed577> dcat:distribution <https://w3id.org/ontouml-models/distribution/e8511b6e-2606-46a1-85a9-13234dbaa1df/>,
+                      <https://w3id.org/ontouml-models/distribution/a34737aa-768a-4bf0-8aaa-b7a52f8f1226/>,
+                      <https://w3id.org/ontouml-models/distribution/e11c132e-5f2f-45e3-8ec4-c7ee94cae9ba/>,
+                      <https://w3id.org/ontouml-models/distribution/ccc688bb-f163-481e-bb42-f1183ca4cb4f>,
+                      <https://w3id.org/ontouml-models/distribution/a3df3168-bfe9-4068-8e76-7592fba06862>,
+                      <https://w3id.org/ontouml-models/distribution/15b09781-f3ab-44fe-a384-fcb83b8c9b7a>,
+                      <https://w3id.org/ontouml-models/distribution/675cb39f-f1bc-4c00-9c7b-c84242912e32>,
+                      <https://w3id.org/ontouml-models/distribution/0428fa33-0df7-406c-931b-f7a3fbacdc7a>,
+                      <https://w3id.org/ontouml-models/distribution/bd170ec1-3e06-4b5e-989e-ccbefcfe12f8> .

--- a/models/ahmad2018aviation/metadata.ttl
+++ b/models/ahmad2018aviation/metadata.ttl
@@ -1,30 +1,39 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/660ad6c4-dbc1-43e7-b582-d7eb9ec43739/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:title "Aviation Safety Ontology";
     dct:issued "2018"^^xsd:gYear;
     dcat:theme lcc:T;
     dct:language "en";
-    dct:contributor <https://dblp.org/pid/185/3559>, <https://dblp.org/pid/77/5702>, <https://dblp.org/pid/166/2116>;
-    dcat:keyword "safety"@en, "aviation"@en;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    dct:contributor <https://dblp.org/pid/185/3559>,
+                    <https://dblp.org/pid/77/5702>,
+                    <https://dblp.org/pid/166/2116>;
+    dcat:keyword "safety"@en,
+                 "aviation"@en;
+    dct:source <https://doi.org/10.1007/978-3-030-02671-4_22>;
     mod:designedForTask ocmv:InformationRetrieval;
     ocmv:context ocmv:Research;
-    dct:source <https://doi.org/10.1007/978-3-030-02671-4_22>;
     ocmv:representationStyle ocmv:UfoStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/ahmad2018aviation"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/ahmad2018aviation"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:34:11.689440155Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:34:11.689440155Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/660ad6c4-dbc1-43e7-b582-d7eb9ec43739> dcat:distribution <https://w3id.org/ontouml-models/distribution/69cd521b-671c-49f2-a176-e31910dec404/>, <https://w3id.org/ontouml-models/distribution/f74b710c-d8a5-4f95-b9d1-5a2e07327bbd/>, <https://w3id.org/ontouml-models/distribution/cb1161ec-9638-4496-8334-de3dd75be0c5/>, <https://w3id.org/ontouml-models/distribution/639ce4c9-d83b-4c4e-b207-e605284a3084>, <https://w3id.org/ontouml-models/distribution/471c8f9e-f70f-45f9-a445-ca201e694ff1>, <https://w3id.org/ontouml-models/distribution/c093f9de-5481-41dd-9466-e74c2153b479>, <https://w3id.org/ontouml-models/distribution/c2ba45c2-15ea-413b-a647-3a2fbc9a07e9>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/660ad6c4-dbc1-43e7-b582-d7eb9ec43739> dcat:distribution <https://w3id.org/ontouml-models/distribution/69cd521b-671c-49f2-a176-e31910dec404/>,
+                      <https://w3id.org/ontouml-models/distribution/f74b710c-d8a5-4f95-b9d1-5a2e07327bbd/>,
+                      <https://w3id.org/ontouml-models/distribution/cb1161ec-9638-4496-8334-de3dd75be0c5/>,
+                      <https://w3id.org/ontouml-models/distribution/639ce4c9-d83b-4c4e-b207-e605284a3084>,
+                      <https://w3id.org/ontouml-models/distribution/471c8f9e-f70f-45f9-a445-ca201e694ff1>,
+                      <https://w3id.org/ontouml-models/distribution/c093f9de-5481-41dd-9466-e74c2153b479>,
+                      <https://w3id.org/ontouml-models/distribution/c2ba45c2-15ea-413b-a647-3a2fbc9a07e9> .

--- a/models/aires2022valuenetworks-geo/metadata.ttl
+++ b/models/aires2022valuenetworks-geo/metadata.ttl
@@ -1,31 +1,41 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/3886f70e-5a91-411d-a50e-370eb4f93c5a/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:title "Ontology for Value Networks with Geographic Information";
     dct:issued "2022"^^xsd:gYear;
     dct:modified "2022"^^xsd:gYear;
     dcat:theme lcc:H;
-    skos:editorialNote "The ontology was developed in the context of a master thesis which isn't yet published.\nThe ontology contains multiples derivations of the same class, which cannot be represented in Visual Paradigm. In these cases, additional derivations were represented as dependency links and are not being currently serialized to JSON.\nThe cardinalities in derivation link were represented in UML notes.\nThere is a collection of generalizations of relators into a single category near a {disjoint} constraint. Given the context, the generalizations were interpreted as part of the same set, and the category's \"restrictedTo\" was set to \"relator\".\n";
+    skos:editorialNote """The ontology was developed in the context of a master thesis which isn't yet published.
+The ontology contains multiples derivations of the same class, which cannot be represented in Visual Paradigm. In these cases, additional derivations were represented as dependency links and are not being currently serialized to JSON.
+The cardinalities in derivation link were represented in UML notes.
+There is a collection of generalizations of relators into a single category near a {disjoint} constraint. Given the context, the generalizations were interpreted as part of the same set, and the category's "restrictedTo" was set to "relator".
+""";
     dct:language "en";
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:contributor <https://dblp.org/pid/284/5427>;
     dcat:keyword "value networks"@en;
     mod:designedForTask ocmv:LanguageEngineering;
     ocmv:context ocmv:Research;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/aires2022valuenetworks-geo"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/aires2022valuenetworks-geo"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:34:24.406334322Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:34:24.406334322Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/3886f70e-5a91-411d-a50e-370eb4f93c5a> dcat:distribution <https://w3id.org/ontouml-models/distribution/3109bec0-7e3c-4773-9cb2-7d982b38f11e/>, <https://w3id.org/ontouml-models/distribution/b49051c3-8f8a-468b-9802-2131a4d9ada9/>, <https://w3id.org/ontouml-models/distribution/18584c3c-f9c9-4548-8d63-2a4e1bccd7b9/>, <https://w3id.org/ontouml-models/distribution/81c4321a-1e4e-483c-926b-c671bffdefcb>, <https://w3id.org/ontouml-models/distribution/8a296356-6da0-4e20-819a-25634676e462>, <https://w3id.org/ontouml-models/distribution/9d0309ef-011c-411f-a990-517d17404b42>, <https://w3id.org/ontouml-models/distribution/71b2894f-8e29-476a-b11f-6d401db22f76>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/3886f70e-5a91-411d-a50e-370eb4f93c5a> dcat:distribution <https://w3id.org/ontouml-models/distribution/3109bec0-7e3c-4773-9cb2-7d982b38f11e/>,
+                      <https://w3id.org/ontouml-models/distribution/b49051c3-8f8a-468b-9802-2131a4d9ada9/>,
+                      <https://w3id.org/ontouml-models/distribution/18584c3c-f9c9-4548-8d63-2a4e1bccd7b9/>,
+                      <https://w3id.org/ontouml-models/distribution/81c4321a-1e4e-483c-926b-c671bffdefcb>,
+                      <https://w3id.org/ontouml-models/distribution/8a296356-6da0-4e20-819a-25634676e462>,
+                      <https://w3id.org/ontouml-models/distribution/9d0309ef-011c-411f-a990-517d17404b42>,
+                      <https://w3id.org/ontouml-models/distribution/71b2894f-8e29-476a-b11f-6d401db22f76> .

--- a/models/albuquerque2011ontobio/metadata.ttl
+++ b/models/albuquerque2011ontobio/metadata.ttl
@@ -1,18 +1,16 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/f3d40402-e30d-4bbc-8792-5566bc8c30e9/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:title "OntoBio";
     dct:issued "2011"^^xsd:gYear;
     dct:modified "2016"^^xsd:gYear;
@@ -20,14 +18,39 @@
     skos:editorialNote "in the reference papers we do not have reference diagrams. However, we have a GitHub page were to get some visual information. Still, the quality of the images is very low. Some images are unreadable which led to them not being included in this model";
     dct:language "en";
     dcat:landingPage <https://github.com/unibz-core/OntoBio_Ontology>;
-    dct:contributor <https://dblp.org/pid/135/0761>, <https://dblp.org/pid/88/711>, <https://dblp.org/pid/61/2142>, <https://orcid.org/0000-0002-1904-3751>, <https://dblp.org/pid/200/9519>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    dct:contributor <https://dblp.org/pid/135/0761>,
+                    <https://dblp.org/pid/88/711>,
+                    <https://dblp.org/pid/61/2142>,
+                    <https://orcid.org/0000-0002-1904-3751>,
+                    <https://dblp.org/pid/200/9519>;
     dcat:keyword "biology"@en;
-    mod:designedForTask ocmv:SoftwareEngineering, ocmv:Interoperability;
+    dct:source <https://doi.org/10.1109/HICSS.2015.453>,
+               <https://tede.ufam.edu.br/handle/tede/2887>,
+               <https://dblp.org/rec/conf/ontobras/AlbuquerqueSJ16>,
+               <https://www.researchgate.net/profile/Marcos-De-Sousa-2/publication/284186226_Novas_Contribuicoes_e_Implementacoes_a_um_Modelo_Formal_de_Ontologia_de_Dominio_para_Biodiversidade/links/564f233708aeafc2aab39cca/Novas-Contribuicoes-e-Implementacoes-a-um-Modelo-Formal-de-Ontologia-de-Dominio-para-Biodiversidade.pdf>;
+    mod:designedForTask ocmv:SoftwareEngineering,
+                        ocmv:Interoperability;
     ocmv:context ocmv:Research;
-    dct:source <https://doi.org/10.1109/HICSS.2015.453>, <https://tede.ufam.edu.br/handle/tede/2887>, <https://dblp.org/rec/conf/ontobras/AlbuquerqueSJ16>, <https://www.researchgate.net/profile/Marcos-De-Sousa-2/publication/284186226_Novas_Contribuicoes_e_Implementacoes_a_um_Modelo_Formal_de_Ontologia_de_Dominio_para_Biodiversidade/links/564f233708aeafc2aab39cca/Novas-Contribuicoes-e-Implementacoes-a-um-Modelo-Formal-de-Ontologia-de-Dominio-para-Biodiversidade.pdf>;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/albuquerque2011ontobio"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/albuquerque2011ontobio"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:34:37.144775488Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:34:37.144775488Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/f3d40402-e30d-4bbc-8792-5566bc8c30e9> dcat:distribution <https://w3id.org/ontouml-models/distribution/f374fbe4-fffb-4ce0-afe8-3145fadf7c68/>, <https://w3id.org/ontouml-models/distribution/faf6213a-d88b-4399-a12b-e6ea29a4ad01/>, <https://w3id.org/ontouml-models/distribution/d1958e48-22ad-41f8-883a-e97182837cba/>, <https://w3id.org/ontouml-models/distribution/ddbda5c3-b3f4-4594-a8aa-c8475c3addcb>, <https://w3id.org/ontouml-models/distribution/3b5772c6-7d3f-4218-8130-c8e965efa060>, <https://w3id.org/ontouml-models/distribution/e9aff4cb-35dc-480a-805f-39e3a844b0bf>, <https://w3id.org/ontouml-models/distribution/89c8999a-b6fe-4ddf-aa40-b3bf739953cc>, <https://w3id.org/ontouml-models/distribution/7e36cc2e-57c8-4263-969b-e760ca339084>, <https://w3id.org/ontouml-models/distribution/3542273f-972a-4c0c-8d04-9fe5e2297e70>, <https://w3id.org/ontouml-models/distribution/174e42cd-5144-4772-a749-e83d01826595>, <https://w3id.org/ontouml-models/distribution/d7fbd6dd-6ee9-4871-9141-69858e1773cd>, <https://w3id.org/ontouml-models/distribution/c2d3369d-7ca5-454f-902f-e2eab1accda3>, <https://w3id.org/ontouml-models/distribution/bd6e147c-95b4-45d0-bcca-8b58ee7c7095>, <https://w3id.org/ontouml-models/distribution/30353c59-7bc9-44b0-9c63-ffbd0bbe7fb5>, <https://w3id.org/ontouml-models/distribution/2f453c71-2cf4-4e9a-9743-9bf27b0df2d0>, <https://w3id.org/ontouml-models/distribution/57881ae9-a04a-422b-bf06-53981f75c103>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/f3d40402-e30d-4bbc-8792-5566bc8c30e9> dcat:distribution <https://w3id.org/ontouml-models/distribution/f374fbe4-fffb-4ce0-afe8-3145fadf7c68/>,
+                      <https://w3id.org/ontouml-models/distribution/faf6213a-d88b-4399-a12b-e6ea29a4ad01/>,
+                      <https://w3id.org/ontouml-models/distribution/d1958e48-22ad-41f8-883a-e97182837cba/>,
+                      <https://w3id.org/ontouml-models/distribution/ddbda5c3-b3f4-4594-a8aa-c8475c3addcb>,
+                      <https://w3id.org/ontouml-models/distribution/3b5772c6-7d3f-4218-8130-c8e965efa060>,
+                      <https://w3id.org/ontouml-models/distribution/e9aff4cb-35dc-480a-805f-39e3a844b0bf>,
+                      <https://w3id.org/ontouml-models/distribution/89c8999a-b6fe-4ddf-aa40-b3bf739953cc>,
+                      <https://w3id.org/ontouml-models/distribution/7e36cc2e-57c8-4263-969b-e760ca339084>,
+                      <https://w3id.org/ontouml-models/distribution/3542273f-972a-4c0c-8d04-9fe5e2297e70>,
+                      <https://w3id.org/ontouml-models/distribution/174e42cd-5144-4772-a749-e83d01826595>,
+                      <https://w3id.org/ontouml-models/distribution/d7fbd6dd-6ee9-4871-9141-69858e1773cd>,
+                      <https://w3id.org/ontouml-models/distribution/c2d3369d-7ca5-454f-902f-e2eab1accda3>,
+                      <https://w3id.org/ontouml-models/distribution/bd6e147c-95b4-45d0-bcca-8b58ee7c7095>,
+                      <https://w3id.org/ontouml-models/distribution/30353c59-7bc9-44b0-9c63-ffbd0bbe7fb5>,
+                      <https://w3id.org/ontouml-models/distribution/2f453c71-2cf4-4e9a-9743-9bf27b0df2d0>,
+                      <https://w3id.org/ontouml-models/distribution/57881ae9-a04a-422b-bf06-53981f75c103> .

--- a/models/alkhalaf2024/metadata.ttl
+++ b/models/alkhalaf2024/metadata.ttl
@@ -1,37 +1,44 @@
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/model/alkhalaf2024/> a dcat:Dataset, mod:SemanticArtefact;
+<https://w3id.org/ontouml-models/model/alkhalaf2024/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
+    dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
     dct:title "Ontology to Explain SARS-CoV-2 Variants' Effects";
     mod:acronym "OntoEffect";
     dct:issued "2023"^^xsd:gYear;
     dcat:theme lcc:Q;
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:contributor <https://dblp.org/pid/292/3745>, <https://dblp.org/pid/25/929-2>, <https://dblp.org/pid/201/2998>;
-    mod:designedForTask ocmv:ConceptualClarification, ocmv:Interoperability, ocmv:OntologicalAnalysis;
+    dct:contributor <https://dblp.org/pid/292/3745>,
+                    <https://dblp.org/pid/25/929-2>,
+                    <https://dblp.org/pid/201/2998>;
+    dcat:keyword "genetic mutations"@en,
+                 "viral fitness"@en,
+                 "host-virus interaction"@en;
+    dct:source <https://doi.org/10.5220/0012183900003598>;
+    mod:designedForTask ocmv:ConceptualClarification,
+                        ocmv:Interoperability,
+                        ocmv:OntologicalAnalysis;
     ocmv:context ocmv:Research;
-    dct:source <https://doi.org/10.5220/0012183900003598>.
-<https://w3id.org/ontouml-models/model/alkhalaf2024/> dcat:distribution <https://w3id.org/ontouml-models/model/alkhalaf2024/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/alkhalaf2024/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Ontology to Explain SARS-CoV-2 Variants' Effects\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/alkhalaf2024/ontology.ttl>.
-<https://w3id.org/ontouml-models/model/alkhalaf2024/> dcat:distribution <https://w3id.org/ontouml-models/model/alkhalaf2024/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/alkhalaf2024/distribution/ttl> a dcat:Distribution;
-    dct:title "JSON distribution of \"Ontology to Explain SARS-CoV-2 Variants' Effects\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/alkhalaf2024/ontology.json>.
-<https://w3id.org/ontouml-models/model/alkhalaf2024/> dcat:distribution <https://w3id.org/ontouml-models/model/alkhalaf2024/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/alkhalaf2024/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Ontology to Explain SARS-CoV-2 Variants' Effects\""@en;
-    dcat:mediaType <https://www.visual-paradigm.com/vpp>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/alkhalaf2024/ontology.vpp>.
+    ocmv:representationStyle ocmv:OntoumlStyle;
+    ocmv:ontologyType ocmv:Domain;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/alkhalaf2024"^^xsd:anyURI;
+    fdpo:metadataIssued "2026-06-23T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/alkhalaf2024/> dcat:distribution <https://w3id.org/ontouml-models/model/alkhalaf2024/distribution/ttl>,
+                      <https://www.iana.org/assignments/media-types/text/turtle>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/alkhalaf2024/ontology.ttl>,
+                      <https://w3id.org/ontouml-models/model/alkhalaf2024/>,
+                      <https://www.iana.org/assignments/media-types/application/json>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/alkhalaf2024/ontology.json>,
+                      <https://www.visual-paradigm.com/vpp>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/alkhalaf2024/ontology.vpp> .

--- a/models/alpinebits2022/metadata.ttl
+++ b/models/alpinebits2022/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/ad142d17-1fcd-4189-b050-faed17165bc7/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -20,14 +19,30 @@
     dct:language "en";
     dcat:landingPage <https://www.alpinebits.org/destinationdata/>;
     dct:license <https://creativecommons.org/licenses/by-sa/3.0/>;
-    dct:contributor <https://dblp.org/pid/134/4947>, <https://dblp.org/pid/169/2246>;
-    dcat:keyword "tourism"@en, "alpine tourism"@en;
-    mod:designedForTask ocmv:SoftwareEngineering, ocmv:Interoperability;
-    ocmv:context ocmv:Industry;
+    dct:contributor <https://dblp.org/pid/134/4947>,
+                    <https://dblp.org/pid/169/2246>;
+    dcat:keyword "tourism"@en,
+                 "alpine tourism"@en;
     dct:source <https://www.alpinebits.org/wp-content/uploads/2020/08/AlpineBits_2020-04.pdf>;
+    mod:designedForTask ocmv:SoftwareEngineering,
+                        ocmv:Interoperability;
+    ocmv:context ocmv:Industry;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/alpinebits2022"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/alpinebits2022"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:35:06.066269877Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:35:06.066269877Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/ad142d17-1fcd-4189-b050-faed17165bc7> dcat:distribution <https://w3id.org/ontouml-models/distribution/c9f1c174-5b7e-441e-9318-6a5858d053b8/>, <https://w3id.org/ontouml-models/distribution/b329a4b1-7b57-4aa4-a284-787a4c7abcf2/>, <https://w3id.org/ontouml-models/distribution/239bafd0-8488-4d1e-8653-e345eb321ddb/>, <https://w3id.org/ontouml-models/distribution/1b8aa827-34d6-48a2-912c-3102bf19c8b9>, <https://w3id.org/ontouml-models/distribution/d5c967e7-6c25-4e0f-8470-2a730e6aa485>, <https://w3id.org/ontouml-models/distribution/d0826d3a-ff11-4a82-88c2-c4e2694023c0>, <https://w3id.org/ontouml-models/distribution/2ec02438-513d-4831-a63b-a2a8b778d8d3>, <https://w3id.org/ontouml-models/distribution/8900bdf9-9648-4b4a-8014-d21375eca02e>, <https://w3id.org/ontouml-models/distribution/ada9e8d9-d8b6-41c1-9a95-53c77d90282b>, <https://w3id.org/ontouml-models/distribution/4d697615-1b3d-442e-9515-0f6dddbdb14f>, <https://w3id.org/ontouml-models/distribution/c65eb571-8769-40ba-aa47-35aaf1d749a6>, <https://w3id.org/ontouml-models/distribution/f95e0b19-2e6d-4eea-af9e-bc0dedb20753>, <https://w3id.org/ontouml-models/distribution/c068ef99-4866-4e86-a596-561fa9907ad5>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/ad142d17-1fcd-4189-b050-faed17165bc7> dcat:distribution <https://w3id.org/ontouml-models/distribution/c9f1c174-5b7e-441e-9318-6a5858d053b8/>,
+                      <https://w3id.org/ontouml-models/distribution/b329a4b1-7b57-4aa4-a284-787a4c7abcf2/>,
+                      <https://w3id.org/ontouml-models/distribution/239bafd0-8488-4d1e-8653-e345eb321ddb/>,
+                      <https://w3id.org/ontouml-models/distribution/1b8aa827-34d6-48a2-912c-3102bf19c8b9>,
+                      <https://w3id.org/ontouml-models/distribution/d5c967e7-6c25-4e0f-8470-2a730e6aa485>,
+                      <https://w3id.org/ontouml-models/distribution/d0826d3a-ff11-4a82-88c2-c4e2694023c0>,
+                      <https://w3id.org/ontouml-models/distribution/2ec02438-513d-4831-a63b-a2a8b778d8d3>,
+                      <https://w3id.org/ontouml-models/distribution/8900bdf9-9648-4b4a-8014-d21375eca02e>,
+                      <https://w3id.org/ontouml-models/distribution/ada9e8d9-d8b6-41c1-9a95-53c77d90282b>,
+                      <https://w3id.org/ontouml-models/distribution/4d697615-1b3d-442e-9515-0f6dddbdb14f>,
+                      <https://w3id.org/ontouml-models/distribution/c65eb571-8769-40ba-aa47-35aaf1d749a6>,
+                      <https://w3id.org/ontouml-models/distribution/f95e0b19-2e6d-4eea-af9e-bc0dedb20753>,
+                      <https://w3id.org/ontouml-models/distribution/c068ef99-4866-4e86-a596-561fa9907ad5> .

--- a/models/amaral2019rot/metadata.ttl
+++ b/models/amaral2019rot/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/d88fe48c-d574-43b4-85d6-a6e1aeaa6726/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -21,14 +20,35 @@
     dct:language "en";
     dcat:landingPage <https://github.com/unibz-core/trust-ontology>;
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:contributor <https://dblp.org/pid/81/4277>, <https://dblp.org/pid/134/4947>, <https://dblp.org/pid/11/78>, <https://dblp.org/pid/33/8219>, <https://dblp.org/pid/91/3408>, <https://dblp.org/pid/75/5043>, <https://dblp.org/pid/m/JohnMylopoulos>;
+    dct:contributor <https://dblp.org/pid/81/4277>,
+                    <https://dblp.org/pid/134/4947>,
+                    <https://dblp.org/pid/11/78>,
+                    <https://dblp.org/pid/33/8219>,
+                    <https://dblp.org/pid/91/3408>,
+                    <https://dblp.org/pid/75/5043>,
+                    <https://dblp.org/pid/m/JohnMylopoulos>;
     dcat:keyword "trust"@en;
+    dct:source <https://doi.org/10.1007/978-3-030-33246-4_1>,
+               <https://dblp.org/rec/conf/vmbo/AmaralSGP21>,
+               <https://doi.org/10.1007/978-3-030-63479-7_6>,
+               <https://doi.org/10.1007/978-3-030-62522-1_25>;
     mod:designedForTask ocmv:ConceptualClarification;
     ocmv:context ocmv:Research;
-    dct:source <https://doi.org/10.1007/978-3-030-33246-4_1>, <https://dblp.org/rec/conf/vmbo/AmaralSGP21>, <https://doi.org/10.1007/978-3-030-63479-7_6>, <https://doi.org/10.1007/978-3-030-62522-1_25>;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/amaral2019rot"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/amaral2019rot"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:35:28.608937306Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:35:28.608937306Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/d88fe48c-d574-43b4-85d6-a6e1aeaa6726> dcat:distribution <https://w3id.org/ontouml-models/distribution/78713112-cf7e-45f1-8c74-c7b5906f5b7c/>, <https://w3id.org/ontouml-models/distribution/7c83f03b-c170-49d2-9dd9-0a600be6cc96/>, <https://w3id.org/ontouml-models/distribution/48c920df-896e-43db-baa4-adcc206d1b3d/>, <https://w3id.org/ontouml-models/distribution/669a3a1a-fd31-436e-8f31-932b4119de47>, <https://w3id.org/ontouml-models/distribution/59c1c3b5-7621-45a0-b1b9-2538e01c1b3c>, <https://w3id.org/ontouml-models/distribution/56072ed6-b5ff-467d-8424-965d41535e23>, <https://w3id.org/ontouml-models/distribution/dc069a25-ecdb-400e-83e1-5e77a4286b28>, <https://w3id.org/ontouml-models/distribution/72eba497-015a-4513-8364-3f2db1d58a2e>, <https://w3id.org/ontouml-models/distribution/abfd6260-2036-4561-9aef-2e5699d19c0e>, <https://w3id.org/ontouml-models/distribution/2a78d0c1-b55f-49bf-a915-1490005b1de8>, <https://w3id.org/ontouml-models/distribution/412737ce-27ad-44af-a1ea-d25b919d0c5f>, <https://w3id.org/ontouml-models/distribution/aba47a58-1fa8-4281-a03c-5455bd860a03>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/d88fe48c-d574-43b4-85d6-a6e1aeaa6726> dcat:distribution <https://w3id.org/ontouml-models/distribution/78713112-cf7e-45f1-8c74-c7b5906f5b7c/>,
+                      <https://w3id.org/ontouml-models/distribution/7c83f03b-c170-49d2-9dd9-0a600be6cc96/>,
+                      <https://w3id.org/ontouml-models/distribution/48c920df-896e-43db-baa4-adcc206d1b3d/>,
+                      <https://w3id.org/ontouml-models/distribution/669a3a1a-fd31-436e-8f31-932b4119de47>,
+                      <https://w3id.org/ontouml-models/distribution/59c1c3b5-7621-45a0-b1b9-2538e01c1b3c>,
+                      <https://w3id.org/ontouml-models/distribution/56072ed6-b5ff-467d-8424-965d41535e23>,
+                      <https://w3id.org/ontouml-models/distribution/dc069a25-ecdb-400e-83e1-5e77a4286b28>,
+                      <https://w3id.org/ontouml-models/distribution/72eba497-015a-4513-8364-3f2db1d58a2e>,
+                      <https://w3id.org/ontouml-models/distribution/abfd6260-2036-4561-9aef-2e5699d19c0e>,
+                      <https://w3id.org/ontouml-models/distribution/2a78d0c1-b55f-49bf-a915-1490005b1de8>,
+                      <https://w3id.org/ontouml-models/distribution/412737ce-27ad-44af-a1ea-d25b919d0c5f>,
+                      <https://w3id.org/ontouml-models/distribution/aba47a58-1fa8-4281-a03c-5455bd860a03> .

--- a/models/amaral2020game-theory/metadata.ttl
+++ b/models/amaral2020game-theory/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/0d5ccd09-3436-4dba-831a-9c0b705bb4fa/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -18,14 +17,27 @@
     skos:editorialNote "The main contribution of the paper is based on the COVER ontology, which COVER was not reproduced. However, COVER is available in this dataset as a standalone contribution.";
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:contributor <https://dblp.org/pid/81/4277>, <https://dblp.org/pid/33/8219>, <https://dblp.org/pid/134/4947>, <https://dblp.org/pid/11/78>;
-    dcat:keyword "game theory"@en, "risk"@en, "value"@en, "enterprise architecture"@en;
+    dct:contributor <https://dblp.org/pid/81/4277>,
+                    <https://dblp.org/pid/33/8219>,
+                    <https://dblp.org/pid/134/4947>,
+                    <https://dblp.org/pid/11/78>;
+    dcat:keyword "game theory"@en,
+                 "risk"@en,
+                 "value"@en,
+                 "enterprise architecture"@en;
+    dct:source <https://doi.org/10.1007/978-3-030-74196-9_5>;
     mod:designedForTask ocmv:ConceptualClarification;
     ocmv:context ocmv:Research;
-    dct:source <https://doi.org/10.1007/978-3-030-74196-9_5>;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/amaral2020game-theory"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/amaral2020game-theory"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:35:49.3695402Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:35:49.3695402Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/0d5ccd09-3436-4dba-831a-9c0b705bb4fa> dcat:distribution <https://w3id.org/ontouml-models/distribution/ff7fb85f-71d4-4bb6-8d79-bebc5ddad162/>, <https://w3id.org/ontouml-models/distribution/73b8e2a0-2b4c-4faa-884a-a36d6c077421/>, <https://w3id.org/ontouml-models/distribution/719fa5ab-8045-4aa1-b8db-5cb7dd53456f/>, <https://w3id.org/ontouml-models/distribution/7936a7b1-234c-4726-8adf-88be63ef787e>, <https://w3id.org/ontouml-models/distribution/dd642af0-1c82-4d7f-bfcb-3db39f766dc6>, <https://w3id.org/ontouml-models/distribution/c3167bf8-90d3-4171-88f6-89896a1d2592>, <https://w3id.org/ontouml-models/distribution/700ab40c-0ed0-4868-86d9-a62c033f680f>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/0d5ccd09-3436-4dba-831a-9c0b705bb4fa> dcat:distribution <https://w3id.org/ontouml-models/distribution/ff7fb85f-71d4-4bb6-8d79-bebc5ddad162/>,
+                      <https://w3id.org/ontouml-models/distribution/73b8e2a0-2b4c-4faa-884a-a36d6c077421/>,
+                      <https://w3id.org/ontouml-models/distribution/719fa5ab-8045-4aa1-b8db-5cb7dd53456f/>,
+                      <https://w3id.org/ontouml-models/distribution/7936a7b1-234c-4726-8adf-88be63ef787e>,
+                      <https://w3id.org/ontouml-models/distribution/dd642af0-1c82-4d7f-bfcb-3db39f766dc6>,
+                      <https://w3id.org/ontouml-models/distribution/c3167bf8-90d3-4171-88f6-89896a1d2592>,
+                      <https://w3id.org/ontouml-models/distribution/700ab40c-0ed0-4868-86d9-a62c033f680f> .

--- a/models/amaral2020rome/metadata.ttl
+++ b/models/amaral2020rome/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/d7a95e79-d01a-42cd-b059-400f314a8038/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -20,14 +19,32 @@
     dct:language "en";
     dcat:landingPage <https://github.com/unibz-core/money-ontology>;
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:contributor <https://dblp.org/pid/81/4277>, <https://dblp.org/pid/134/4947>, <https://dblp.org/pid/11/78>, <https://dblp.org/pid/33/8219>, <https://dblp.org/pid/65/6778>;
-    dcat:keyword "money"@en, "virtual currencies"@en, "finance"@en;
+    dct:contributor <https://dblp.org/pid/81/4277>,
+                    <https://dblp.org/pid/134/4947>,
+                    <https://dblp.org/pid/11/78>,
+                    <https://dblp.org/pid/33/8219>,
+                    <https://dblp.org/pid/65/6778>;
+    dcat:keyword "money"@en,
+                 "virtual currencies"@en,
+                 "finance"@en;
+    dct:source <https://doi.org/10.1007/978-3-030-63479-7_16>,
+               <https://dblp.org/rec/conf/vmbo/AmaralSGPG20>,
+               <https://dblp.org/rec/conf/vmbo/AmaralSG21>;
     mod:designedForTask ocmv:ConceptualClarification;
     ocmv:context ocmv:Research;
-    dct:source <https://doi.org/10.1007/978-3-030-63479-7_16>, <https://dblp.org/rec/conf/vmbo/AmaralSGPG20>, <https://dblp.org/rec/conf/vmbo/AmaralSG21>;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/amaral2020rome"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/amaral2020rome"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:36:01.981831574Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:36:01.981831574Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/d7a95e79-d01a-42cd-b059-400f314a8038> dcat:distribution <https://w3id.org/ontouml-models/distribution/a46f55b3-84a1-4a39-a35f-f26fe9004ff0/>, <https://w3id.org/ontouml-models/distribution/b57526c2-c842-4d12-920a-d0bfd27037f1/>, <https://w3id.org/ontouml-models/distribution/df265f56-ac94-43cd-ac74-e18532cf1df0/>, <https://w3id.org/ontouml-models/distribution/10e9fd6a-4421-4e0a-91d5-8569201118ef>, <https://w3id.org/ontouml-models/distribution/3bf7ecd8-45d2-408f-9f98-bc5330f23c7b>, <https://w3id.org/ontouml-models/distribution/8c33b44d-465e-4d9b-a412-3f933c8ef7c0>, <https://w3id.org/ontouml-models/distribution/2175a9d5-0f0e-407c-9796-5f4165f8ef75>, <https://w3id.org/ontouml-models/distribution/385816cc-e7c2-4b52-8354-542f6dce62bd>, <https://w3id.org/ontouml-models/distribution/b6441c03-3c91-4cc5-9d4c-c2b48af40a62>, <https://w3id.org/ontouml-models/distribution/10afbfb0-9f66-4904-a2a2-16a3132f6671>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/d7a95e79-d01a-42cd-b059-400f314a8038> dcat:distribution <https://w3id.org/ontouml-models/distribution/a46f55b3-84a1-4a39-a35f-f26fe9004ff0/>,
+                      <https://w3id.org/ontouml-models/distribution/b57526c2-c842-4d12-920a-d0bfd27037f1/>,
+                      <https://w3id.org/ontouml-models/distribution/df265f56-ac94-43cd-ac74-e18532cf1df0/>,
+                      <https://w3id.org/ontouml-models/distribution/10e9fd6a-4421-4e0a-91d5-8569201118ef>,
+                      <https://w3id.org/ontouml-models/distribution/3bf7ecd8-45d2-408f-9f98-bc5330f23c7b>,
+                      <https://w3id.org/ontouml-models/distribution/8c33b44d-465e-4d9b-a412-3f933c8ef7c0>,
+                      <https://w3id.org/ontouml-models/distribution/2175a9d5-0f0e-407c-9796-5f4165f8ef75>,
+                      <https://w3id.org/ontouml-models/distribution/385816cc-e7c2-4b52-8354-542f6dce62bd>,
+                      <https://w3id.org/ontouml-models/distribution/b6441c03-3c91-4cc5-9d4c-c2b48af40a62>,
+                      <https://w3id.org/ontouml-models/distribution/10afbfb0-9f66-4904-a2a2-16a3132f6671> .

--- a/models/amaral2022ethical-requirements/metadata.ttl
+++ b/models/amaral2022ethical-requirements/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/407f7c94-9ebb-44f1-adef-47cc0c22d89d/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -18,14 +17,26 @@
     skos:editorialNote "Created from vpp file sent by one of the authors. The activity diagram and the COVER diagram were deleted from the vpp project. The model sanitizer was used for correcting the stereotypes. As requested by the authors, a type was corrected in one of the diagrams (\"Nonmaleficence\" was with written with s instead of c).";
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:contributor <https://dblp.org/pid/75/5043>, <https://dblp.org/pid/81/4277>, <https://dblp.org/pid/11/78>, <https://dblp.org/pid/m/JohnMylopoulos>;
-    dcat:keyword "requirements"@en, "ethics"@en, "software engineering"@en;
+    dct:contributor <https://dblp.org/pid/75/5043>,
+                    <https://dblp.org/pid/81/4277>,
+                    <https://dblp.org/pid/11/78>,
+                    <https://dblp.org/pid/m/JohnMylopoulos>;
+    dcat:keyword "requirements"@en,
+                 "ethics"@en,
+                 "software engineering"@en;
+    dct:source <https://doi.org/10.1007/978-3-031-07475-2_15>;
     mod:designedForTask ocmv:ConceptualClarification;
     ocmv:context ocmv:Research;
-    dct:source <https://doi.org/10.1007/978-3-031-07475-2_15>;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/amaral2022ethical-requirements"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/amaral2022ethical-requirements"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:36:19.551858786Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:36:19.551858786Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/407f7c94-9ebb-44f1-adef-47cc0c22d89d> dcat:distribution <https://w3id.org/ontouml-models/distribution/b92781f6-ac50-40ef-b15b-5f901f20bac8/>, <https://w3id.org/ontouml-models/distribution/76593568-c576-4098-b845-c2335fa3e6b3/>, <https://w3id.org/ontouml-models/distribution/327eb447-9f42-4d2b-ae76-0255ea71a42a/>, <https://w3id.org/ontouml-models/distribution/dd5cd5a3-ec14-45a5-857a-544088f329cd>, <https://w3id.org/ontouml-models/distribution/e1f480b6-4ca6-4ec3-af33-91abf439ac0f>, <https://w3id.org/ontouml-models/distribution/165983b9-92a4-4257-b803-46864ea1fcab>, <https://w3id.org/ontouml-models/distribution/9ee6a4cb-487a-41e1-a925-c84669a02b2a>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/407f7c94-9ebb-44f1-adef-47cc0c22d89d> dcat:distribution <https://w3id.org/ontouml-models/distribution/b92781f6-ac50-40ef-b15b-5f901f20bac8/>,
+                      <https://w3id.org/ontouml-models/distribution/76593568-c576-4098-b845-c2335fa3e6b3/>,
+                      <https://w3id.org/ontouml-models/distribution/327eb447-9f42-4d2b-ae76-0255ea71a42a/>,
+                      <https://w3id.org/ontouml-models/distribution/dd5cd5a3-ec14-45a5-857a-544088f329cd>,
+                      <https://w3id.org/ontouml-models/distribution/e1f480b6-4ca6-4ec3-af33-91abf439ac0f>,
+                      <https://w3id.org/ontouml-models/distribution/165983b9-92a4-4257-b803-46864ea1fcab>,
+                      <https://w3id.org/ontouml-models/distribution/9ee6a4cb-487a-41e1-a925-c84669a02b2a> .

--- a/models/andersson2018value-ascription/metadata.ttl
+++ b/models/andersson2018value-ascription/metadata.ttl
@@ -1,32 +1,40 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/3df10e52-a7e6-4e42-a5e5-c34495a5826b/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:title "Value Ascription Ontology";
     dct:issued "2018"^^xsd:gYear;
     dct:modified "2018"^^xsd:gYear;
     dcat:theme lcc:H;
-    skos:editorialNote "There is a previous publication on Value Ascription Ontology from the same authors, which even includes a more extensive use of OntoUML. However, it was decided to focus on this one as it seems to represent a step away from the original proposal.\n";
+    skos:editorialNote """There is a previous publication on Value Ascription Ontology from the same authors, which even includes a more extensive use of OntoUML. However, it was decided to focus on this one as it seems to represent a step away from the original proposal.
+""";
     dct:language "en";
-    dct:contributor <https://dblp.org/pid/g/JaapGordijn>, <https://dblp.org/pid/p/ErikProper>;
-    dcat:keyword "economics"@en, "value"@en, "value ascription"@en;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    dct:contributor <https://dblp.org/pid/g/JaapGordijn>,
+                    <https://dblp.org/pid/p/ErikProper>;
+    dcat:keyword "economics"@en,
+                 "value"@en,
+                 "value ascription"@en;
+    dct:source <https://dblp.org/rec/conf/vmbo/2018>;
     mod:designedForTask ocmv:ConceptualClarification;
     ocmv:context ocmv:Research;
-    dct:source <https://dblp.org/rec/conf/vmbo/2018>;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/andersson2018value-ascription"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/andersson2018value-ascription"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:36:32.310917693Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:36:32.310917693Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/3df10e52-a7e6-4e42-a5e5-c34495a5826b> dcat:distribution <https://w3id.org/ontouml-models/distribution/94303827-76ed-41cc-b2e1-4298b8a18a65/>, <https://w3id.org/ontouml-models/distribution/9d8ead3b-b161-46e4-8a6a-83bf35d08c02/>, <https://w3id.org/ontouml-models/distribution/80cbc2af-8276-4d52-a36f-061170dc121b/>, <https://w3id.org/ontouml-models/distribution/4d50c81a-e5fe-47a8-927f-ef85ca3313a8>, <https://w3id.org/ontouml-models/distribution/34e886d7-1125-479a-9bec-d68a50ee3452>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/3df10e52-a7e6-4e42-a5e5-c34495a5826b> dcat:distribution <https://w3id.org/ontouml-models/distribution/94303827-76ed-41cc-b2e1-4298b8a18a65/>,
+                      <https://w3id.org/ontouml-models/distribution/9d8ead3b-b161-46e4-8a6a-83bf35d08c02/>,
+                      <https://w3id.org/ontouml-models/distribution/80cbc2af-8276-4d52-a36f-061170dc121b/>,
+                      <https://w3id.org/ontouml-models/distribution/4d50c81a-e5fe-47a8-927f-ef85ca3313a8>,
+                      <https://w3id.org/ontouml-models/distribution/34e886d7-1125-479a-9bec-d68a50ee3452> .

--- a/models/andrade2023integracao/metadata.ttl
+++ b/models/andrade2023integracao/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/1b6b8e8d-92a6-4be9-b6d4-106f9ccb15a0/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -18,13 +17,24 @@
     skos:editorialNote "The original name of the ontology, in portuguese, is \"Ontologia para Integração de Dados de Publicações Científicas\".";
     dct:language "pt-br";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:contributor <https://www.linkedin.com/in/jo%C3%A3o-paulo-andrade-4ba425173>, <https://dblp.org/pid/65/4688>, <https://dblp.org/pid/37/528>;
-    dcat:keyword "scientific publishing"@en, "sciences"@en, "publishing"@en;
-    mod:designedForTask ocmv:ConceptualClarification, ocmv:SoftwareEngineering;
+    dct:contributor <https://www.linkedin.com/in/jo%C3%A3o-paulo-andrade-4ba425173>,
+                    <https://dblp.org/pid/65/4688>,
+                    <https://dblp.org/pid/37/528>;
+    dcat:keyword "scientific publishing"@en,
+                 "sciences"@en,
+                 "publishing"@en;
+    mod:designedForTask ocmv:ConceptualClarification,
+                        ocmv:SoftwareEngineering;
     ocmv:context ocmv:Research;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/andrade2023integracao"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/andrade2023integracao"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:36:42.030304566Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:36:42.030304566Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/1b6b8e8d-92a6-4be9-b6d4-106f9ccb15a0> dcat:distribution <https://w3id.org/ontouml-models/distribution/2e6cdb7f-31a1-4b96-89be-fec35d1554a2/>, <https://w3id.org/ontouml-models/distribution/b3076957-2199-4612-88fa-96691c5ab4d7/>, <https://w3id.org/ontouml-models/distribution/884901a2-a36e-4e5e-8134-59df4e387497/>, <https://w3id.org/ontouml-models/distribution/2988efa5-1aa8-4a68-93a9-38c23f983a25>, <https://w3id.org/ontouml-models/distribution/e0e76abe-a731-464a-a0f2-b5dfc997efb7>, <https://w3id.org/ontouml-models/distribution/7043cde0-963f-49c8-a244-66e77cee8c4c>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/1b6b8e8d-92a6-4be9-b6d4-106f9ccb15a0> dcat:distribution <https://w3id.org/ontouml-models/distribution/2e6cdb7f-31a1-4b96-89be-fec35d1554a2/>,
+                      <https://w3id.org/ontouml-models/distribution/b3076957-2199-4612-88fa-96691c5ab4d7/>,
+                      <https://w3id.org/ontouml-models/distribution/884901a2-a36e-4e5e-8134-59df4e387497/>,
+                      <https://w3id.org/ontouml-models/distribution/2988efa5-1aa8-4a68-93a9-38c23f983a25>,
+                      <https://w3id.org/ontouml-models/distribution/e0e76abe-a731-464a-a0f2-b5dfc997efb7>,
+                      <https://w3id.org/ontouml-models/distribution/7043cde0-963f-49c8-a244-66e77cee8c4c> .

--- a/models/aristotle-ontology2019/metadata.ttl
+++ b/models/aristotle-ontology2019/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/667449b5-c595-4ecf-84b3-c461252353c6/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -21,12 +20,35 @@
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:contributor <https://a-komaromi.medium.com>;
     dcat:keyword "philosophy"@en;
+    dct:source <https://philosophy-models.blog/tag/aristotle-384-322-bc/>;
     mod:designedForTask ocmv:ConceptualClarification;
     ocmv:context ocmv:Research;
-    dct:source <https://philosophy-models.blog/tag/aristotle-384-322-bc/>;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/aristotle-ontology2019"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/aristotle-ontology2019"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:36:54.015704212Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:36:54.015704212Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/667449b5-c595-4ecf-84b3-c461252353c6> dcat:distribution <https://w3id.org/ontouml-models/distribution/f1e201ef-d234-4922-abfc-a21ef6a4e4a8/>, <https://w3id.org/ontouml-models/distribution/05566017-de04-491c-b822-642a28611696/>, <https://w3id.org/ontouml-models/distribution/9424e194-84ab-41b0-8589-a53ac7b0ff85/>, <https://w3id.org/ontouml-models/distribution/af8d7eb4-c51b-4fcb-b95d-dfa811b8c349>, <https://w3id.org/ontouml-models/distribution/6ce1db1e-0186-40de-a995-892c7b14dd89>, <https://w3id.org/ontouml-models/distribution/23fba2ca-eaeb-41b9-b023-567ec00fbf36>, <https://w3id.org/ontouml-models/distribution/b0aed13d-6a8c-4c70-9bde-1b1872466190>, <https://w3id.org/ontouml-models/distribution/b17dbda7-799f-4c89-857d-be76196ad865>, <https://w3id.org/ontouml-models/distribution/0d0f9d8b-6b31-4028-9052-ba573f1ab924>, <https://w3id.org/ontouml-models/distribution/0a74d2d5-6434-4504-b0ab-7720e8488c72>, <https://w3id.org/ontouml-models/distribution/74de52f1-2573-49ba-ab36-ad589c4bd9ad>, <https://w3id.org/ontouml-models/distribution/1d24a6e7-8c40-4316-b020-c8757e0185e8>, <https://w3id.org/ontouml-models/distribution/b09fd3c9-d969-4818-aa9c-20d2d3cb29ac>, <https://w3id.org/ontouml-models/distribution/232daa4f-f76a-455a-9113-9cca23886191>, <https://w3id.org/ontouml-models/distribution/87a7d6ec-81c9-4ff8-b5e1-3e93c90f1081>, <https://w3id.org/ontouml-models/distribution/ab814ac1-1c25-48ce-8e59-24418fbf95a0>, <https://w3id.org/ontouml-models/distribution/dcee94b7-621e-41ec-83d9-36f854ca8708>, <https://w3id.org/ontouml-models/distribution/417c9e6d-b2e4-4427-b880-ce0736946b3a>, <https://w3id.org/ontouml-models/distribution/43627d54-ffa4-4b6a-9418-9d86787f0446>, <https://w3id.org/ontouml-models/distribution/8c6824c3-f589-4b14-988a-27c348684343>, <https://w3id.org/ontouml-models/distribution/f29877bc-f858-4f24-9caf-58f1843e6488>, <https://w3id.org/ontouml-models/distribution/2fc0542e-1221-4e94-be83-5e2cc9f4c385>, <https://w3id.org/ontouml-models/distribution/b42956ef-8d8e-4839-8f1b-3ee64f4e0c22>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/667449b5-c595-4ecf-84b3-c461252353c6> dcat:distribution <https://w3id.org/ontouml-models/distribution/f1e201ef-d234-4922-abfc-a21ef6a4e4a8/>,
+                      <https://w3id.org/ontouml-models/distribution/05566017-de04-491c-b822-642a28611696/>,
+                      <https://w3id.org/ontouml-models/distribution/9424e194-84ab-41b0-8589-a53ac7b0ff85/>,
+                      <https://w3id.org/ontouml-models/distribution/af8d7eb4-c51b-4fcb-b95d-dfa811b8c349>,
+                      <https://w3id.org/ontouml-models/distribution/6ce1db1e-0186-40de-a995-892c7b14dd89>,
+                      <https://w3id.org/ontouml-models/distribution/23fba2ca-eaeb-41b9-b023-567ec00fbf36>,
+                      <https://w3id.org/ontouml-models/distribution/b0aed13d-6a8c-4c70-9bde-1b1872466190>,
+                      <https://w3id.org/ontouml-models/distribution/b17dbda7-799f-4c89-857d-be76196ad865>,
+                      <https://w3id.org/ontouml-models/distribution/0d0f9d8b-6b31-4028-9052-ba573f1ab924>,
+                      <https://w3id.org/ontouml-models/distribution/0a74d2d5-6434-4504-b0ab-7720e8488c72>,
+                      <https://w3id.org/ontouml-models/distribution/74de52f1-2573-49ba-ab36-ad589c4bd9ad>,
+                      <https://w3id.org/ontouml-models/distribution/1d24a6e7-8c40-4316-b020-c8757e0185e8>,
+                      <https://w3id.org/ontouml-models/distribution/b09fd3c9-d969-4818-aa9c-20d2d3cb29ac>,
+                      <https://w3id.org/ontouml-models/distribution/232daa4f-f76a-455a-9113-9cca23886191>,
+                      <https://w3id.org/ontouml-models/distribution/87a7d6ec-81c9-4ff8-b5e1-3e93c90f1081>,
+                      <https://w3id.org/ontouml-models/distribution/ab814ac1-1c25-48ce-8e59-24418fbf95a0>,
+                      <https://w3id.org/ontouml-models/distribution/dcee94b7-621e-41ec-83d9-36f854ca8708>,
+                      <https://w3id.org/ontouml-models/distribution/417c9e6d-b2e4-4427-b880-ce0736946b3a>,
+                      <https://w3id.org/ontouml-models/distribution/43627d54-ffa4-4b6a-9418-9d86787f0446>,
+                      <https://w3id.org/ontouml-models/distribution/8c6824c3-f589-4b14-988a-27c348684343>,
+                      <https://w3id.org/ontouml-models/distribution/f29877bc-f858-4f24-9caf-58f1843e6488>,
+                      <https://w3id.org/ontouml-models/distribution/2fc0542e-1221-4e94-be83-5e2cc9f4c385>,
+                      <https://w3id.org/ontouml-models/distribution/b42956ef-8d8e-4839-8f1b-3ee64f4e0c22> .

--- a/models/bank-account2013/metadata.ttl
+++ b/models/bank-account2013/metadata.ttl
@@ -1,35 +1,38 @@
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/model/bank-account2013/> a dcat:Dataset, mod:SemanticArtefact;
+<https://w3id.org/ontouml-models/model/bank-account2013/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
+    dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
     dct:title "Bank Account Ontology";
     dct:issued "2013"^^xsd:gYear;
     dcat:theme lcc:H;
-    skos:editorialNote "Ontology created during an Ontology Engineering lecture by students who wanted to remain anonymous. The ontology was build in a different editor tool and imported to Visual Paradigm, the current diagrammation may not exacly match the original one.";
+    skos:editorialNote "Ontology created during an Ontology Engineering lecture by students who wanted to remain anonymous. The ontology was build in a different editor tool and imported to Visual Paradigm, the current diagrammation may not exactly match the original one.";
     dct:language "pt-br";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    mod:designedForTask ocmv:ConceptualClarification, ocmv:Learning;
-    ocmv:context ocmv:Classroom.
-<https://w3id.org/ontouml-models/model/bank-account2013/> dcat:distribution <https://w3id.org/ontouml-models/model/bank-account2013/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/bank-account2013/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Bank Account Ontology\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/bank-account2013/ontology.ttl>.
-<https://w3id.org/ontouml-models/model/bank-account2013/> dcat:distribution <https://w3id.org/ontouml-models/model/bank-account2013/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/bank-account2013/distribution/ttl> a dcat:Distribution;
-    dct:title "JSON distribution of \"Bank Account Ontology\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/bank-account2013/ontology.json>.
-<https://w3id.org/ontouml-models/model/bank-account2013/> dcat:distribution <https://w3id.org/ontouml-models/model/bank-account2013/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/bank-account2013/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Bank Account Ontology\""@en;
-    dcat:mediaType <https://www.visual-paradigm.com/vpp>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/bank-account2013/ontology.vpp>.
+    dcat:keyword "bank account"@en,
+                 "finance"@en;
+    mod:designedForTask ocmv:ConceptualClarification,
+                        ocmv:Learning;
+    ocmv:context ocmv:Classroom;
+    ocmv:representationStyle ocmv:OntoumlStyle;
+    ocmv:ontologyType ocmv:Domain;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/bank-account2013"^^xsd:anyURI;
+    fdpo:metadataIssued "2026-06-23T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/bank-account2013/> dcat:distribution <https://w3id.org/ontouml-models/model/bank-account2013/distribution/ttl>,
+                      <https://www.iana.org/assignments/media-types/text/turtle>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/bank-account2013/ontology.ttl>,
+                      <https://w3id.org/ontouml-models/model/bank-account2013/>,
+                      <https://www.iana.org/assignments/media-types/application/json>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/bank-account2013/ontology.json>,
+                      <https://www.visual-paradigm.com/vpp>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/bank-account2013/ontology.vpp> .

--- a/models/bank-model/metadata.ttl
+++ b/models/bank-model/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/db57ef4e-b335-4fcd-9935-609e932ba8e8/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -18,12 +17,18 @@
     skos:editorialNote "model developed in classroom. The author asked to remain anonymous.";
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dcat:keyword "banking"@en, "finance"@en;
+    dcat:keyword "banking"@en,
+                 "finance"@en;
     mod:designedForTask ocmv:Learning;
     ocmv:context ocmv:Classroom;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/bank-model"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/bank-model"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:37:32.234964024Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:37:32.234964024Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/db57ef4e-b335-4fcd-9935-609e932ba8e8> dcat:distribution <https://w3id.org/ontouml-models/distribution/3212e572-0bf6-43cd-824c-d533db24bd19/>, <https://w3id.org/ontouml-models/distribution/158a3063-48a4-4f2a-914a-abb9f6f8dff1/>, <https://w3id.org/ontouml-models/distribution/5637c70a-a015-40dc-bae6-03b8966fc355/>, <https://w3id.org/ontouml-models/distribution/08ee5527-2216-409e-9cd5-3f6460455699>, <https://w3id.org/ontouml-models/distribution/3e3d2bb5-a7c0-498c-92d4-44605794a525>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/db57ef4e-b335-4fcd-9935-609e932ba8e8> dcat:distribution <https://w3id.org/ontouml-models/distribution/3212e572-0bf6-43cd-824c-d533db24bd19/>,
+                      <https://w3id.org/ontouml-models/distribution/158a3063-48a4-4f2a-914a-abb9f6f8dff1/>,
+                      <https://w3id.org/ontouml-models/distribution/5637c70a-a015-40dc-bae6-03b8966fc355/>,
+                      <https://w3id.org/ontouml-models/distribution/08ee5527-2216-409e-9cd5-3f6460455699>,
+                      <https://w3id.org/ontouml-models/distribution/3e3d2bb5-a7c0-498c-92d4-44605794a525> .

--- a/models/barcelos2013normative-acts/metadata.ttl
+++ b/models/barcelos2013normative-acts/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/bbf816c7-da70-4f18-9c45-376612673f38/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -19,14 +18,30 @@
     dct:language "en";
     dcat:landingPage <https://github.com/unibz-core/Normative_Acts_Ontology>;
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:contributor <https://dblp.org/pid/96/8280>, <https://dblp.org/pid/75/5043>, <https://dblp.org/pid/06/10125>;
+    dct:contributor <https://dblp.org/pid/96/8280>,
+                    <https://dblp.org/pid/75/5043>,
+                    <https://dblp.org/pid/06/10125>;
     dcat:keyword "normative acts"@en;
-    mod:designedForTask ocmv:ConceptualClarification;
-    ocmv:context ocmv:Research, ocmv:Industry;
     dct:source <https://dblp.org/rec/conf/ontobras/BarcelosGG13>;
+    mod:designedForTask ocmv:ConceptualClarification;
+    ocmv:context ocmv:Research,
+                 ocmv:Industry;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/barcelos2013normative-acts"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/barcelos2013normative-acts"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:37:41.666245145Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:37:41.666245145Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/bbf816c7-da70-4f18-9c45-376612673f38> dcat:distribution <https://w3id.org/ontouml-models/distribution/2092feea-b4b2-4c24-9e7b-1f6f829c9808/>, <https://w3id.org/ontouml-models/distribution/1aa0868e-ad4d-4cf9-ab11-146a71bd747e/>, <https://w3id.org/ontouml-models/distribution/30dc6894-f641-46ab-84c6-e52ca042b1ca/>, <https://w3id.org/ontouml-models/distribution/df2b0244-8a10-4d87-b016-ad360c9fa405>, <https://w3id.org/ontouml-models/distribution/e12b34fc-3366-4e94-8af6-4bee923e947c>, <https://w3id.org/ontouml-models/distribution/f55e0aa1-c6d9-46a0-8619-5a8af056d964>, <https://w3id.org/ontouml-models/distribution/7f10d4f9-171b-4890-be8a-ee27d33186ff>, <https://w3id.org/ontouml-models/distribution/57b6b0e0-cce2-40ff-a159-d54ef734999b>, <https://w3id.org/ontouml-models/distribution/c5f6a140-811c-44c0-877d-f3cb11a0b5f8>, <https://w3id.org/ontouml-models/distribution/bf7dbdf4-aa05-426d-9dac-a15df0ff470b>, <https://w3id.org/ontouml-models/distribution/e8024bce-ef69-44ef-9991-56159f1734a9>, <https://w3id.org/ontouml-models/distribution/8560b605-57f2-4b59-a7d3-95a6717114f1>, <https://w3id.org/ontouml-models/distribution/441f96da-6b4c-4cf0-bed5-41f2dc8438c6>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/bbf816c7-da70-4f18-9c45-376612673f38> dcat:distribution <https://w3id.org/ontouml-models/distribution/2092feea-b4b2-4c24-9e7b-1f6f829c9808/>,
+                      <https://w3id.org/ontouml-models/distribution/1aa0868e-ad4d-4cf9-ab11-146a71bd747e/>,
+                      <https://w3id.org/ontouml-models/distribution/30dc6894-f641-46ab-84c6-e52ca042b1ca/>,
+                      <https://w3id.org/ontouml-models/distribution/df2b0244-8a10-4d87-b016-ad360c9fa405>,
+                      <https://w3id.org/ontouml-models/distribution/e12b34fc-3366-4e94-8af6-4bee923e947c>,
+                      <https://w3id.org/ontouml-models/distribution/f55e0aa1-c6d9-46a0-8619-5a8af056d964>,
+                      <https://w3id.org/ontouml-models/distribution/7f10d4f9-171b-4890-be8a-ee27d33186ff>,
+                      <https://w3id.org/ontouml-models/distribution/57b6b0e0-cce2-40ff-a159-d54ef734999b>,
+                      <https://w3id.org/ontouml-models/distribution/c5f6a140-811c-44c0-877d-f3cb11a0b5f8>,
+                      <https://w3id.org/ontouml-models/distribution/bf7dbdf4-aa05-426d-9dac-a15df0ff470b>,
+                      <https://w3id.org/ontouml-models/distribution/e8024bce-ef69-44ef-9991-56159f1734a9>,
+                      <https://w3id.org/ontouml-models/distribution/8560b605-57f2-4b59-a7d3-95a6717114f1>,
+                      <https://w3id.org/ontouml-models/distribution/441f96da-6b4c-4cf0-bed5-41f2dc8438c6> .

--- a/models/barcelos2015transport-networks/metadata.ttl
+++ b/models/barcelos2015transport-networks/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/ff3e16d6-8349-4bea-81e1-c1213e652170/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -20,13 +19,201 @@
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:contributor <https://dblp.org/pid/96/8280>;
-    dcat:keyword "networks"@en, "transport networks"@en, "itu-t g.805"@en;
-    mod:designedForTask ocmv:ConceptualClarification, ocmv:Interoperability;
-    ocmv:context ocmv:Research;
+    dcat:keyword "networks"@en,
+                 "transport networks"@en,
+                 "itu-t g.805"@en;
     dct:source <http://repositorio.ufes.br/handle/10/9712>;
+    mod:designedForTask ocmv:ConceptualClarification,
+                        ocmv:Interoperability;
+    ocmv:context ocmv:Research;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/barcelos2015transport-networks"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/barcelos2015transport-networks"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:38:05.756485013Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:38:05.756485013Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/ff3e16d6-8349-4bea-81e1-c1213e652170> dcat:distribution <https://w3id.org/ontouml-models/distribution/6a4ad553-2143-4fcd-a636-82d693f1c149/>, <https://w3id.org/ontouml-models/distribution/c4d18b0a-e891-4b5b-8e41-aa913f8ebdfd/>, <https://w3id.org/ontouml-models/distribution/f6cabca7-35e8-4f2a-8f5a-660f1aff3700/>, <https://w3id.org/ontouml-models/distribution/ba77ee11-c2dd-4962-8fe3-a6d18350fc6a>, <https://w3id.org/ontouml-models/distribution/4364c4c1-0e7f-449d-8d8f-01eb2b9b2899>, <https://w3id.org/ontouml-models/distribution/582ff060-5734-4267-941b-00afb73c3042>, <https://w3id.org/ontouml-models/distribution/976211cb-cb3d-442e-8823-6e9a4c85b7d0>, <https://w3id.org/ontouml-models/distribution/4dea65fc-7686-4730-8d56-45d8afa40100>, <https://w3id.org/ontouml-models/distribution/e4e2659f-78b9-4dce-b9a0-c912efb1e7bf>, <https://w3id.org/ontouml-models/distribution/fc22151c-7269-4e9c-b7b6-e0f2f7278aba>, <https://w3id.org/ontouml-models/distribution/382a12ae-3988-4143-a9e7-60df211a224c>, <https://w3id.org/ontouml-models/distribution/759795d2-4f0a-4222-898a-7e0d621ef498>, <https://w3id.org/ontouml-models/distribution/ec0ab08c-2e73-494c-95f3-0144943e1119>, <https://w3id.org/ontouml-models/distribution/dcc2379e-cd5b-4e1d-9fa4-088cbdb155bc>, <https://w3id.org/ontouml-models/distribution/74595a58-6f10-4111-bd88-cb06ba78be7b>, <https://w3id.org/ontouml-models/distribution/45d96840-3fbc-41f6-aa3d-53a2882be718>, <https://w3id.org/ontouml-models/distribution/9b1c8e30-93e7-41c6-9fdc-95d33fef9cac>, <https://w3id.org/ontouml-models/distribution/2212db64-0dbe-4b81-8165-33abc9995d6a>, <https://w3id.org/ontouml-models/distribution/150580e8-f544-47ac-ba03-7833ebe02402>, <https://w3id.org/ontouml-models/distribution/1e1dc2e2-b2ce-43c2-83c9-5b27e55e8491>, <https://w3id.org/ontouml-models/distribution/17f87033-c2de-448a-af51-ea7cc3d9db36>, <https://w3id.org/ontouml-models/distribution/7e05619f-2340-49f8-84dd-597eb786137d>, <https://w3id.org/ontouml-models/distribution/466f5510-dd36-4a76-b4be-d4a2ef0734fa>, <https://w3id.org/ontouml-models/distribution/620af721-32ca-48f9-b88f-374f85bca98b>, <https://w3id.org/ontouml-models/distribution/4fdf51e9-4319-46d5-b2e7-8210372e4e38>, <https://w3id.org/ontouml-models/distribution/91b7f1ee-7fd8-4daf-8dc2-84c2b9365806>, <https://w3id.org/ontouml-models/distribution/042d81dc-5dcd-4e4c-b369-a466c30c327a>, <https://w3id.org/ontouml-models/distribution/525df4ed-5957-4cbc-9d7f-e08bcf995341>, <https://w3id.org/ontouml-models/distribution/6e80297e-1bd0-491b-bb91-1a15f7d6b2f7>, <https://w3id.org/ontouml-models/distribution/c4302e19-0f94-4f46-b859-501efc2f3ddc>, <https://w3id.org/ontouml-models/distribution/75d22929-73e8-4b95-871c-b97b0e0025f0>, <https://w3id.org/ontouml-models/distribution/7211cf9b-519b-4b17-adad-6833b24c113f>, <https://w3id.org/ontouml-models/distribution/e00385d8-1d3f-4076-b29c-b5b759386680>, <https://w3id.org/ontouml-models/distribution/9d753518-1b18-428d-8ca9-36064bf2c0fd>, <https://w3id.org/ontouml-models/distribution/411a017c-64df-41d3-be73-9e5ec67873d5>, <https://w3id.org/ontouml-models/distribution/8ae31a53-219c-476d-9d2b-6050ed291573>, <https://w3id.org/ontouml-models/distribution/dfb4a070-92e1-4a82-9004-22742d53a703>, <https://w3id.org/ontouml-models/distribution/c675af17-c4c8-4c1a-8ba7-35a212df3972>, <https://w3id.org/ontouml-models/distribution/0c368651-a6ff-4017-af40-a43c7e95c292>, <https://w3id.org/ontouml-models/distribution/358136b4-d2dc-45ad-ab9f-1a423bab9f1f>, <https://w3id.org/ontouml-models/distribution/02dc70bd-93b2-467a-bd05-18f93178ba7e>, <https://w3id.org/ontouml-models/distribution/5b9ab117-a940-4a38-bdde-ad38cedda323>, <https://w3id.org/ontouml-models/distribution/0f12540e-7e3d-4c99-9d75-3587d3b52bf3>, <https://w3id.org/ontouml-models/distribution/27c5c821-12ba-4eb6-acd0-d3a79d83e342>, <https://w3id.org/ontouml-models/distribution/4fe0ebfa-0bc8-4caa-ae2d-fd5cde6235c3>, <https://w3id.org/ontouml-models/distribution/1558416c-ad02-4bf2-b588-6dd5b1f6d88a>, <https://w3id.org/ontouml-models/distribution/ffb418f9-fa21-47ce-9175-8c325316407c>, <https://w3id.org/ontouml-models/distribution/df344924-8a1e-464f-a058-562d14837677>, <https://w3id.org/ontouml-models/distribution/15401ced-d414-436d-91ac-66ed6c70685d>, <https://w3id.org/ontouml-models/distribution/fe7646ff-6d03-4292-a576-8f2303de14aa>, <https://w3id.org/ontouml-models/distribution/7ad34580-c29b-4d96-8261-cc8a1f8d18c2>, <https://w3id.org/ontouml-models/distribution/d1feaf90-3c0a-45be-ab35-0e2f4e4eb537>, <https://w3id.org/ontouml-models/distribution/b0aa02f9-ea75-413b-b085-b100736185e7>, <https://w3id.org/ontouml-models/distribution/4fbc3ad0-aa75-4f04-a165-ca812242ce96>, <https://w3id.org/ontouml-models/distribution/adf658ba-a8db-4a61-9dc8-f31b2999ee38>, <https://w3id.org/ontouml-models/distribution/54841adf-6083-410a-ac28-a6b66613e038>, <https://w3id.org/ontouml-models/distribution/4547a611-965b-4b59-8238-787c6107fd33>, <https://w3id.org/ontouml-models/distribution/ddd2fc1f-beef-4461-ba9c-63e3a1c3a45c>, <https://w3id.org/ontouml-models/distribution/238bd9cb-81e2-46dd-8e76-0206217766c0>, <https://w3id.org/ontouml-models/distribution/1654fb13-353e-40ef-a176-807188643cc7>, <https://w3id.org/ontouml-models/distribution/478c28d3-9942-44a6-aea2-4fd5c421d8bc>, <https://w3id.org/ontouml-models/distribution/ff8fcac3-ce7f-402d-a330-cf905fa59f33>, <https://w3id.org/ontouml-models/distribution/86e6354f-e2a1-4e62-b8ba-402ff5f1f6e0>, <https://w3id.org/ontouml-models/distribution/a29f2c07-f706-46ee-944b-bdbfe4397f62>, <https://w3id.org/ontouml-models/distribution/61318928-050a-4489-adfb-e93cf4a22c9b>, <https://w3id.org/ontouml-models/distribution/9ab78b05-61a4-4448-a34f-57ba5e1f43b3>, <https://w3id.org/ontouml-models/distribution/2ab6d654-a413-44ac-b6fd-bed4bf909da9>, <https://w3id.org/ontouml-models/distribution/01eaf833-b8e2-4d20-8ceb-66ae4bd421a2>, <https://w3id.org/ontouml-models/distribution/51a09cad-ec66-41c9-91a4-61732b946aa7>, <https://w3id.org/ontouml-models/distribution/a95dc1af-24fb-42b8-b543-84444947243d>, <https://w3id.org/ontouml-models/distribution/9691f1a0-412c-4504-ac8d-0f596ddd17ba>, <https://w3id.org/ontouml-models/distribution/4e5d6dd7-73e2-40a1-92f0-1205b877e118>, <https://w3id.org/ontouml-models/distribution/3236ad7c-e033-40b4-8ebe-0eaff7fb6870>, <https://w3id.org/ontouml-models/distribution/18e54698-253a-4908-ae67-ba20243b1615>, <https://w3id.org/ontouml-models/distribution/389f3614-b3de-41d8-a21f-155728139d6e>, <https://w3id.org/ontouml-models/distribution/7ee5b4af-0743-4b84-aa06-b5fd0f6e4377>, <https://w3id.org/ontouml-models/distribution/22aae069-5775-4a86-a448-3a10e0466f7d>, <https://w3id.org/ontouml-models/distribution/2d57cf1f-b3ff-474f-891c-0cf482232b16>, <https://w3id.org/ontouml-models/distribution/81992b06-e338-41c8-975d-287850f62ad5>, <https://w3id.org/ontouml-models/distribution/077d8d31-8729-4ab4-9ea2-494d08c165bf>, <https://w3id.org/ontouml-models/distribution/3069c4e0-5c98-436f-8db8-f0c01147ec7e>, <https://w3id.org/ontouml-models/distribution/34693771-4993-4432-b3cc-dad18a2c2713>, <https://w3id.org/ontouml-models/distribution/35df917b-18c3-4ce1-98e6-d5e18802b905>, <https://w3id.org/ontouml-models/distribution/e3a0e1ff-7bda-4f29-9581-e9b0e0e721e1>, <https://w3id.org/ontouml-models/distribution/c800d3cb-cdef-4fe4-b2c4-3f8ca17a3c8a>, <https://w3id.org/ontouml-models/distribution/70743640-e3cb-43c8-aaad-bc7abccc5fd4>, <https://w3id.org/ontouml-models/distribution/bb3c7db5-344d-4be1-b8eb-36a2d3c1a185>, <https://w3id.org/ontouml-models/distribution/6409c1a4-74d7-4c60-a734-b1856b881fb3>, <https://w3id.org/ontouml-models/distribution/0d59653a-94d9-4662-86ce-aade940ea556>, <https://w3id.org/ontouml-models/distribution/b7925303-73c8-4a82-8105-7bbb9094dbf6>, <https://w3id.org/ontouml-models/distribution/4d3d020c-9882-4165-9c3a-98d0bcad3a15>, <https://w3id.org/ontouml-models/distribution/39f11e9b-1baf-4fb2-967c-9d92a3160a3a>, <https://w3id.org/ontouml-models/distribution/752ae33c-fcab-4c30-b35f-7a5092046e9b>, <https://w3id.org/ontouml-models/distribution/a986c04b-27bb-4340-bdb9-166a472283bf>, <https://w3id.org/ontouml-models/distribution/3d6d0fe4-64f4-4fd1-922b-0e14ef8bb5b4>, <https://w3id.org/ontouml-models/distribution/fe075779-4958-4f19-9fc2-039c4873d49d>, <https://w3id.org/ontouml-models/distribution/456fb683-4d2d-4952-8175-f6a885b35d86>, <https://w3id.org/ontouml-models/distribution/7669db2b-29ae-4bc7-924c-ee89da179dc4>, <https://w3id.org/ontouml-models/distribution/021200c2-4aaf-4e8b-9857-570f73dff3ca>, <https://w3id.org/ontouml-models/distribution/f7167cce-4b7c-4b13-9104-e3b59fc875f0>, <https://w3id.org/ontouml-models/distribution/4a552f4d-2166-4b2b-94ea-ae413b9a5d97>, <https://w3id.org/ontouml-models/distribution/2360e75b-8720-4cd3-a6ec-585999b59658>, <https://w3id.org/ontouml-models/distribution/6efad562-3f38-4612-b760-a3ef70efad2a>, <https://w3id.org/ontouml-models/distribution/6a5fcd28-c397-49e5-a7a4-5337149e21bd>, <https://w3id.org/ontouml-models/distribution/cc873122-adea-4e3c-aaf9-81b45e5f3448>, <https://w3id.org/ontouml-models/distribution/ccc84f6d-f5de-4311-a69a-c4b8a97f9680>, <https://w3id.org/ontouml-models/distribution/06bef6a9-bd18-40be-a673-075801f7f44d>, <https://w3id.org/ontouml-models/distribution/f37cc55a-60d7-4437-a0da-166749eed7f2>, <https://w3id.org/ontouml-models/distribution/813e1c5d-e4bd-456a-835d-13c04ff8df2a>, <https://w3id.org/ontouml-models/distribution/edd0fa16-76be-4a07-84d2-5e2392b6744f>, <https://w3id.org/ontouml-models/distribution/a51df8c0-7812-4255-b5de-dd21112e2544>, <https://w3id.org/ontouml-models/distribution/a102b255-aaf4-4870-af1c-1c3decdc7bdd>, <https://w3id.org/ontouml-models/distribution/af1e117e-aace-446d-afe4-3b11b7f6e143>, <https://w3id.org/ontouml-models/distribution/5be3790b-6bd8-4f7c-a637-bcce50194ccd>, <https://w3id.org/ontouml-models/distribution/4e3b3be1-f589-4c5c-a09b-6e3f73518e72>, <https://w3id.org/ontouml-models/distribution/0289eb7b-9877-494d-978d-bb388b83b500>, <https://w3id.org/ontouml-models/distribution/18c7635b-bb0a-4476-bb17-2db287260a47>, <https://w3id.org/ontouml-models/distribution/f776a347-05c5-4792-9e52-287028c4eab1>, <https://w3id.org/ontouml-models/distribution/b013f9df-5ed6-4a14-ade5-3a6785a94bfd>, <https://w3id.org/ontouml-models/distribution/1d762395-3e06-4c88-9de0-11992702d38d>, <https://w3id.org/ontouml-models/distribution/2338e3e2-109e-41c8-8230-47ccdd03cc53>, <https://w3id.org/ontouml-models/distribution/0a16abcc-85f2-4cd9-a71e-8a0b0c8a7ca8>, <https://w3id.org/ontouml-models/distribution/09b5be5b-a566-4313-84cd-f32388915ffb>, <https://w3id.org/ontouml-models/distribution/74d479e5-a66d-4808-8bfd-debc63375655>, <https://w3id.org/ontouml-models/distribution/61e65ef6-6a99-4bcd-8f13-a728f39a3ec7>, <https://w3id.org/ontouml-models/distribution/42dc11b3-3cd1-48cc-b8e8-9420e17e875f>, <https://w3id.org/ontouml-models/distribution/1e25fa17-0d8b-458c-bc95-c7a58ebf5f66>, <https://w3id.org/ontouml-models/distribution/d43392f6-69f7-48f8-a407-4bb31b831e9c>, <https://w3id.org/ontouml-models/distribution/6bb7317e-c439-4f5d-ad7c-1ed95f41a24a>, <https://w3id.org/ontouml-models/distribution/9096df6c-ca9e-4afc-b3bf-70c12bd6a90b>, <https://w3id.org/ontouml-models/distribution/290296a5-d82e-4ddd-bc18-e588641b5de7>, <https://w3id.org/ontouml-models/distribution/78bac83c-918e-412f-bf11-5b7c2b725cbe>, <https://w3id.org/ontouml-models/distribution/7d169c52-cc73-426a-88d9-2abd742a06ee>, <https://w3id.org/ontouml-models/distribution/dd9ffa9e-c10e-4475-a278-f230691fe4e5>, <https://w3id.org/ontouml-models/distribution/53db55cc-ad29-4c00-abcf-129bb0b81d87>, <https://w3id.org/ontouml-models/distribution/90f27d66-d421-4ae7-9d99-9d12a182f272>, <https://w3id.org/ontouml-models/distribution/171caed8-98d9-4ad3-9977-e5744343bd23>, <https://w3id.org/ontouml-models/distribution/9b1180b3-baf8-43bc-92f6-f272fefdd481>, <https://w3id.org/ontouml-models/distribution/222782e4-ccc1-4cd6-99e0-ceb15018de5a>, <https://w3id.org/ontouml-models/distribution/17a9cf32-4430-4d69-9192-9b38a04e7e5d>, <https://w3id.org/ontouml-models/distribution/8b6c5742-eec0-4e77-956e-0cbba06a8db2>, <https://w3id.org/ontouml-models/distribution/d4e6094d-4a03-4eaf-888d-916d4e970678>, <https://w3id.org/ontouml-models/distribution/23230c66-ec06-412b-bcd3-93953c908e9e>, <https://w3id.org/ontouml-models/distribution/aa310827-80fe-421b-8e00-9d5cc44e36b1>, <https://w3id.org/ontouml-models/distribution/b4eed3a4-c6a3-4529-9d06-6e8d627d223c>, <https://w3id.org/ontouml-models/distribution/2e0319db-84c8-417e-9c6a-4e9bbb74dd9e>, <https://w3id.org/ontouml-models/distribution/dd7c5b24-4d0b-434f-9261-4613f861d5b3>, <https://w3id.org/ontouml-models/distribution/b7827847-c7a6-47b8-ad66-8c967902c513>, <https://w3id.org/ontouml-models/distribution/773d3f52-6f8b-4d64-87a0-a9472e459e47>, <https://w3id.org/ontouml-models/distribution/cb65f1cb-14ad-48a0-9fd7-52917b1aaf69>, <https://w3id.org/ontouml-models/distribution/82b4fc13-a511-4293-9d19-3c9493b75e06>, <https://w3id.org/ontouml-models/distribution/c9d843a5-21f1-4b66-9e2e-ad599882a437>, <https://w3id.org/ontouml-models/distribution/4f97b4f1-f2fa-4d8b-b5c0-e3491dde0316>, <https://w3id.org/ontouml-models/distribution/86b429a3-c33e-4147-9513-e84a97a539f8>, <https://w3id.org/ontouml-models/distribution/2145c52e-ce94-4fe5-baca-877606003bb1>, <https://w3id.org/ontouml-models/distribution/d1875ec4-d611-4a11-af7f-3868bfe6cbf7>, <https://w3id.org/ontouml-models/distribution/162f6476-d310-487d-8e96-ea2ce4e3b02b>, <https://w3id.org/ontouml-models/distribution/ad303363-2759-4deb-8a97-15b5ce5ea528>, <https://w3id.org/ontouml-models/distribution/70f396ae-2e5c-4020-87bf-0c0dee4937f6>, <https://w3id.org/ontouml-models/distribution/63babb27-06c4-4d37-8385-4fc99b2f3862>, <https://w3id.org/ontouml-models/distribution/8bd5a6d8-4b89-46fa-b694-44618b5a409c>, <https://w3id.org/ontouml-models/distribution/5d5b97d7-562c-45e8-9e91-e3ab50fc46eb>, <https://w3id.org/ontouml-models/distribution/14128cab-c7d0-40a0-9aeb-71372950f705>, <https://w3id.org/ontouml-models/distribution/7b7e3426-c6ba-4e10-bf46-afdb76c02f32>, <https://w3id.org/ontouml-models/distribution/cd81c727-9bad-449f-9392-dc9dcc839597>, <https://w3id.org/ontouml-models/distribution/bfb5c726-0ca8-46ea-b0e6-bb301a6eb53d>, <https://w3id.org/ontouml-models/distribution/5cd7aa4b-f6bb-4030-b46c-0f158c971798>, <https://w3id.org/ontouml-models/distribution/9d75dc04-0e25-4a9e-a389-900f8ecc8974>, <https://w3id.org/ontouml-models/distribution/ad6a3cb8-ca41-424e-be1e-0d6830ee88fd>, <https://w3id.org/ontouml-models/distribution/27794346-2b06-45dc-a20b-71c4401cfb99>, <https://w3id.org/ontouml-models/distribution/db12b39c-35c3-4b14-902e-3378fc891215>, <https://w3id.org/ontouml-models/distribution/d4e2e46d-a21f-48e2-81b7-85edcd475471>, <https://w3id.org/ontouml-models/distribution/54d14d3b-6c57-4d20-823a-4de0cf797d46>, <https://w3id.org/ontouml-models/distribution/7746bf3f-ec8e-473a-9781-c730947054a0>, <https://w3id.org/ontouml-models/distribution/8d0b5872-6c03-4a3f-8bae-a50cef773f3a>, <https://w3id.org/ontouml-models/distribution/bae27f67-8d6a-4eb9-a850-967ddf9ba635>, <https://w3id.org/ontouml-models/distribution/aeb47f31-7509-409d-976d-3c6556ad248a>, <https://w3id.org/ontouml-models/distribution/d22196fe-fb27-4142-bedf-039f8a806fde>, <https://w3id.org/ontouml-models/distribution/ce315d34-abcd-4970-80cd-cb7e425cf886>, <https://w3id.org/ontouml-models/distribution/df284709-53cb-467a-9d79-fd2878526fa4>, <https://w3id.org/ontouml-models/distribution/f08b3072-1d8a-4dde-98fa-df72d22bb15c>, <https://w3id.org/ontouml-models/distribution/f03daa58-5dfb-4eb0-b744-b98f4f7cbc54>, <https://w3id.org/ontouml-models/distribution/e71c19c5-88c2-4111-9914-346efb42dcc9>, <https://w3id.org/ontouml-models/distribution/d23cca47-4c94-4237-94cf-fd20f70eeea8>, <https://w3id.org/ontouml-models/distribution/bb38cb32-c3c2-466c-b617-bdd78d5b5889>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/ff3e16d6-8349-4bea-81e1-c1213e652170> dcat:distribution <https://w3id.org/ontouml-models/distribution/6a4ad553-2143-4fcd-a636-82d693f1c149/>,
+                      <https://w3id.org/ontouml-models/distribution/c4d18b0a-e891-4b5b-8e41-aa913f8ebdfd/>,
+                      <https://w3id.org/ontouml-models/distribution/f6cabca7-35e8-4f2a-8f5a-660f1aff3700/>,
+                      <https://w3id.org/ontouml-models/distribution/ba77ee11-c2dd-4962-8fe3-a6d18350fc6a>,
+                      <https://w3id.org/ontouml-models/distribution/4364c4c1-0e7f-449d-8d8f-01eb2b9b2899>,
+                      <https://w3id.org/ontouml-models/distribution/582ff060-5734-4267-941b-00afb73c3042>,
+                      <https://w3id.org/ontouml-models/distribution/976211cb-cb3d-442e-8823-6e9a4c85b7d0>,
+                      <https://w3id.org/ontouml-models/distribution/4dea65fc-7686-4730-8d56-45d8afa40100>,
+                      <https://w3id.org/ontouml-models/distribution/e4e2659f-78b9-4dce-b9a0-c912efb1e7bf>,
+                      <https://w3id.org/ontouml-models/distribution/fc22151c-7269-4e9c-b7b6-e0f2f7278aba>,
+                      <https://w3id.org/ontouml-models/distribution/382a12ae-3988-4143-a9e7-60df211a224c>,
+                      <https://w3id.org/ontouml-models/distribution/759795d2-4f0a-4222-898a-7e0d621ef498>,
+                      <https://w3id.org/ontouml-models/distribution/ec0ab08c-2e73-494c-95f3-0144943e1119>,
+                      <https://w3id.org/ontouml-models/distribution/dcc2379e-cd5b-4e1d-9fa4-088cbdb155bc>,
+                      <https://w3id.org/ontouml-models/distribution/74595a58-6f10-4111-bd88-cb06ba78be7b>,
+                      <https://w3id.org/ontouml-models/distribution/45d96840-3fbc-41f6-aa3d-53a2882be718>,
+                      <https://w3id.org/ontouml-models/distribution/9b1c8e30-93e7-41c6-9fdc-95d33fef9cac>,
+                      <https://w3id.org/ontouml-models/distribution/2212db64-0dbe-4b81-8165-33abc9995d6a>,
+                      <https://w3id.org/ontouml-models/distribution/150580e8-f544-47ac-ba03-7833ebe02402>,
+                      <https://w3id.org/ontouml-models/distribution/1e1dc2e2-b2ce-43c2-83c9-5b27e55e8491>,
+                      <https://w3id.org/ontouml-models/distribution/17f87033-c2de-448a-af51-ea7cc3d9db36>,
+                      <https://w3id.org/ontouml-models/distribution/7e05619f-2340-49f8-84dd-597eb786137d>,
+                      <https://w3id.org/ontouml-models/distribution/466f5510-dd36-4a76-b4be-d4a2ef0734fa>,
+                      <https://w3id.org/ontouml-models/distribution/620af721-32ca-48f9-b88f-374f85bca98b>,
+                      <https://w3id.org/ontouml-models/distribution/4fdf51e9-4319-46d5-b2e7-8210372e4e38>,
+                      <https://w3id.org/ontouml-models/distribution/91b7f1ee-7fd8-4daf-8dc2-84c2b9365806>,
+                      <https://w3id.org/ontouml-models/distribution/042d81dc-5dcd-4e4c-b369-a466c30c327a>,
+                      <https://w3id.org/ontouml-models/distribution/525df4ed-5957-4cbc-9d7f-e08bcf995341>,
+                      <https://w3id.org/ontouml-models/distribution/6e80297e-1bd0-491b-bb91-1a15f7d6b2f7>,
+                      <https://w3id.org/ontouml-models/distribution/c4302e19-0f94-4f46-b859-501efc2f3ddc>,
+                      <https://w3id.org/ontouml-models/distribution/75d22929-73e8-4b95-871c-b97b0e0025f0>,
+                      <https://w3id.org/ontouml-models/distribution/7211cf9b-519b-4b17-adad-6833b24c113f>,
+                      <https://w3id.org/ontouml-models/distribution/e00385d8-1d3f-4076-b29c-b5b759386680>,
+                      <https://w3id.org/ontouml-models/distribution/9d753518-1b18-428d-8ca9-36064bf2c0fd>,
+                      <https://w3id.org/ontouml-models/distribution/411a017c-64df-41d3-be73-9e5ec67873d5>,
+                      <https://w3id.org/ontouml-models/distribution/8ae31a53-219c-476d-9d2b-6050ed291573>,
+                      <https://w3id.org/ontouml-models/distribution/dfb4a070-92e1-4a82-9004-22742d53a703>,
+                      <https://w3id.org/ontouml-models/distribution/c675af17-c4c8-4c1a-8ba7-35a212df3972>,
+                      <https://w3id.org/ontouml-models/distribution/0c368651-a6ff-4017-af40-a43c7e95c292>,
+                      <https://w3id.org/ontouml-models/distribution/358136b4-d2dc-45ad-ab9f-1a423bab9f1f>,
+                      <https://w3id.org/ontouml-models/distribution/02dc70bd-93b2-467a-bd05-18f93178ba7e>,
+                      <https://w3id.org/ontouml-models/distribution/5b9ab117-a940-4a38-bdde-ad38cedda323>,
+                      <https://w3id.org/ontouml-models/distribution/0f12540e-7e3d-4c99-9d75-3587d3b52bf3>,
+                      <https://w3id.org/ontouml-models/distribution/27c5c821-12ba-4eb6-acd0-d3a79d83e342>,
+                      <https://w3id.org/ontouml-models/distribution/4fe0ebfa-0bc8-4caa-ae2d-fd5cde6235c3>,
+                      <https://w3id.org/ontouml-models/distribution/1558416c-ad02-4bf2-b588-6dd5b1f6d88a>,
+                      <https://w3id.org/ontouml-models/distribution/ffb418f9-fa21-47ce-9175-8c325316407c>,
+                      <https://w3id.org/ontouml-models/distribution/df344924-8a1e-464f-a058-562d14837677>,
+                      <https://w3id.org/ontouml-models/distribution/15401ced-d414-436d-91ac-66ed6c70685d>,
+                      <https://w3id.org/ontouml-models/distribution/fe7646ff-6d03-4292-a576-8f2303de14aa>,
+                      <https://w3id.org/ontouml-models/distribution/7ad34580-c29b-4d96-8261-cc8a1f8d18c2>,
+                      <https://w3id.org/ontouml-models/distribution/d1feaf90-3c0a-45be-ab35-0e2f4e4eb537>,
+                      <https://w3id.org/ontouml-models/distribution/b0aa02f9-ea75-413b-b085-b100736185e7>,
+                      <https://w3id.org/ontouml-models/distribution/4fbc3ad0-aa75-4f04-a165-ca812242ce96>,
+                      <https://w3id.org/ontouml-models/distribution/adf658ba-a8db-4a61-9dc8-f31b2999ee38>,
+                      <https://w3id.org/ontouml-models/distribution/54841adf-6083-410a-ac28-a6b66613e038>,
+                      <https://w3id.org/ontouml-models/distribution/4547a611-965b-4b59-8238-787c6107fd33>,
+                      <https://w3id.org/ontouml-models/distribution/ddd2fc1f-beef-4461-ba9c-63e3a1c3a45c>,
+                      <https://w3id.org/ontouml-models/distribution/238bd9cb-81e2-46dd-8e76-0206217766c0>,
+                      <https://w3id.org/ontouml-models/distribution/1654fb13-353e-40ef-a176-807188643cc7>,
+                      <https://w3id.org/ontouml-models/distribution/478c28d3-9942-44a6-aea2-4fd5c421d8bc>,
+                      <https://w3id.org/ontouml-models/distribution/ff8fcac3-ce7f-402d-a330-cf905fa59f33>,
+                      <https://w3id.org/ontouml-models/distribution/86e6354f-e2a1-4e62-b8ba-402ff5f1f6e0>,
+                      <https://w3id.org/ontouml-models/distribution/a29f2c07-f706-46ee-944b-bdbfe4397f62>,
+                      <https://w3id.org/ontouml-models/distribution/61318928-050a-4489-adfb-e93cf4a22c9b>,
+                      <https://w3id.org/ontouml-models/distribution/9ab78b05-61a4-4448-a34f-57ba5e1f43b3>,
+                      <https://w3id.org/ontouml-models/distribution/2ab6d654-a413-44ac-b6fd-bed4bf909da9>,
+                      <https://w3id.org/ontouml-models/distribution/01eaf833-b8e2-4d20-8ceb-66ae4bd421a2>,
+                      <https://w3id.org/ontouml-models/distribution/51a09cad-ec66-41c9-91a4-61732b946aa7>,
+                      <https://w3id.org/ontouml-models/distribution/a95dc1af-24fb-42b8-b543-84444947243d>,
+                      <https://w3id.org/ontouml-models/distribution/9691f1a0-412c-4504-ac8d-0f596ddd17ba>,
+                      <https://w3id.org/ontouml-models/distribution/4e5d6dd7-73e2-40a1-92f0-1205b877e118>,
+                      <https://w3id.org/ontouml-models/distribution/3236ad7c-e033-40b4-8ebe-0eaff7fb6870>,
+                      <https://w3id.org/ontouml-models/distribution/18e54698-253a-4908-ae67-ba20243b1615>,
+                      <https://w3id.org/ontouml-models/distribution/389f3614-b3de-41d8-a21f-155728139d6e>,
+                      <https://w3id.org/ontouml-models/distribution/7ee5b4af-0743-4b84-aa06-b5fd0f6e4377>,
+                      <https://w3id.org/ontouml-models/distribution/22aae069-5775-4a86-a448-3a10e0466f7d>,
+                      <https://w3id.org/ontouml-models/distribution/2d57cf1f-b3ff-474f-891c-0cf482232b16>,
+                      <https://w3id.org/ontouml-models/distribution/81992b06-e338-41c8-975d-287850f62ad5>,
+                      <https://w3id.org/ontouml-models/distribution/077d8d31-8729-4ab4-9ea2-494d08c165bf>,
+                      <https://w3id.org/ontouml-models/distribution/3069c4e0-5c98-436f-8db8-f0c01147ec7e>,
+                      <https://w3id.org/ontouml-models/distribution/34693771-4993-4432-b3cc-dad18a2c2713>,
+                      <https://w3id.org/ontouml-models/distribution/35df917b-18c3-4ce1-98e6-d5e18802b905>,
+                      <https://w3id.org/ontouml-models/distribution/e3a0e1ff-7bda-4f29-9581-e9b0e0e721e1>,
+                      <https://w3id.org/ontouml-models/distribution/c800d3cb-cdef-4fe4-b2c4-3f8ca17a3c8a>,
+                      <https://w3id.org/ontouml-models/distribution/70743640-e3cb-43c8-aaad-bc7abccc5fd4>,
+                      <https://w3id.org/ontouml-models/distribution/bb3c7db5-344d-4be1-b8eb-36a2d3c1a185>,
+                      <https://w3id.org/ontouml-models/distribution/6409c1a4-74d7-4c60-a734-b1856b881fb3>,
+                      <https://w3id.org/ontouml-models/distribution/0d59653a-94d9-4662-86ce-aade940ea556>,
+                      <https://w3id.org/ontouml-models/distribution/b7925303-73c8-4a82-8105-7bbb9094dbf6>,
+                      <https://w3id.org/ontouml-models/distribution/4d3d020c-9882-4165-9c3a-98d0bcad3a15>,
+                      <https://w3id.org/ontouml-models/distribution/39f11e9b-1baf-4fb2-967c-9d92a3160a3a>,
+                      <https://w3id.org/ontouml-models/distribution/752ae33c-fcab-4c30-b35f-7a5092046e9b>,
+                      <https://w3id.org/ontouml-models/distribution/a986c04b-27bb-4340-bdb9-166a472283bf>,
+                      <https://w3id.org/ontouml-models/distribution/3d6d0fe4-64f4-4fd1-922b-0e14ef8bb5b4>,
+                      <https://w3id.org/ontouml-models/distribution/fe075779-4958-4f19-9fc2-039c4873d49d>,
+                      <https://w3id.org/ontouml-models/distribution/456fb683-4d2d-4952-8175-f6a885b35d86>,
+                      <https://w3id.org/ontouml-models/distribution/7669db2b-29ae-4bc7-924c-ee89da179dc4>,
+                      <https://w3id.org/ontouml-models/distribution/021200c2-4aaf-4e8b-9857-570f73dff3ca>,
+                      <https://w3id.org/ontouml-models/distribution/f7167cce-4b7c-4b13-9104-e3b59fc875f0>,
+                      <https://w3id.org/ontouml-models/distribution/4a552f4d-2166-4b2b-94ea-ae413b9a5d97>,
+                      <https://w3id.org/ontouml-models/distribution/2360e75b-8720-4cd3-a6ec-585999b59658>,
+                      <https://w3id.org/ontouml-models/distribution/6efad562-3f38-4612-b760-a3ef70efad2a>,
+                      <https://w3id.org/ontouml-models/distribution/6a5fcd28-c397-49e5-a7a4-5337149e21bd>,
+                      <https://w3id.org/ontouml-models/distribution/cc873122-adea-4e3c-aaf9-81b45e5f3448>,
+                      <https://w3id.org/ontouml-models/distribution/ccc84f6d-f5de-4311-a69a-c4b8a97f9680>,
+                      <https://w3id.org/ontouml-models/distribution/06bef6a9-bd18-40be-a673-075801f7f44d>,
+                      <https://w3id.org/ontouml-models/distribution/f37cc55a-60d7-4437-a0da-166749eed7f2>,
+                      <https://w3id.org/ontouml-models/distribution/813e1c5d-e4bd-456a-835d-13c04ff8df2a>,
+                      <https://w3id.org/ontouml-models/distribution/edd0fa16-76be-4a07-84d2-5e2392b6744f>,
+                      <https://w3id.org/ontouml-models/distribution/a51df8c0-7812-4255-b5de-dd21112e2544>,
+                      <https://w3id.org/ontouml-models/distribution/a102b255-aaf4-4870-af1c-1c3decdc7bdd>,
+                      <https://w3id.org/ontouml-models/distribution/af1e117e-aace-446d-afe4-3b11b7f6e143>,
+                      <https://w3id.org/ontouml-models/distribution/5be3790b-6bd8-4f7c-a637-bcce50194ccd>,
+                      <https://w3id.org/ontouml-models/distribution/4e3b3be1-f589-4c5c-a09b-6e3f73518e72>,
+                      <https://w3id.org/ontouml-models/distribution/0289eb7b-9877-494d-978d-bb388b83b500>,
+                      <https://w3id.org/ontouml-models/distribution/18c7635b-bb0a-4476-bb17-2db287260a47>,
+                      <https://w3id.org/ontouml-models/distribution/f776a347-05c5-4792-9e52-287028c4eab1>,
+                      <https://w3id.org/ontouml-models/distribution/b013f9df-5ed6-4a14-ade5-3a6785a94bfd>,
+                      <https://w3id.org/ontouml-models/distribution/1d762395-3e06-4c88-9de0-11992702d38d>,
+                      <https://w3id.org/ontouml-models/distribution/2338e3e2-109e-41c8-8230-47ccdd03cc53>,
+                      <https://w3id.org/ontouml-models/distribution/0a16abcc-85f2-4cd9-a71e-8a0b0c8a7ca8>,
+                      <https://w3id.org/ontouml-models/distribution/09b5be5b-a566-4313-84cd-f32388915ffb>,
+                      <https://w3id.org/ontouml-models/distribution/74d479e5-a66d-4808-8bfd-debc63375655>,
+                      <https://w3id.org/ontouml-models/distribution/61e65ef6-6a99-4bcd-8f13-a728f39a3ec7>,
+                      <https://w3id.org/ontouml-models/distribution/42dc11b3-3cd1-48cc-b8e8-9420e17e875f>,
+                      <https://w3id.org/ontouml-models/distribution/1e25fa17-0d8b-458c-bc95-c7a58ebf5f66>,
+                      <https://w3id.org/ontouml-models/distribution/d43392f6-69f7-48f8-a407-4bb31b831e9c>,
+                      <https://w3id.org/ontouml-models/distribution/6bb7317e-c439-4f5d-ad7c-1ed95f41a24a>,
+                      <https://w3id.org/ontouml-models/distribution/9096df6c-ca9e-4afc-b3bf-70c12bd6a90b>,
+                      <https://w3id.org/ontouml-models/distribution/290296a5-d82e-4ddd-bc18-e588641b5de7>,
+                      <https://w3id.org/ontouml-models/distribution/78bac83c-918e-412f-bf11-5b7c2b725cbe>,
+                      <https://w3id.org/ontouml-models/distribution/7d169c52-cc73-426a-88d9-2abd742a06ee>,
+                      <https://w3id.org/ontouml-models/distribution/dd9ffa9e-c10e-4475-a278-f230691fe4e5>,
+                      <https://w3id.org/ontouml-models/distribution/53db55cc-ad29-4c00-abcf-129bb0b81d87>,
+                      <https://w3id.org/ontouml-models/distribution/90f27d66-d421-4ae7-9d99-9d12a182f272>,
+                      <https://w3id.org/ontouml-models/distribution/171caed8-98d9-4ad3-9977-e5744343bd23>,
+                      <https://w3id.org/ontouml-models/distribution/9b1180b3-baf8-43bc-92f6-f272fefdd481>,
+                      <https://w3id.org/ontouml-models/distribution/222782e4-ccc1-4cd6-99e0-ceb15018de5a>,
+                      <https://w3id.org/ontouml-models/distribution/17a9cf32-4430-4d69-9192-9b38a04e7e5d>,
+                      <https://w3id.org/ontouml-models/distribution/8b6c5742-eec0-4e77-956e-0cbba06a8db2>,
+                      <https://w3id.org/ontouml-models/distribution/d4e6094d-4a03-4eaf-888d-916d4e970678>,
+                      <https://w3id.org/ontouml-models/distribution/23230c66-ec06-412b-bcd3-93953c908e9e>,
+                      <https://w3id.org/ontouml-models/distribution/aa310827-80fe-421b-8e00-9d5cc44e36b1>,
+                      <https://w3id.org/ontouml-models/distribution/b4eed3a4-c6a3-4529-9d06-6e8d627d223c>,
+                      <https://w3id.org/ontouml-models/distribution/2e0319db-84c8-417e-9c6a-4e9bbb74dd9e>,
+                      <https://w3id.org/ontouml-models/distribution/dd7c5b24-4d0b-434f-9261-4613f861d5b3>,
+                      <https://w3id.org/ontouml-models/distribution/b7827847-c7a6-47b8-ad66-8c967902c513>,
+                      <https://w3id.org/ontouml-models/distribution/773d3f52-6f8b-4d64-87a0-a9472e459e47>,
+                      <https://w3id.org/ontouml-models/distribution/cb65f1cb-14ad-48a0-9fd7-52917b1aaf69>,
+                      <https://w3id.org/ontouml-models/distribution/82b4fc13-a511-4293-9d19-3c9493b75e06>,
+                      <https://w3id.org/ontouml-models/distribution/c9d843a5-21f1-4b66-9e2e-ad599882a437>,
+                      <https://w3id.org/ontouml-models/distribution/4f97b4f1-f2fa-4d8b-b5c0-e3491dde0316>,
+                      <https://w3id.org/ontouml-models/distribution/86b429a3-c33e-4147-9513-e84a97a539f8>,
+                      <https://w3id.org/ontouml-models/distribution/2145c52e-ce94-4fe5-baca-877606003bb1>,
+                      <https://w3id.org/ontouml-models/distribution/d1875ec4-d611-4a11-af7f-3868bfe6cbf7>,
+                      <https://w3id.org/ontouml-models/distribution/162f6476-d310-487d-8e96-ea2ce4e3b02b>,
+                      <https://w3id.org/ontouml-models/distribution/ad303363-2759-4deb-8a97-15b5ce5ea528>,
+                      <https://w3id.org/ontouml-models/distribution/70f396ae-2e5c-4020-87bf-0c0dee4937f6>,
+                      <https://w3id.org/ontouml-models/distribution/63babb27-06c4-4d37-8385-4fc99b2f3862>,
+                      <https://w3id.org/ontouml-models/distribution/8bd5a6d8-4b89-46fa-b694-44618b5a409c>,
+                      <https://w3id.org/ontouml-models/distribution/5d5b97d7-562c-45e8-9e91-e3ab50fc46eb>,
+                      <https://w3id.org/ontouml-models/distribution/14128cab-c7d0-40a0-9aeb-71372950f705>,
+                      <https://w3id.org/ontouml-models/distribution/7b7e3426-c6ba-4e10-bf46-afdb76c02f32>,
+                      <https://w3id.org/ontouml-models/distribution/cd81c727-9bad-449f-9392-dc9dcc839597>,
+                      <https://w3id.org/ontouml-models/distribution/bfb5c726-0ca8-46ea-b0e6-bb301a6eb53d>,
+                      <https://w3id.org/ontouml-models/distribution/5cd7aa4b-f6bb-4030-b46c-0f158c971798>,
+                      <https://w3id.org/ontouml-models/distribution/9d75dc04-0e25-4a9e-a389-900f8ecc8974>,
+                      <https://w3id.org/ontouml-models/distribution/ad6a3cb8-ca41-424e-be1e-0d6830ee88fd>,
+                      <https://w3id.org/ontouml-models/distribution/27794346-2b06-45dc-a20b-71c4401cfb99>,
+                      <https://w3id.org/ontouml-models/distribution/db12b39c-35c3-4b14-902e-3378fc891215>,
+                      <https://w3id.org/ontouml-models/distribution/d4e2e46d-a21f-48e2-81b7-85edcd475471>,
+                      <https://w3id.org/ontouml-models/distribution/54d14d3b-6c57-4d20-823a-4de0cf797d46>,
+                      <https://w3id.org/ontouml-models/distribution/7746bf3f-ec8e-473a-9781-c730947054a0>,
+                      <https://w3id.org/ontouml-models/distribution/8d0b5872-6c03-4a3f-8bae-a50cef773f3a>,
+                      <https://w3id.org/ontouml-models/distribution/bae27f67-8d6a-4eb9-a850-967ddf9ba635>,
+                      <https://w3id.org/ontouml-models/distribution/aeb47f31-7509-409d-976d-3c6556ad248a>,
+                      <https://w3id.org/ontouml-models/distribution/d22196fe-fb27-4142-bedf-039f8a806fde>,
+                      <https://w3id.org/ontouml-models/distribution/ce315d34-abcd-4970-80cd-cb7e425cf886>,
+                      <https://w3id.org/ontouml-models/distribution/df284709-53cb-467a-9d79-fd2878526fa4>,
+                      <https://w3id.org/ontouml-models/distribution/f08b3072-1d8a-4dde-98fa-df72d22bb15c>,
+                      <https://w3id.org/ontouml-models/distribution/f03daa58-5dfb-4eb0-b744-b98f4f7cbc54>,
+                      <https://w3id.org/ontouml-models/distribution/e71c19c5-88c2-4111-9914-346efb42dcc9>,
+                      <https://w3id.org/ontouml-models/distribution/d23cca47-4c94-4237-94cf-fd20f70eeea8>,
+                      <https://w3id.org/ontouml-models/distribution/bb38cb32-c3c2-466c-b617-bdd78d5b5889> .

--- a/models/barcelos2024resiliont/metadata.ttl
+++ b/models/barcelos2024resiliont/metadata.ttl
@@ -1,15 +1,16 @@
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/model/barcelos2024resiliont/> a dcat:Dataset, mod:SemanticArtefact;
+<https://w3id.org/ontouml-models/model/barcelos2024resiliont/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
+    dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
     dct:title "Resilience Core Ontology";
     mod:acronym "ResiliOnt";
     dct:issued "2024"^^xsd:gYear;
@@ -18,22 +19,30 @@
     dct:language "en";
     dcat:landingPage <https://w3id.org/resiliont/git>;
     dct:license <https://www.apache.org/licenses/LICENSE-2.0>;
-    dct:contributor <https://dblp.org/pid/96/8280>, <https://dblp.org/pid/63/9777>, <https://dblp.org/pid/212/6684>, <https://dblp.org/pid/134/4947>, <https://dblp.org/pid/95/6356>, <https://dblp.org/pid/72/6796>, <https://dblp.org/pid/11/78>;
-    mod:designedForTask ocmv:ConceptualClarification, ocmv:OntologicalAnalysis;
+    dct:contributor <https://dblp.org/pid/96/8280>,
+                    <https://dblp.org/pid/63/9777>,
+                    <https://dblp.org/pid/212/6684>,
+                    <https://dblp.org/pid/134/4947>,
+                    <https://dblp.org/pid/95/6356>,
+                    <https://dblp.org/pid/72/6796>,
+                    <https://dblp.org/pid/11/78>;
+    dcat:keyword "resilience"@en,
+                 "risk"@en;
+    dct:source <https://raw.githubusercontent.com/pedropaulofb/resiliont/main/resources/Ontological%20Foundations%20of%20Resilience.pdf>;
+    mod:designedForTask ocmv:ConceptualClarification,
+                        ocmv:OntologicalAnalysis;
     ocmv:context ocmv:Research;
-    dct:source <https://raw.githubusercontent.com/pedropaulofb/resiliont/main/resources/Ontological%20Foundations%20of%20Resilience.pdf>.
-<https://w3id.org/ontouml-models/model/barcelos2024resiliont/> dcat:distribution <https://w3id.org/ontouml-models/model/barcelos2024resiliont/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/barcelos2024resiliont/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Resilience Core Ontology\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/barcelos2024resiliont/ontology.ttl>.
-<https://w3id.org/ontouml-models/model/barcelos2024resiliont/> dcat:distribution <https://w3id.org/ontouml-models/model/barcelos2024resiliont/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/barcelos2024resiliont/distribution/ttl> a dcat:Distribution;
-    dct:title "JSON distribution of \"Resilience Core Ontology\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/barcelos2024resiliont/ontology.json>.
-<https://w3id.org/ontouml-models/model/barcelos2024resiliont/> dcat:distribution <https://w3id.org/ontouml-models/model/barcelos2024resiliont/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/barcelos2024resiliont/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Resilience Core Ontology\""@en;
-    dcat:mediaType <https://www.visual-paradigm.com/vpp>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/barcelos2024resiliont/ontology.vpp>.
+    ocmv:representationStyle ocmv:OntoumlStyle;
+    ocmv:ontologyType ocmv:Core;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/barcelos2024resiliont"^^xsd:anyURI;
+    fdpo:metadataIssued "2026-06-23T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/barcelos2024resiliont/> dcat:distribution <https://w3id.org/ontouml-models/model/barcelos2024resiliont/distribution/ttl>,
+                      <https://www.iana.org/assignments/media-types/text/turtle>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/barcelos2024resiliont/ontology.ttl>,
+                      <https://w3id.org/ontouml-models/model/barcelos2024resiliont/>,
+                      <https://www.iana.org/assignments/media-types/application/json>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/barcelos2024resiliont/ontology.json>,
+                      <https://www.visual-paradigm.com/vpp>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/barcelos2024resiliont/ontology.vpp> .

--- a/models/barros2020programming/metadata.ttl
+++ b/models/barros2020programming/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/65a05fab-35fe-4eff-bf19-2eb0aea54022/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -18,14 +17,22 @@
     dcat:theme lcc:K;
     dct:language "pt-br";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:contributor <https://dblp.org/pid/281/3280>, <https://dblp.org/pid/o/JosePalazzoMoreiradeOliveira>, <https://dblp.org/pid/281/3252>;
-    dcat:keyword "government"@en, "law"@en;
+    dct:contributor <https://dblp.org/pid/281/3280>,
+                    <https://dblp.org/pid/o/JosePalazzoMoreiradeOliveira>,
+                    <https://dblp.org/pid/281/3252>;
+    dcat:keyword "government"@en,
+                 "law"@en;
+    dct:source <https://dblp.org/rec/conf/caise/BarrosOR20>;
     mod:designedForTask ocmv:ConceptualClarification;
     ocmv:context ocmv:Research;
-    dct:source <https://dblp.org/rec/conf/caise/BarrosOR20>;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/barros2020programming"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/barros2020programming"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:42:53.81381862Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:42:53.81381862Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/65a05fab-35fe-4eff-bf19-2eb0aea54022> dcat:distribution <https://w3id.org/ontouml-models/distribution/4dd299af-a36d-4fa6-a3fc-52c7d80ffe1b/>, <https://w3id.org/ontouml-models/distribution/d4422bf0-758f-48e4-9fab-04f448139826/>, <https://w3id.org/ontouml-models/distribution/fa05d72c-19cd-40ef-b0f3-7720475e3e36/>, <https://w3id.org/ontouml-models/distribution/6d0d5260-2bea-4351-af77-b63612eec53e>, <https://w3id.org/ontouml-models/distribution/9543b614-cd3b-4aa7-b748-8228367c40e3>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/65a05fab-35fe-4eff-bf19-2eb0aea54022> dcat:distribution <https://w3id.org/ontouml-models/distribution/4dd299af-a36d-4fa6-a3fc-52c7d80ffe1b/>,
+                      <https://w3id.org/ontouml-models/distribution/d4422bf0-758f-48e4-9fab-04f448139826/>,
+                      <https://w3id.org/ontouml-models/distribution/fa05d72c-19cd-40ef-b0f3-7720475e3e36/>,
+                      <https://w3id.org/ontouml-models/distribution/6d0d5260-2bea-4351-af77-b63612eec53e>,
+                      <https://w3id.org/ontouml-models/distribution/9543b614-cd3b-4aa7-b748-8228367c40e3> .

--- a/models/bernasconi2021ontovcm/metadata.ttl
+++ b/models/bernasconi2021ontovcm/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/37ec1d52-b8c1-4e6e-9917-d6e4b58d1c6d/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -19,14 +18,26 @@
     dcat:theme lcc:Q;
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:contributor <https://dblp.org/pid/25/929-2>, <https://dblp.org/pid/11/78>, <https://dblp.org/pid/p/OscarPastor>, <https://dblp.org/pid/41/1781>;
-    dcat:keyword "virology"@en, "biology"@en;
+    dct:contributor <https://dblp.org/pid/25/929-2>,
+                    <https://dblp.org/pid/11/78>,
+                    <https://dblp.org/pid/p/OscarPastor>,
+                    <https://dblp.org/pid/41/1781>;
+    dcat:keyword "virology"@en,
+                 "biology"@en;
+    dct:source <https://doi.org/10.1007/978-3-030-89022-3_28>;
     mod:designedForTask ocmv:OntologicalAnalysis;
     ocmv:context ocmv:Research;
-    dct:source <https://doi.org/10.1007/978-3-030-89022-3_28>;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/bernasconi2021ontovcm"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/bernasconi2021ontovcm"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:43:02.339786159Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:43:02.339786159Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/37ec1d52-b8c1-4e6e-9917-d6e4b58d1c6d> dcat:distribution <https://w3id.org/ontouml-models/distribution/6e0dfae8-179e-4910-92d8-e50f98cea75e/>, <https://w3id.org/ontouml-models/distribution/696eca1a-7e4f-4554-9000-b6a8aa8a161b/>, <https://w3id.org/ontouml-models/distribution/56ab0219-6f03-41f8-bb8d-8d59c233de90/>, <https://w3id.org/ontouml-models/distribution/0695d03a-db59-4b65-9362-850aff28b1a5>, <https://w3id.org/ontouml-models/distribution/7fb21626-0701-48f7-a1c3-f4bfabcd4ab4>, <https://w3id.org/ontouml-models/distribution/7fe00b9d-c1ee-41f4-827e-31913e9636d0>, <https://w3id.org/ontouml-models/distribution/40bade4a-a3f7-4610-9e1d-080347a21dc7>, <https://w3id.org/ontouml-models/distribution/5ebfcbc4-aa20-46b4-96ae-5293af3c163f>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/37ec1d52-b8c1-4e6e-9917-d6e4b58d1c6d> dcat:distribution <https://w3id.org/ontouml-models/distribution/6e0dfae8-179e-4910-92d8-e50f98cea75e/>,
+                      <https://w3id.org/ontouml-models/distribution/696eca1a-7e4f-4554-9000-b6a8aa8a161b/>,
+                      <https://w3id.org/ontouml-models/distribution/56ab0219-6f03-41f8-bb8d-8d59c233de90/>,
+                      <https://w3id.org/ontouml-models/distribution/0695d03a-db59-4b65-9362-850aff28b1a5>,
+                      <https://w3id.org/ontouml-models/distribution/7fb21626-0701-48f7-a1c3-f4bfabcd4ab4>,
+                      <https://w3id.org/ontouml-models/distribution/7fe00b9d-c1ee-41f4-827e-31913e9636d0>,
+                      <https://w3id.org/ontouml-models/distribution/40bade4a-a3f7-4610-9e1d-080347a21dc7>,
+                      <https://w3id.org/ontouml-models/distribution/5ebfcbc4-aa20-46b4-96ae-5293af3c163f> .

--- a/models/bernasconi2023fair-principles/metadata.ttl
+++ b/models/bernasconi2023fair-principles/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/648b1a98-41f6-49b9-be93-6b012d52593c/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -19,14 +18,32 @@
     skos:editorialNote "The source field must be updated after the document receives a valid DOI.";
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:contributor <https://dblp.org/pid/25/929-2>, <https://dblp.org/pid/201/2998>, <https://dblp.org/pid/11/78>, <https://dblp.org/pid/68/84>, <https://dblp.org/pid/41/1781>;
-    dcat:keyword "fair principles"@en, "fair data"@en, "fairness"@en, "findability"@en, "accessibility"@en, "interoperability"@en, "reusability"@en;
-    mod:designedForTask ocmv:ConceptualClarification, ocmv:Interoperability;
-    ocmv:context ocmv:Research;
+    dct:contributor <https://dblp.org/pid/25/929-2>,
+                    <https://dblp.org/pid/201/2998>,
+                    <https://dblp.org/pid/11/78>,
+                    <https://dblp.org/pid/68/84>,
+                    <https://dblp.org/pid/41/1781>;
+    dcat:keyword "fair principles"@en,
+                 "fair data"@en,
+                 "fairness"@en,
+                 "findability"@en,
+                 "accessibility"@en,
+                 "interoperability"@en,
+                 "reusability"@en;
     dct:source <https://www.researchgate.net/publication/369850668_Ontological_representation_of_FAIR_principles_A_blueprint_for_FAIRer_data_sources>;
+    mod:designedForTask ocmv:ConceptualClarification,
+                        ocmv:Interoperability;
+    ocmv:context ocmv:Research;
     ocmv:representationStyle ocmv:OntoumlStyle;
-    ocmv:ontologyType ocmv:Domain, ocmv:Application;
+    ocmv:ontologyType ocmv:Domain,
+                      ocmv:Application;
     ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/bernasconi2023fair-principles"^^xsd:anyURI;
     fdpo:metadataIssued "2023-05-30T14:34:56.729971243Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-05-30T14:34:56.729971243Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/648b1a98-41f6-49b9-be93-6b012d52593c> dcat:distribution <https://w3id.org/ontouml-models/distribution/77f09632-9ee2-445e-9263-140aff501f7c/>, <https://w3id.org/ontouml-models/distribution/4755588d-bdf0-40d4-9fa3-8ccf1421c0af/>, <https://w3id.org/ontouml-models/distribution/43eb8441-e657-4384-9161-79cd562f793c/>, <https://w3id.org/ontouml-models/distribution/c40e80a3-d3f1-404c-aa31-39f07a48b763>, <https://w3id.org/ontouml-models/distribution/575527e2-35bb-4da2-b5cd-4a6028da7e88>, <https://w3id.org/ontouml-models/distribution/f2a089fa-7055-48a3-b2dc-5309a3bbb665>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/648b1a98-41f6-49b9-be93-6b012d52593c> dcat:distribution <https://w3id.org/ontouml-models/distribution/77f09632-9ee2-445e-9263-140aff501f7c/>,
+                      <https://w3id.org/ontouml-models/distribution/4755588d-bdf0-40d4-9fa3-8ccf1421c0af/>,
+                      <https://w3id.org/ontouml-models/distribution/43eb8441-e657-4384-9161-79cd562f793c/>,
+                      <https://w3id.org/ontouml-models/distribution/c40e80a3-d3f1-404c-aa31-39f07a48b763>,
+                      <https://w3id.org/ontouml-models/distribution/575527e2-35bb-4da2-b5cd-4a6028da7e88>,
+                      <https://w3id.org/ontouml-models/distribution/f2a089fa-7055-48a3-b2dc-5309a3bbb665> .

--- a/models/blums2024ccf/metadata.ttl
+++ b/models/blums2024ccf/metadata.ttl
@@ -1,37 +1,44 @@
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/model/blums2024ccf/> a dcat:Dataset, mod:SemanticArtefact;
+<https://w3id.org/ontouml-models/model/blums2024ccf/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
+    dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
     dct:title "Ontology of Converged Conceptual Frameworks for Financial Reporting";
     mod:acronym "CCF Ontology";
     dct:issued "2024"^^xsd:gYear;
     dcat:theme lcc:H;
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:contributor <https://dblp.org/pid/184/4586.html>, <https://dblp.org/pid/70/260.html>;
-    mod:designedForTask ocmv:ConceptualClarification, ocmv:Interoperability, ocmv:OntologicalAnalysis;
-    ocmv:context ocmv:Research, ocmv:Industry;
-    dct:source <http://doi.org/10.13140/RG.2.2.31144.99843>.
-<https://w3id.org/ontouml-models/model/blums2024ccf/> dcat:distribution <https://w3id.org/ontouml-models/model/blums2024ccf/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/blums2024ccf/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Ontology of Converged Conceptual Frameworks for Financial Reporting\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/blums2024ccf/ontology.ttl>.
-<https://w3id.org/ontouml-models/model/blums2024ccf/> dcat:distribution <https://w3id.org/ontouml-models/model/blums2024ccf/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/blums2024ccf/distribution/ttl> a dcat:Distribution;
-    dct:title "JSON distribution of \"Ontology of Converged Conceptual Frameworks for Financial Reporting\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/blums2024ccf/ontology.json>.
-<https://w3id.org/ontouml-models/model/blums2024ccf/> dcat:distribution <https://w3id.org/ontouml-models/model/blums2024ccf/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/blums2024ccf/distribution/vpp> a dcat:Distribution;
-    dct:title "Visual Paradigm distribution of \"Ontology of Converged Conceptual Frameworks for Financial Reporting\""@en;
-    dcat:mediaType <https://www.visual-paradigm.com/vpp>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/blums2024ccf/ontology.vpp>.
+    dct:contributor <https://dblp.org/pid/184/4586.html>,
+                    <https://dblp.org/pid/70/260.html>;
+    dcat:keyword "accounting"@en,
+                 "financial reporting"@en;
+    dct:source <http://doi.org/10.13140/RG.2.2.31144.99843>;
+    mod:designedForTask ocmv:ConceptualClarification,
+                        ocmv:Interoperability,
+                        ocmv:OntologicalAnalysis;
+    ocmv:context ocmv:Research,
+                 ocmv:Industry;
+    ocmv:representationStyle ocmv:OntoumlStyle;
+    ocmv:ontologyType ocmv:Core;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/blums2024ccf"^^xsd:anyURI;
+    fdpo:metadataIssued "2026-06-23T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/blums2024ccf/> dcat:distribution <https://w3id.org/ontouml-models/model/blums2024ccf/distribution/ttl>,
+                      <https://www.iana.org/assignments/media-types/text/turtle>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/blums2024ccf/ontology.ttl>,
+                      <https://w3id.org/ontouml-models/model/blums2024ccf/>,
+                      <https://www.iana.org/assignments/media-types/application/json>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/blums2024ccf/ontology.json>,
+                      <https://w3id.org/ontouml-models/model/blums2024ccf/distribution/vpp>,
+                      <https://www.visual-paradigm.com/vpp>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/blums2024ccf/ontology.vpp> .

--- a/models/blums2025cofris/metadata.ttl
+++ b/models/blums2025cofris/metadata.ttl
@@ -1,38 +1,45 @@
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/model/blums2025cofris/> a dcat:Dataset, mod:SemanticArtefact;
+<https://w3id.org/ontouml-models/model/blums2025cofris/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
+    dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
     dct:title "Core Ontology for Financial Reporting Information Systems 3.0";
     mod:acronym "COFRIS 3.0";
     dct:issued "2025"^^xsd:gYear;
     dcat:theme lcc:H;
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:contributor <https://dblp.org/pid/184/4586>, <https://dblp.org/pid/70/260>;
-    mod:designedForTask ocmv:ConceptualClarification, ocmv:OntologicalAnalysis;
+    dct:contributor <https://dblp.org/pid/184/4586>,
+                    <https://dblp.org/pid/70/260>;
+    dcat:keyword "financial reporting"@en,
+                 "accounting standards"@en,
+                 "economic exchange"@en,
+                 "legal obligations"@en;
+    dct:source <https://www.utwente.nl/en/eemcs/vmbo2025/papers/vmbo-2025-paper-9-2.pdf>;
+    mod:designedForTask ocmv:ConceptualClarification,
+                        ocmv:OntologicalAnalysis;
     ocmv:context ocmv:Research;
-    dct:source <https://www.utwente.nl/en/eemcs/vmbo2025/papers/vmbo-2025-paper-9-2.pdf>.
-<https://purl.org/ontouml-models/catalog> dcat:dataset <https://w3id.org/ontouml-models/model/blums2025cofris/>.
-<https://w3id.org/ontouml-models/model/blums2025cofris/> dcat:distribution <https://w3id.org/ontouml-models/model/blums2025cofris/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/blums2025cofris/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Core Ontology for Financial Reporting Information Systems 3.0\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/blums2025cofris/ontology.ttl>.
-<https://w3id.org/ontouml-models/model/blums2025cofris/> dcat:distribution <https://w3id.org/ontouml-models/model/blums2025cofris/distribution/json>.
-<https://w3id.org/ontouml-models/model/blums2025cofris/distribution/json> a dcat:Distribution;
-    dct:title "JSON distribution of \"Core Ontology for Financial Reporting Information Systems 3.0\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/blums2025cofris/ontology.json>.
-<https://w3id.org/ontouml-models/model/blums2025cofris/> dcat:distribution <https://w3id.org/ontouml-models/model/blums2025cofris/distribution/vpp>.
-<https://w3id.org/ontouml-models/model/blums2025cofris/distribution/vpp> a dcat:Distribution;
-    dct:title "Visual Paradigm distribution of \"Core Ontology for Financial Reporting Information Systems 3.0\""@en;
-    dcat:mediaType <https://www.visual-paradigm.com/vpp>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/blums2025cofris/ontology.vpp>.
+    ocmv:representationStyle ocmv:OntoumlStyle;
+    ocmv:ontologyType ocmv:Core;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/blums2025cofris"^^xsd:anyURI;
+    fdpo:metadataIssued "2026-06-23T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/blums2025cofris/> dcat:distribution <https://w3id.org/ontouml-models/model/blums2025cofris/distribution/ttl>,
+                      <https://www.iana.org/assignments/media-types/text/turtle>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/blums2025cofris/ontology.ttl>,
+                      <https://w3id.org/ontouml-models/model/blums2025cofris/>,
+                      <https://w3id.org/ontouml-models/model/blums2025cofris/distribution/json>,
+                      <https://www.iana.org/assignments/media-types/application/json>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/blums2025cofris/ontology.json>,
+                      <https://w3id.org/ontouml-models/model/blums2025cofris/distribution/vpp>,
+                      <https://www.visual-paradigm.com/vpp>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/blums2025cofris/ontology.vpp> .

--- a/models/brazilian-governmental-organizational-structures/metadata.ttl
+++ b/models/brazilian-governmental-organizational-structures/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/3ed5bea4-4acf-4d1d-9810-4d1e478b92aa/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -18,12 +17,18 @@
     skos:editorialNote "A draft made by members of the Brazilian Ministry of Planning and Management";
     dct:language "pt-br";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dcat:keyword "organizational structures"@en, "government"@en;
+    dcat:keyword "organizational structures"@en,
+                 "government"@en;
     mod:designedForTask ocmv:ConceptualClarification;
     ocmv:context ocmv:Industry;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/brazilian-governmental-organizational-structures"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/brazilian-governmental-organizational-structures"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:43:15.510610949Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:43:15.510610949Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/3ed5bea4-4acf-4d1d-9810-4d1e478b92aa> dcat:distribution <https://w3id.org/ontouml-models/distribution/9ff8b4d0-0765-45d6-9740-d1aa16b59c20/>, <https://w3id.org/ontouml-models/distribution/4939e819-08d2-421a-87e7-2c7a32142fa0/>, <https://w3id.org/ontouml-models/distribution/c386819b-975f-42ce-9778-abb5e3404a68/>, <https://w3id.org/ontouml-models/distribution/b2c52a16-b01f-4d97-a477-c6dfef7e2da0>, <https://w3id.org/ontouml-models/distribution/91a0a64e-5c6f-40f0-bc56-1c27c9d89277>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/3ed5bea4-4acf-4d1d-9810-4d1e478b92aa> dcat:distribution <https://w3id.org/ontouml-models/distribution/9ff8b4d0-0765-45d6-9740-d1aa16b59c20/>,
+                      <https://w3id.org/ontouml-models/distribution/4939e819-08d2-421a-87e7-2c7a32142fa0/>,
+                      <https://w3id.org/ontouml-models/distribution/c386819b-975f-42ce-9778-abb5e3404a68/>,
+                      <https://w3id.org/ontouml-models/distribution/b2c52a16-b01f-4d97-a477-c6dfef7e2da0>,
+                      <https://w3id.org/ontouml-models/distribution/91a0a64e-5c6f-40f0-bc56-1c27c9d89277> .

--- a/models/buchtela2020connection/metadata.ttl
+++ b/models/buchtela2020connection/metadata.ttl
@@ -1,31 +1,37 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/1b479664-a287-4503-9d2b-7d8cf8bed271/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:title "Knowledge Representation Model of Students' Activities";
     dct:issued "2020"^^xsd:gYear;
     dct:modified "2020"^^xsd:gYear;
     dcat:theme lcc:L;
     dct:language "en";
-    dct:contributor <https://dblp.org/pid/03/3150>, <https://orcid.org/0000-0001-8955-6002>;
-    dcat:keyword "education"@en, "students' activities"@en;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    dct:contributor <https://dblp.org/pid/03/3150>,
+                    <https://orcid.org/0000-0001-8955-6002>;
+    dcat:keyword "education"@en,
+                 "students' activities"@en;
+    dct:source <https://us.edu.pl/wydzial/wsne/nauka-i-badania/serie-wydawnicze/seria-e-learning/12-articles/07-2/>;
     mod:designedForTask ocmv:ConceptualClarification;
     ocmv:context ocmv:Research;
-    dct:source <https://us.edu.pl/wydzial/wsne/nauka-i-badania/serie-wydawnicze/seria-e-learning/12-articles/07-2/>;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/buchtela2020connection"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/buchtela2020connection"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:43:24.638462282Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:43:24.638462282Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/1b479664-a287-4503-9d2b-7d8cf8bed271> dcat:distribution <https://w3id.org/ontouml-models/distribution/038e6492-9309-40f8-8a64-fb34f92362f6/>, <https://w3id.org/ontouml-models/distribution/f51e72a0-f624-48e3-abd2-af359eea0f23/>, <https://w3id.org/ontouml-models/distribution/e587995d-4b83-4161-90b5-675f4d6acef2/>, <https://w3id.org/ontouml-models/distribution/75edf9e3-3878-4d92-816a-b96fc7eb6f73>, <https://w3id.org/ontouml-models/distribution/fa341f6e-f2e2-4fe5-9e52-9e44b2089b92>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/1b479664-a287-4503-9d2b-7d8cf8bed271> dcat:distribution <https://w3id.org/ontouml-models/distribution/038e6492-9309-40f8-8a64-fb34f92362f6/>,
+                      <https://w3id.org/ontouml-models/distribution/f51e72a0-f624-48e3-abd2-af359eea0f23/>,
+                      <https://w3id.org/ontouml-models/distribution/e587995d-4b83-4161-90b5-675f4d6acef2/>,
+                      <https://w3id.org/ontouml-models/distribution/75edf9e3-3878-4d92-816a-b96fc7eb6f73>,
+                      <https://w3id.org/ontouml-models/distribution/fa341f6e-f2e2-4fe5-9e52-9e44b2089b92> .

--- a/models/buridan-ontology2021/metadata.ttl
+++ b/models/buridan-ontology2021/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/7a585e3c-9a42-4bd7-8d50-bdbd9332c9ba/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -21,12 +20,21 @@
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:contributor <https://a-komaromi.medium.com>;
     dcat:keyword "philosophy"@en;
+    dct:source <https://philosophy-models.blog/tag/john-buridan-1301-1358-ad/>;
     mod:designedForTask ocmv:ConceptualClarification;
     ocmv:context ocmv:Research;
-    dct:source <https://philosophy-models.blog/tag/john-buridan-1301-1358-ad/>;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/buridan-ontology2021"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/buridan-ontology2021"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:43:33.632304585Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:43:33.632304585Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/7a585e3c-9a42-4bd7-8d50-bdbd9332c9ba> dcat:distribution <https://w3id.org/ontouml-models/distribution/abfd99c5-0674-47bd-bb59-94a76aadabbc/>, <https://w3id.org/ontouml-models/distribution/6b61c448-f3a0-4ec4-945f-d6eb68c162b5/>, <https://w3id.org/ontouml-models/distribution/9bbcebf8-9410-453f-9185-aa59fc0e0896/>, <https://w3id.org/ontouml-models/distribution/0d75dddb-172c-47f2-a446-14a4e5d609dc>, <https://w3id.org/ontouml-models/distribution/b8e1c929-06e1-4f01-9cd5-f7432138bed9>, <https://w3id.org/ontouml-models/distribution/df6aee05-edf2-4128-a8a3-09c42018689f>, <https://w3id.org/ontouml-models/distribution/58a94f4a-eec5-43f1-8f30-a0017e38af55>, <https://w3id.org/ontouml-models/distribution/1f843bb7-b987-43bd-b385-08c29fed5565>, <https://w3id.org/ontouml-models/distribution/4feecb22-b545-4779-b6b9-8f6bc7c6435d>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/7a585e3c-9a42-4bd7-8d50-bdbd9332c9ba> dcat:distribution <https://w3id.org/ontouml-models/distribution/abfd99c5-0674-47bd-bb59-94a76aadabbc/>,
+                      <https://w3id.org/ontouml-models/distribution/6b61c448-f3a0-4ec4-945f-d6eb68c162b5/>,
+                      <https://w3id.org/ontouml-models/distribution/9bbcebf8-9410-453f-9185-aa59fc0e0896/>,
+                      <https://w3id.org/ontouml-models/distribution/0d75dddb-172c-47f2-a446-14a4e5d609dc>,
+                      <https://w3id.org/ontouml-models/distribution/b8e1c929-06e1-4f01-9cd5-f7432138bed9>,
+                      <https://w3id.org/ontouml-models/distribution/df6aee05-edf2-4128-a8a3-09c42018689f>,
+                      <https://w3id.org/ontouml-models/distribution/58a94f4a-eec5-43f1-8f30-a0017e38af55>,
+                      <https://w3id.org/ontouml-models/distribution/1f843bb7-b987-43bd-b385-08c29fed5565>,
+                      <https://w3id.org/ontouml-models/distribution/4feecb22-b545-4779-b6b9-8f6bc7c6435d> .

--- a/models/calhau2024capabilities/metadata.ttl
+++ b/models/calhau2024capabilities/metadata.ttl
@@ -1,36 +1,48 @@
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/model/calhau2024capabilities/> a dcat:Dataset, mod:SemanticArtefact;
+<https://w3id.org/ontouml-models/model/calhau2024capabilities/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
+    dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
     dct:title "Capabilities Ontology";
     dct:issued "2024"^^xsd:gYear;
     dcat:theme lcc:B;
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:contributor <https://dblp.org/pid/63/9777>, <https://dblp.org/pid/11/78>, <https://dblp.org/pid/134/4947>, <https://dblp.org/pid/212/6684>, <https://dblp.org/pid/269/9350>, <https://dblp.org/pid/91/2201>, <https://dblp.org/pid/91/3408>, <https://dblp.org/pid/p/LuisFerreiraPires>;
+    dct:contributor <https://dblp.org/pid/63/9777>,
+                    <https://dblp.org/pid/11/78>,
+                    <https://dblp.org/pid/134/4947>,
+                    <https://dblp.org/pid/212/6684>,
+                    <https://dblp.org/pid/269/9350>,
+                    <https://dblp.org/pid/91/2201>,
+                    <https://dblp.org/pid/91/3408>,
+                    <https://dblp.org/pid/p/LuisFerreiraPires>;
+    dcat:keyword "capability"@en,
+                 "disposition"@en;
+    dct:source <https://doi.org/10.1007/s10270-024-01151-7>,
+               <https://doi.org/10.1007/978-3-031-46587-1_1>;
     mod:designedForTask ocmv:ConceptualClarification;
     ocmv:context ocmv:Research;
-    dct:source <https://doi.org/10.1007/s10270-024-01151-7>, <https://doi.org/10.1007/978-3-031-46587-1_1>.
-<https://w3id.org/ontouml-models/model/calhau2024capabilities/> dcat:distribution <https://w3id.org/ontouml-models/model/calhau2024capabilities/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/calhau2024capabilities/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Capabilities Ontology\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/calhau2024capabilities/ontology.ttl>.
-<https://w3id.org/ontouml-models/model/calhau2024capabilities/> dcat:distribution <https://w3id.org/ontouml-models/model/calhau2024capabilities/distribution/json>.
-<https://w3id.org/ontouml-models/model/calhau2024capabilities/distribution/json> a dcat:Distribution;
-    dct:title "JSON distribution of \"Capabilities Ontology\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/calhau2024capabilities/ontology.json>.
-<https://w3id.org/ontouml-models/model/calhau2024capabilities/> dcat:distribution <https://w3id.org/ontouml-models/model/calhau2024capabilities/distribution/vpp>.
-<https://w3id.org/ontouml-models/model/calhau2024capabilities/distribution/vpp> a dcat:Distribution;
-    dct:title "Visual Paradigm distribution of \"Capabilities Ontology\""@en;
-    dcat:mediaType <https://www.visual-paradigm.com/vpp>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/calhau2024capabilities/ontology.vpp>.
+    ocmv:representationStyle ocmv:OntoumlStyle;
+    ocmv:ontologyType ocmv:Domain;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/calhau2024capabilities"^^xsd:anyURI;
+    fdpo:metadataIssued "2026-06-23T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/calhau2024capabilities/> dcat:distribution <https://w3id.org/ontouml-models/model/calhau2024capabilities/distribution/ttl>,
+                      <https://www.iana.org/assignments/media-types/text/turtle>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/calhau2024capabilities/ontology.ttl>,
+                      <https://w3id.org/ontouml-models/model/calhau2024capabilities/>,
+                      <https://w3id.org/ontouml-models/model/calhau2024capabilities/distribution/json>,
+                      <https://www.iana.org/assignments/media-types/application/json>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/calhau2024capabilities/ontology.json>,
+                      <https://w3id.org/ontouml-models/model/calhau2024capabilities/distribution/vpp>,
+                      <https://www.visual-paradigm.com/vpp>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/calhau2024capabilities/ontology.vpp> .

--- a/models/carolla2014campus-management/metadata.ttl
+++ b/models/carolla2014campus-management/metadata.ttl
@@ -1,32 +1,39 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/e58213c9-beec-47f7-ac55-b5530bad3930/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:title "Campus Management System Reference Data Model";
     dct:issued "2014"^^xsd:gYear;
     dct:modified "2014"^^xsd:gYear;
     dcat:theme lcc:L;
-    skos:editorialNote "A derivation relation could not have its cardinalities properly represented, so a note element was used.\nThe original diagram does not present all stereotypes explained in the text.\n";
+    skos:editorialNote """A derivation relation could not have its cardinalities properly represented, so a note element was used.
+The original diagram does not present all stereotypes explained in the text.
+""";
     dct:language "en";
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:contributor <https://dblp.org/pid/83/4571>;
-    dcat:keyword "education"@en, "university"@en;
+    dcat:keyword "education"@en,
+                 "university"@en;
+    dct:source <https://core.ac.uk/display/211832003>;
     mod:designedForTask ocmv:ConceptualClarification;
     ocmv:context ocmv:Research;
-    dct:source <https://core.ac.uk/display/211832003>;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/carolla2014campus-management"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/carolla2014campus-management"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:43:48.856037859Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:43:48.856037859Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/e58213c9-beec-47f7-ac55-b5530bad3930> dcat:distribution <https://w3id.org/ontouml-models/distribution/ef15add8-be4c-413a-8927-beb28f0371ec/>, <https://w3id.org/ontouml-models/distribution/82cd6931-d4d4-43a8-b06f-709890f7c8a1/>, <https://w3id.org/ontouml-models/distribution/63ae8809-3ac9-4cfe-9cee-7f03c99fc433/>, <https://w3id.org/ontouml-models/distribution/f9e9075c-adff-4a53-bc18-2266715ec689>, <https://w3id.org/ontouml-models/distribution/1b78a165-6b20-42a9-b4d7-9ab1d291620d>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/e58213c9-beec-47f7-ac55-b5530bad3930> dcat:distribution <https://w3id.org/ontouml-models/distribution/ef15add8-be4c-413a-8927-beb28f0371ec/>,
+                      <https://w3id.org/ontouml-models/distribution/82cd6931-d4d4-43a8-b06f-709890f7c8a1/>,
+                      <https://w3id.org/ontouml-models/distribution/63ae8809-3ac9-4cfe-9cee-7f03c99fc433/>,
+                      <https://w3id.org/ontouml-models/distribution/f9e9075c-adff-4a53-bc18-2266715ec689>,
+                      <https://w3id.org/ontouml-models/distribution/1b78a165-6b20-42a9-b4d7-9ab1d291620d> .

--- a/models/castro2012cloudvulnerability/metadata.ttl
+++ b/models/castro2012cloudvulnerability/metadata.ttl
@@ -1,32 +1,48 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/9d3dc47b-2ca8-430e-8e57-c2c0a5ed8015/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:title "Cloud Vulnerability Ontology";
     dct:issued "2012"^^xsd:gYear;
     dct:modified "2012"^^xsd:gYear;
     dcat:theme lcc:T;
     skos:editorialNote "Thesis is not available anymore online, diagrams exerted from another repository effort.";
     dct:language "en";
-    dct:contributor <https://dblp.org/pid/119/6017>, <https://dblp.org/pid/119/6024>, <https://dblp.org/pid/06/10125>, <https://dblp.org/pid/119/6012>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    dct:contributor <https://dblp.org/pid/119/6017>,
+                    <https://dblp.org/pid/119/6024>,
+                    <https://dblp.org/pid/06/10125>,
+                    <https://dblp.org/pid/119/6012>;
     dcat:keyword "cloud computing"@en;
-    mod:designedForTask ocmv:ConceptualClarification, ocmv:Interoperability;
+    dct:source <https://doi.org/10.1109/ICDIM.2012.6360129>,
+               <https://siduece.uece.br/siduece/trabalhoAcademicoPublico.jsf?id=71084>,
+               <https://www.dline.info/jdp/fulltext/v2n3/2.pdf>;
+    mod:designedForTask ocmv:ConceptualClarification,
+                        ocmv:Interoperability;
     ocmv:context ocmv:Research;
-    dct:source <https://doi.org/10.1109/ICDIM.2012.6360129>, <https://siduece.uece.br/siduece/trabalhoAcademicoPublico.jsf?id=71084>, <https://www.dline.info/jdp/fulltext/v2n3/2.pdf>;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/castro2012cloudvulnerability"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/castro2012cloudvulnerability"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:43:57.670981508Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:43:57.670981508Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/9d3dc47b-2ca8-430e-8e57-c2c0a5ed8015> dcat:distribution <https://w3id.org/ontouml-models/distribution/333f75a6-bc22-4a06-942c-7e52fe469587/>, <https://w3id.org/ontouml-models/distribution/e1cb841b-4437-490c-ac86-4454dd5d65a4/>, <https://w3id.org/ontouml-models/distribution/f5bb080e-55d2-49a7-a0c4-d54268f57f7c/>, <https://w3id.org/ontouml-models/distribution/256a9f4f-1714-48cf-8bfd-fa1b3085289d>, <https://w3id.org/ontouml-models/distribution/a7304701-0734-460d-9b65-ebcbf9b6a0d6>, <https://w3id.org/ontouml-models/distribution/50f51c78-3419-4190-b67c-38ef7c99785f>, <https://w3id.org/ontouml-models/distribution/18f7c834-c8fc-4931-9dfc-5cb2b1150d62>, <https://w3id.org/ontouml-models/distribution/6c226bca-3276-4b54-89da-bbcf6e54f9c9>, <https://w3id.org/ontouml-models/distribution/05e97f34-1a58-4b6e-b107-935a426d57de>, <https://w3id.org/ontouml-models/distribution/dfd0b1ba-a4b1-47bf-9717-0713cf65616f>, <https://w3id.org/ontouml-models/distribution/dbf36a8f-d6a7-4036-9eaa-d345629d47b5>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/9d3dc47b-2ca8-430e-8e57-c2c0a5ed8015> dcat:distribution <https://w3id.org/ontouml-models/distribution/333f75a6-bc22-4a06-942c-7e52fe469587/>,
+                      <https://w3id.org/ontouml-models/distribution/e1cb841b-4437-490c-ac86-4454dd5d65a4/>,
+                      <https://w3id.org/ontouml-models/distribution/f5bb080e-55d2-49a7-a0c4-d54268f57f7c/>,
+                      <https://w3id.org/ontouml-models/distribution/256a9f4f-1714-48cf-8bfd-fa1b3085289d>,
+                      <https://w3id.org/ontouml-models/distribution/a7304701-0734-460d-9b65-ebcbf9b6a0d6>,
+                      <https://w3id.org/ontouml-models/distribution/50f51c78-3419-4190-b67c-38ef7c99785f>,
+                      <https://w3id.org/ontouml-models/distribution/18f7c834-c8fc-4931-9dfc-5cb2b1150d62>,
+                      <https://w3id.org/ontouml-models/distribution/6c226bca-3276-4b54-89da-bbcf6e54f9c9>,
+                      <https://w3id.org/ontouml-models/distribution/05e97f34-1a58-4b6e-b107-935a426d57de>,
+                      <https://w3id.org/ontouml-models/distribution/dfd0b1ba-a4b1-47bf-9717-0713cf65616f>,
+                      <https://w3id.org/ontouml-models/distribution/dbf36a8f-d6a7-4036-9eaa-d345629d47b5> .

--- a/models/cgts2021sebim/metadata.ttl
+++ b/models/cgts2021sebim/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/71fdda05-0b9e-4c78-8436-4e470b1e6208/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -21,14 +20,22 @@
     dct:language "en";
     dcat:landingPage <https://github.com/cgtsbr/sebim>;
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:contributor <https://dblp.org/pid/121/5314>, <https://dblp.org/pid/278/1460>;
-    dcat:keyword "sustainability"@en, "building"@en;
+    dct:contributor <https://dblp.org/pid/121/5314>,
+                    <https://dblp.org/pid/278/1460>;
+    dcat:keyword "sustainability"@en,
+                 "building"@en;
+    dct:source <https://dblp.org/rec/conf/ontobras/BaxS21>;
     mod:designedForTask ocmv:DecisionSupportSystem;
     ocmv:context ocmv:Research;
-    dct:source <https://dblp.org/rec/conf/ontobras/BaxS21>;
     ocmv:representationStyle ocmv:OntoumlStyle;
-    ocmv:ontologyType ocmv:Domain, ocmv:Application;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/cgts2021sebim"^^xsd:anyURI ;
+    ocmv:ontologyType ocmv:Domain,
+                      ocmv:Application;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/cgts2021sebim"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:44:15.882875807Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:44:15.882875807Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/71fdda05-0b9e-4c78-8436-4e470b1e6208> dcat:distribution <https://w3id.org/ontouml-models/distribution/7cb3817d-6732-4371-a8a1-91180018dc4c/>, <https://w3id.org/ontouml-models/distribution/c235165c-d113-40a5-8f83-a665ba417cb1/>, <https://w3id.org/ontouml-models/distribution/9a2d3707-d55e-4e58-9076-e1f03e351f3e/>, <https://w3id.org/ontouml-models/distribution/8376a2f0-45aa-40af-b283-f78344d11d4c>, <https://w3id.org/ontouml-models/distribution/3068e6bf-bd1e-4ca2-a319-b10f80c244ed>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/71fdda05-0b9e-4c78-8436-4e470b1e6208> dcat:distribution <https://w3id.org/ontouml-models/distribution/7cb3817d-6732-4371-a8a1-91180018dc4c/>,
+                      <https://w3id.org/ontouml-models/distribution/c235165c-d113-40a5-8f83-a665ba417cb1/>,
+                      <https://w3id.org/ontouml-models/distribution/9a2d3707-d55e-4e58-9076-e1f03e351f3e/>,
+                      <https://w3id.org/ontouml-models/distribution/8376a2f0-45aa-40af-b283-f78344d11d4c>,
+                      <https://w3id.org/ontouml-models/distribution/3068e6bf-bd1e-4ca2-a319-b10f80c244ed> .

--- a/models/chartered-service/metadata.ttl
+++ b/models/chartered-service/metadata.ttl
@@ -1,29 +1,35 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/81ee57e0-d340-4da4-826b-f99e361652d5/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
     dct:title "Chartered Service Ontology";
     dct:issued "2013"^^xsd:gYear;
     dcat:theme lcc:H;
-    skos:editorialNote "This is an ontology about the micro-domain of the Offering of Passenger Rail Chartered Services.,The ontology is inspired by the paper of Nardi et al. entitled \"Towards a Commitment-Based Reference Ontology for Services\".";
+    skos:editorialNote "This is an ontology about the micro-domain of the Offering of Passenger Rail Chartered Services.",
+                       "The ontology is inspired by the paper of Nardi et al. entitled \"Towards a Commitment-Based Reference Ontology for Services\".";
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dcat:keyword "service science"@en;
-    mod:designedForTask ocmv:ConceptualClarification, ocmv:Interoperability;
+    mod:designedForTask ocmv:ConceptualClarification,
+                        ocmv:Interoperability;
     ocmv:context ocmv:Classroom;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/chartered-service"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/chartered-service"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:44:24.770123474Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:44:24.770123474Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/81ee57e0-d340-4da4-826b-f99e361652d5> dcat:distribution <https://w3id.org/ontouml-models/distribution/e9788338-9faa-44f7-9c1a-b4b8d18132be/>, <https://w3id.org/ontouml-models/distribution/cc6a7aa2-cee7-4d07-a7ae-dcc8f267e19f/>, <https://w3id.org/ontouml-models/distribution/7b6290ff-a5c6-449a-9171-3d0c3a0da006/>, <https://w3id.org/ontouml-models/distribution/c6c45430-2f49-41d3-84b6-a3e656ec7fe6>, <https://w3id.org/ontouml-models/distribution/888003cf-595f-466a-a63c-c897612da9c1>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/81ee57e0-d340-4da4-826b-f99e361652d5> dcat:distribution <https://w3id.org/ontouml-models/distribution/e9788338-9faa-44f7-9c1a-b4b8d18132be/>,
+                      <https://w3id.org/ontouml-models/distribution/cc6a7aa2-cee7-4d07-a7ae-dcc8f267e19f/>,
+                      <https://w3id.org/ontouml-models/distribution/7b6290ff-a5c6-449a-9171-3d0c3a0da006/>,
+                      <https://w3id.org/ontouml-models/distribution/c6c45430-2f49-41d3-84b6-a3e656ec7fe6>,
+                      <https://w3id.org/ontouml-models/distribution/888003cf-595f-466a-a63c-c897612da9c1> .

--- a/models/clergy-ontology/metadata.ttl
+++ b/models/clergy-ontology/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/931db746-c36d-4077-bde7-1c317bfa5bcd/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -23,7 +22,12 @@
     ocmv:context ocmv:Classroom;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/clergy-ontology"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/clergy-ontology"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:44:33.540768813Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:44:33.540768813Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/931db746-c36d-4077-bde7-1c317bfa5bcd> dcat:distribution <https://w3id.org/ontouml-models/distribution/568d3128-1436-4d7c-a3e5-c2d66f4b630b/>, <https://w3id.org/ontouml-models/distribution/f2a049dd-f81b-402f-bdcc-40083970b596/>, <https://w3id.org/ontouml-models/distribution/7242f040-363d-4614-ae53-fddeb675d19b/>, <https://w3id.org/ontouml-models/distribution/111f1523-39dd-4fd2-b2bf-8970aaffb372>, <https://w3id.org/ontouml-models/distribution/3a6016dd-25c6-4ba5-912f-8f9eb0ca83c7>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/931db746-c36d-4077-bde7-1c317bfa5bcd> dcat:distribution <https://w3id.org/ontouml-models/distribution/568d3128-1436-4d7c-a3e5-c2d66f4b630b/>,
+                      <https://w3id.org/ontouml-models/distribution/f2a049dd-f81b-402f-bdcc-40083970b596/>,
+                      <https://w3id.org/ontouml-models/distribution/7242f040-363d-4614-ae53-fddeb675d19b/>,
+                      <https://w3id.org/ontouml-models/distribution/111f1523-39dd-4fd2-b2bf-8970aaffb372>,
+                      <https://w3id.org/ontouml-models/distribution/3a6016dd-25c6-4ba5-912f-8f9eb0ca83c7> .

--- a/models/cmpo2017/metadata.ttl
+++ b/models/cmpo2017/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/e9047c5f-2c8c-45cf-90e3-208c9791bba8/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -21,14 +20,27 @@
     dct:language "en";
     dcat:landingPage <https://dev.nemo.inf.ufes.br/seon/CMPO.html>;
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:contributor <https://dblp.org/pid/63/9777>, <https://dblp.org/pid/37/528>, <https://dblp.org/pid/229/4259>, <https://dblp.org/pid/189/5932>, <https://dblp.org/pid/97/7540>, <https://dblp.org/pid/11/78>;
+    dct:contributor <https://dblp.org/pid/63/9777>,
+                    <https://dblp.org/pid/37/528>,
+                    <https://dblp.org/pid/229/4259>,
+                    <https://dblp.org/pid/189/5932>,
+                    <https://dblp.org/pid/97/7540>,
+                    <https://dblp.org/pid/11/78>;
     dcat:keyword "configuration management"@en;
-    mod:designedForTask ocmv:ConceptualClarification, ocmv:Interoperability;
+    dct:source <https://nemo.inf.ufes.br/wp-content/papercite-data/pdf/software_engineering_standards_harmonization__an_ontology_based_approach_2017.pdf>,
+               <https://dl.acm.org/doi/pdf/10.1145/2245276.2245344>,
+               <https://doi.org/10.1007/978-3-319-49004-5_34>;
+    mod:designedForTask ocmv:ConceptualClarification,
+                        ocmv:Interoperability;
     ocmv:context ocmv:Research;
-    dct:source <https://nemo.inf.ufes.br/wp-content/papercite-data/pdf/software_engineering_standards_harmonization__an_ontology_based_approach_2017.pdf>, <https://dl.acm.org/doi/pdf/10.1145/2245276.2245344>, <https://doi.org/10.1007/978-3-319-49004-5_34>;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/cmpo2017"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/cmpo2017"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:44:42.359074731Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:44:42.359074731Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/e9047c5f-2c8c-45cf-90e3-208c9791bba8> dcat:distribution <https://w3id.org/ontouml-models/distribution/5df65aff-1413-44ab-bc14-236531846377/>, <https://w3id.org/ontouml-models/distribution/95ad44c2-f9de-4500-a5b7-51130f4ce226/>, <https://w3id.org/ontouml-models/distribution/f58f37ed-5158-4d76-916b-da03e2bb3cd7/>, <https://w3id.org/ontouml-models/distribution/286a887a-eddd-4c48-bf9f-06b43282abf9>, <https://w3id.org/ontouml-models/distribution/46fb95af-530c-470b-b254-098eafa5c205>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/e9047c5f-2c8c-45cf-90e3-208c9791bba8> dcat:distribution <https://w3id.org/ontouml-models/distribution/5df65aff-1413-44ab-bc14-236531846377/>,
+                      <https://w3id.org/ontouml-models/distribution/95ad44c2-f9de-4500-a5b7-51130f4ce226/>,
+                      <https://w3id.org/ontouml-models/distribution/f58f37ed-5158-4d76-916b-da03e2bb3cd7/>,
+                      <https://w3id.org/ontouml-models/distribution/286a887a-eddd-4c48-bf9f-06b43282abf9>,
+                      <https://w3id.org/ontouml-models/distribution/46fb95af-530c-470b-b254-098eafa5c205> .

--- a/models/construction-model/metadata.ttl
+++ b/models/construction-model/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/0bf7f860-ed96-41a8-be3d-965c8de83b6d/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -19,11 +18,17 @@
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dcat:keyword "construction"@en;
-    mod:designedForTask ocmv:Learning, ocmv:ConceptualClarification;
+    mod:designedForTask ocmv:Learning,
+                        ocmv:ConceptualClarification;
     ocmv:context ocmv:Classroom;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/construction-model"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/construction-model"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:44:51.239172819Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:44:51.239172819Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/0bf7f860-ed96-41a8-be3d-965c8de83b6d> dcat:distribution <https://w3id.org/ontouml-models/distribution/910fce8d-e1df-4e7a-a28d-5e03fcdf8d22/>, <https://w3id.org/ontouml-models/distribution/5d6e6db8-b448-4d07-a758-51cd03e615e5/>, <https://w3id.org/ontouml-models/distribution/d2c1c377-8df9-4ea8-9ded-f9f4f6a8ba39/>, <https://w3id.org/ontouml-models/distribution/0c1de3b5-a58d-40e7-8d75-2e786fafa697>, <https://w3id.org/ontouml-models/distribution/983e969b-e750-44da-8dd2-1f3337e850dc>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/0bf7f860-ed96-41a8-be3d-965c8de83b6d> dcat:distribution <https://w3id.org/ontouml-models/distribution/910fce8d-e1df-4e7a-a28d-5e03fcdf8d22/>,
+                      <https://w3id.org/ontouml-models/distribution/5d6e6db8-b448-4d07-a758-51cd03e615e5/>,
+                      <https://w3id.org/ontouml-models/distribution/d2c1c377-8df9-4ea8-9ded-f9f4f6a8ba39/>,
+                      <https://w3id.org/ontouml-models/distribution/0c1de3b5-a58d-40e7-8d75-2e786fafa697>,
+                      <https://w3id.org/ontouml-models/distribution/983e969b-e750-44da-8dd2-1f3337e850dc> .

--- a/models/core-o2023/metadata.ttl
+++ b/models/core-o2023/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/2b3d29db-eaea-4966-83e5-af9ca54f3086/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -17,15 +16,31 @@
     dct:issued "2023"^^xsd:gYear;
     dcat:theme lcc:H;
     dct:language "en";
-    dcat:landingPage <https://core-o.github.io/ontology/>, <https://github.com/core-o,https://purl.org/coreo>;
+    dcat:landingPage <https://core-o.github.io/ontology/>,
+                     <https://github.com/core-o>,
+                     <https://purl.org/coreo>;
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:contributor <https://dblp.org/pid/11/78>, <https://dblp.org/pid/134/4947>, <https://dblp.org/pid/63/9777>, <https://dblp.org/pid/91/3408>;
-    dcat:keyword "competence"@en, "skill"@en, "human resource"@en;
-    mod:designedForTask ocmv:ConceptualClarification, ocmv:DataPublication, ocmv:InformationRetrieval, ocmv:Interoperability, ocmv:LanguageEngineering;
+    dct:contributor <https://dblp.org/pid/11/78>,
+                    <https://dblp.org/pid/134/4947>,
+                    <https://dblp.org/pid/63/9777>,
+                    <https://dblp.org/pid/91/3408>;
+    dcat:keyword "competence"@en,
+                 "skill"@en,
+                 "human resource"@en;
+    mod:designedForTask ocmv:ConceptualClarification,
+                        ocmv:DataPublication,
+                        ocmv:InformationRetrieval,
+                        ocmv:Interoperability,
+                        ocmv:LanguageEngineering;
     ocmv:context ocmv:Research;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Core;
     ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/core-o2023"^^xsd:anyURI;
     fdpo:metadataIssued "2023-05-30T14:35:22.418951794Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-05-30T14:35:22.418951794Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/2b3d29db-eaea-4966-83e5-af9ca54f3086> dcat:distribution <https://w3id.org/ontouml-models/distribution/ea80f423-ae53-4deb-947c-71ad0e748259/>, <https://w3id.org/ontouml-models/distribution/aa7c8a8e-a45d-4d1a-8e5e-3cbbc4558d9b/>, <https://w3id.org/ontouml-models/distribution/a49b5dde-ba6e-4ce0-a5b2-cccd1c6825c0/>, <https://w3id.org/ontouml-models/distribution/9a459b5e-6fc0-45f2-8633-5e183cd2f669>, <https://w3id.org/ontouml-models/distribution/4b6ea7bc-67d5-4799-b65a-6b399ab2907f>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/2b3d29db-eaea-4966-83e5-af9ca54f3086> dcat:distribution <https://w3id.org/ontouml-models/distribution/ea80f423-ae53-4deb-947c-71ad0e748259/>,
+                      <https://w3id.org/ontouml-models/distribution/aa7c8a8e-a45d-4d1a-8e5e-3cbbc4558d9b/>,
+                      <https://w3id.org/ontouml-models/distribution/a49b5dde-ba6e-4ce0-a5b2-cccd1c6825c0/>,
+                      <https://w3id.org/ontouml-models/distribution/9a459b5e-6fc0-45f2-8633-5e183cd2f669>,
+                      <https://w3id.org/ontouml-models/distribution/4b6ea7bc-67d5-4799-b65a-6b399ab2907f> .

--- a/models/cunha2025soberana/metadata.ttl
+++ b/models/cunha2025soberana/metadata.ttl
@@ -1,15 +1,16 @@
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/model/cunha2025soberana/> a dcat:Dataset, mod:SemanticArtefact;
+<https://w3id.org/ontouml-models/model/cunha2025soberana/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
+    dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
     dct:title "Soberana Domain Reference Ontology for describing an International Data Spaces Ecosystem";
     mod:acronym "SBRN";
     dct:issued "2023"^^xsd:gYear;
@@ -18,22 +19,30 @@
     skos:editorialNote "The ontology was developed under the SABiO methodology, based on UFO, and represented in OntoUML. Its semantic consistency was verified using the OntoUML plugin in Visual Paradigm.";
     dct:language "en";
     dct:license <https://opensource.org/license/mit>;
-    dct:contributor <https://dblp.org/pid/393/9680>, <https://dblp.org/pid/63/5160>, <https://dblp.org/pid/74/7740>;
-    mod:designedForTask ocmv:ConceptualClarification, ocmv:OntologicalAnalysis;
+    dct:contributor <https://dblp.org/pid/393/9680>,
+                    <https://dblp.org/pid/63/5160>,
+                    <https://dblp.org/pid/74/7740>;
+    dcat:keyword "international data spaces"@en,
+                 "data sovereignty"@en,
+                 "data usage policy"@en,
+                 "certification"@en;
+    dct:source <https://repositorio.ufersa.edu.br/handle/prefix/10158>;
+    mod:designedForTask ocmv:ConceptualClarification,
+                        ocmv:OntologicalAnalysis;
     ocmv:context ocmv:Research;
-    dct:source <https://repositorio.ufersa.edu.br/handle/prefix/10158>.
-<https://w3id.org/ontouml-models/model/cunha2025soberana/> dcat:distribution <https://w3id.org/ontouml-models/model/cunha2025soberana/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/cunha2025soberana/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Soberana Domain Reference Ontology for describing an International Data Spaces Ecosystem\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/cunha2025soberana/ontology.ttl>.
-<https://w3id.org/ontouml-models/model/cunha2025soberana/> dcat:distribution <https://w3id.org/ontouml-models/model/cunha2025soberana/distribution/json>.
-<https://w3id.org/ontouml-models/model/cunha2025soberana/distribution/json> a dcat:Distribution;
-    dct:title "JSON distribution of \"Soberana Domain Reference Ontology for describing an International Data Spaces Ecosystem\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/cunha2025soberana/ontology.json>.
-<https://w3id.org/ontouml-models/model/cunha2025soberana/> dcat:distribution <https://w3id.org/ontouml-models/model/cunha2025soberana/distribution/vpp>.
-<https://w3id.org/ontouml-models/model/cunha2025soberana/distribution/vpp> a dcat:Distribution;
-    dct:title "Visual Paradigm distribution of \"Soberana Domain Reference Ontology for describing an International Data Spaces Ecosystem\""@en;
-    dcat:mediaType <https://www.visual-paradigm.com/vpp>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/cunha2025soberana/ontology.vpp>.
+    ocmv:representationStyle ocmv:OntoumlStyle;
+    ocmv:ontologyType ocmv:Domain;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/cunha2025soberana"^^xsd:anyURI;
+    fdpo:metadataIssued "2026-06-23T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/cunha2025soberana/> dcat:distribution <https://w3id.org/ontouml-models/model/cunha2025soberana/distribution/ttl>,
+                      <https://www.iana.org/assignments/media-types/text/turtle>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/cunha2025soberana/ontology.ttl>,
+                      <https://w3id.org/ontouml-models/model/cunha2025soberana/>,
+                      <https://w3id.org/ontouml-models/model/cunha2025soberana/distribution/json>,
+                      <https://www.iana.org/assignments/media-types/application/json>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/cunha2025soberana/ontology.json>,
+                      <https://w3id.org/ontouml-models/model/cunha2025soberana/distribution/vpp>,
+                      <https://www.visual-paradigm.com/vpp>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/cunha2025soberana/ontology.vpp> .

--- a/models/dcat-mlt-ufo2023/metadata.ttl
+++ b/models/dcat-mlt-ufo2023/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/a2b41412-02d5-4716-bdb0-c4112a2626d7/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -19,14 +18,26 @@
     skos:editorialNote "The model was designed using the Visual Paradigm tool, version 16.3, with the OntoUML plugin. The original file contained classes and relationships duplicated in different packages; they were merged and removed whenever possible.";
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:contributor <https://dblp.org/pid/01/4327>, <https://dblp.org/pid/312/4450>, <https://dblp.org/pid/78/4279>;
-    dcat:keyword "catalogue"@en, "repository"@en, "catalogued resource"@en;
-    mod:designedForTask ocmv:ConceptualClarification, ocmv:InformationRetrieval, ocmv:Interoperability;
-    ocmv:context ocmv:Research;
+    dct:contributor <https://dblp.org/pid/01/4327>,
+                    <https://dblp.org/pid/312/4450>,
+                    <https://dblp.org/pid/78/4279>;
+    dcat:keyword "catalogue"@en,
+                 "repository"@en,
+                 "catalogued resource"@en;
     dct:source <https://ceur-ws.org/Vol-3346/Paper4.pdf>;
+    mod:designedForTask ocmv:ConceptualClarification,
+                        ocmv:InformationRetrieval,
+                        ocmv:Interoperability;
+    ocmv:context ocmv:Research;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Core;
     ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/dcat-mlt-ufo2023"^^xsd:anyURI;
     fdpo:metadataIssued "2023-05-30T14:35:33.724439936Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-05-30T14:35:33.724439936Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/a2b41412-02d5-4716-bdb0-c4112a2626d7> dcat:distribution <https://w3id.org/ontouml-models/distribution/556883d0-b35f-4cb8-8c74-f7d0ec169d6f/>, <https://w3id.org/ontouml-models/distribution/0b736b1f-8dfa-4d7c-bf8d-7bd491b3d019/>, <https://w3id.org/ontouml-models/distribution/7c60e86d-6ce7-4953-9d22-6a465dcd74bd/>, <https://w3id.org/ontouml-models/distribution/82fc1586-4e4a-4632-9376-873b8c2c588c>, <https://w3id.org/ontouml-models/distribution/b9fcecbb-0033-4d8a-9fd8-ba91b1f275f3>, <https://w3id.org/ontouml-models/distribution/5794d57f-0ba1-4c24-9bda-6b40af002416>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/a2b41412-02d5-4716-bdb0-c4112a2626d7> dcat:distribution <https://w3id.org/ontouml-models/distribution/556883d0-b35f-4cb8-8c74-f7d0ec169d6f/>,
+                      <https://w3id.org/ontouml-models/distribution/0b736b1f-8dfa-4d7c-bf8d-7bd491b3d019/>,
+                      <https://w3id.org/ontouml-models/distribution/7c60e86d-6ce7-4953-9d22-6a465dcd74bd/>,
+                      <https://w3id.org/ontouml-models/distribution/82fc1586-4e4a-4632-9376-873b8c2c588c>,
+                      <https://w3id.org/ontouml-models/distribution/b9fcecbb-0033-4d8a-9fd8-ba91b1f275f3>,
+                      <https://w3id.org/ontouml-models/distribution/5794d57f-0ba1-4c24-9bda-6b40af002416> .

--- a/models/debbech2019gosmo/metadata.ttl
+++ b/models/debbech2019gosmo/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/09d75270-acbd-4533-b7ed-6c498cf2a3c6/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -19,14 +18,22 @@
     dcat:theme lcc:T;
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:contributor <https://dblp.org/pid/240/8231>, <https://dblp.org/pid/128/8062>, <https://dblp.org/pid/29/3283>;
+    dct:contributor <https://dblp.org/pid/240/8231>,
+                    <https://dblp.org/pid/128/8062>,
+                    <https://dblp.org/pid/29/3283>;
     dcat:keyword "safety critical systems"@en;
+    dct:source <https://doi.org/10.5220/0007932502870297>,
+               <https://doi.org/10.17706/jcp.14.4.257-267>;
     mod:designedForTask ocmv:ConceptualClarification;
     ocmv:context ocmv:Research;
-    dct:source <https://doi.org/10.5220/0007932502870297>, <https://doi.org/10.17706/jcp.14.4.257-267>;
     ocmv:representationStyle ocmv:UfoStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/debbech2019gosmo"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/debbech2019gosmo"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:44:59.909631301Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:44:59.909631301Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/09d75270-acbd-4533-b7ed-6c498cf2a3c6> dcat:distribution <https://w3id.org/ontouml-models/distribution/4c152305-3a4d-4a9f-b4f0-db4db4886192/>, <https://w3id.org/ontouml-models/distribution/84d37483-1ceb-4325-b96f-deba2aa2c652/>, <https://w3id.org/ontouml-models/distribution/8cd7341f-217c-48c7-a7c6-e7b10100ddce/>, <https://w3id.org/ontouml-models/distribution/22db1cd5-7901-4c14-bf17-415b98cf2e26>, <https://w3id.org/ontouml-models/distribution/0c323f34-bc3c-4599-b553-97f20588c632>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/09d75270-acbd-4533-b7ed-6c498cf2a3c6> dcat:distribution <https://w3id.org/ontouml-models/distribution/4c152305-3a4d-4a9f-b4f0-db4db4886192/>,
+                      <https://w3id.org/ontouml-models/distribution/84d37483-1ceb-4325-b96f-deba2aa2c652/>,
+                      <https://w3id.org/ontouml-models/distribution/8cd7341f-217c-48c7-a7c6-e7b10100ddce/>,
+                      <https://w3id.org/ontouml-models/distribution/22db1cd5-7901-4c14-bf17-415b98cf2e26>,
+                      <https://w3id.org/ontouml-models/distribution/0c323f34-bc3c-4599-b553-97f20588c632> .

--- a/models/debbech2020dysfunction-analysis/metadata.ttl
+++ b/models/debbech2020dysfunction-analysis/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/1516b7a7-5310-4dda-a7a6-ff711d73f925/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -19,14 +18,27 @@
     skos:editorialNote "License derived from the one stated in the publication.";
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by-nd/4.0/>;
-    dct:contributor <https://dblp.org/pid/240/8231>, <https://dblp.org/pid/29/3283>, <https://dblp.org/pid/128/8062>, <https://dblp.org/pid/205/5972>, <https://dblp.org/pid/128/0920>;
+    dct:contributor <https://dblp.org/pid/240/8231>,
+                    <https://dblp.org/pid/29/3283>,
+                    <https://dblp.org/pid/128/8062>,
+                    <https://dblp.org/pid/205/5972>,
+                    <https://dblp.org/pid/128/0920>;
     dcat:keyword "safety"@en;
-    mod:designedForTask ocmv:ConceptualClarification, ocmv:Interoperability;
+    dct:source <https://dblp.org/rec/journals/jucs/DebbechDB20>,
+               <https://doi.org/10.1007/978-3-030-33223-5_28>;
+    mod:designedForTask ocmv:ConceptualClarification,
+                        ocmv:Interoperability;
     ocmv:context ocmv:Industry;
-    dct:source <https://dblp.org/rec/journals/jucs/DebbechDB20>, <https://doi.org/10.1007/978-3-030-33223-5_28>;
     ocmv:representationStyle ocmv:UfoStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/debbech2020dysfunction-analysis"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/debbech2020dysfunction-analysis"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:45:09.278382788Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:45:09.278382788Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/1516b7a7-5310-4dda-a7a6-ff711d73f925> dcat:distribution <https://w3id.org/ontouml-models/distribution/97526a1e-7c8d-4d15-9513-7e8012dd1b2a/>, <https://w3id.org/ontouml-models/distribution/450974bd-5932-4593-9a0d-103382316215/>, <https://w3id.org/ontouml-models/distribution/9a25326e-6be8-4cb9-9f12-bd95c7d8a1f3/>, <https://w3id.org/ontouml-models/distribution/9bd67385-6aef-49af-abd8-2620e3ebc9eb>, <https://w3id.org/ontouml-models/distribution/dadbffe5-31d6-42e6-ac32-b06014a94ca4>, <https://w3id.org/ontouml-models/distribution/9bc2f151-5dab-4982-a1ed-5d68be5ff950>, <https://w3id.org/ontouml-models/distribution/0df0d58a-3489-4537-af16-cda284d9352a>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/1516b7a7-5310-4dda-a7a6-ff711d73f925> dcat:distribution <https://w3id.org/ontouml-models/distribution/97526a1e-7c8d-4d15-9513-7e8012dd1b2a/>,
+                      <https://w3id.org/ontouml-models/distribution/450974bd-5932-4593-9a0d-103382316215/>,
+                      <https://w3id.org/ontouml-models/distribution/9a25326e-6be8-4cb9-9f12-bd95c7d8a1f3/>,
+                      <https://w3id.org/ontouml-models/distribution/9bd67385-6aef-49af-abd8-2620e3ebc9eb>,
+                      <https://w3id.org/ontouml-models/distribution/dadbffe5-31d6-42e6-ac32-b06014a94ca4>,
+                      <https://w3id.org/ontouml-models/distribution/9bc2f151-5dab-4982-a1ed-5d68be5ff950>,
+                      <https://w3id.org/ontouml-models/distribution/0df0d58a-3489-4537-af16-cda284d9352a> .

--- a/models/demori2023miscon/metadata.ttl
+++ b/models/demori2023miscon/metadata.ttl
@@ -1,15 +1,16 @@
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/model/demori2023miscon/> a dcat:Dataset, mod:SemanticArtefact;
+<https://w3id.org/ontouml-models/model/demori2023miscon/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
+    dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
     dct:title "Military Scenario Ontology";
     mod:acronym "MiScOn";
     dct:issued "2023"^^xsd:gYear;
@@ -17,22 +18,33 @@
     skos:editorialNote "This model contains a n-ary relation. These relations are not supported by the current JSON exportation feature. Hence, to be able to generate the ontology.json file, this n-ary relation was temporarily excluded (but it is kept in the vpp file).";
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:contributor <https://dblp.org/pid/342/7506>, <https://dblp.org/pid/166/2068>, <https://dblp.org/pid/125/7740>, <https://dblp.org/pid/352/9170>, <https://dblp.org/pid/352/9879>, <https://dblp.org/pid/35/9023>, <https://dblp.org/pid/96/3201>, <https://dblp.org/pid/c/MariaClaudiaReisCavalcanti>;
-    mod:designedForTask ocmv:ConceptualClarification, ocmv:DecisionSupportSystem, ocmv:OntologicalAnalysis;
+    dct:contributor <https://dblp.org/pid/342/7506>,
+                    <https://dblp.org/pid/166/2068>,
+                    <https://dblp.org/pid/125/7740>,
+                    <https://dblp.org/pid/352/9170>,
+                    <https://dblp.org/pid/352/9879>,
+                    <https://dblp.org/pid/35/9023>,
+                    <https://dblp.org/pid/96/3201>,
+                    <https://dblp.org/pid/c/MariaClaudiaReisCavalcanti>;
+    dcat:keyword "military personnel"@en,
+                 "military equipment"@en,
+                 "military organization"@en;
+    dct:source <https://doi.org/10.5220/0012088600003541>;
+    mod:designedForTask ocmv:ConceptualClarification,
+                        ocmv:DecisionSupportSystem,
+                        ocmv:OntologicalAnalysis;
     ocmv:context ocmv:Research;
-    dct:source <https://doi.org/10.5220/0012088600003541>.
-<https://w3id.org/ontouml-models/model/demori2023miscon/> dcat:distribution <https://w3id.org/ontouml-models/model/demori2023miscon/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/demori2023miscon/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Military Scenario Ontology\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/demori2023miscon/ontology.ttl>.
-<https://w3id.org/ontouml-models/model/demori2023miscon/> dcat:distribution <https://w3id.org/ontouml-models/model/demori2023miscon/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/demori2023miscon/distribution/ttl> a dcat:Distribution;
-    dct:title "JSON distribution of \"Military Scenario Ontology\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/demori2023miscon/ontology.json>.
-<https://w3id.org/ontouml-models/model/demori2023miscon/> dcat:distribution <https://w3id.org/ontouml-models/model/demori2023miscon/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/demori2023miscon/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Military Scenario Ontology\""@en;
-    dcat:mediaType <https://www.visual-paradigm.com/vpp>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/demori2023miscon/ontology.vpp>.
+    ocmv:representationStyle ocmv:OntoumlStyle;
+    ocmv:ontologyType ocmv:Domain;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/demori2023miscon"^^xsd:anyURI;
+    fdpo:metadataIssued "2026-06-23T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/demori2023miscon/> dcat:distribution <https://w3id.org/ontouml-models/model/demori2023miscon/distribution/ttl>,
+                      <https://www.iana.org/assignments/media-types/text/turtle>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/demori2023miscon/ontology.ttl>,
+                      <https://w3id.org/ontouml-models/model/demori2023miscon/>,
+                      <https://www.iana.org/assignments/media-types/application/json>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/demori2023miscon/ontology.json>,
+                      <https://www.visual-paradigm.com/vpp>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/demori2023miscon/ontology.vpp> .

--- a/models/derave2019dpo/metadata.ttl
+++ b/models/derave2019dpo/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/203d95b5-1957-46ae-9d3b-065da02ada09/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -21,14 +20,88 @@
     dct:language "en";
     dcat:landingPage <https://www.model-a-platform.com>;
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:contributor <https://dblp.org/pid/251/5991>, <https://dblp.org/pid/134/4947>, <https://dblp.org/pid/152/3885>, <https://dblp.org/pid/95/6356>, <https://dblp.org/pid/72/6796>;
+    dct:contributor <https://dblp.org/pid/251/5991>,
+                    <https://dblp.org/pid/134/4947>,
+                    <https://dblp.org/pid/152/3885>,
+                    <https://dblp.org/pid/95/6356>,
+                    <https://dblp.org/pid/72/6796>;
     dcat:keyword "digital platforms"@en;
+    dct:source <https://doi.org/10.1007/978-3-030-34146-6_17>,
+               <https://dblp.org/rec/conf/vmbo/DeraveSPG20>,
+               <https://doi.org/10.1007/978-3-030-62522-1_21>,
+               <https://doi.org/10.1007/978-3-030-79382-1_25>,
+               <https://dblp.org/rec/conf/ifip8-1/DeraveSGP21>,
+               <https://doi.org/10.3390/su14042076>;
     mod:designedForTask ocmv:SoftwareEngineering;
     ocmv:context ocmv:Research;
-    dct:source <https://doi.org/10.1007/978-3-030-34146-6_17>, <https://dblp.org/rec/conf/vmbo/DeraveSPG20>, <https://doi.org/10.1007/978-3-030-62522-1_21>, <https://doi.org/10.1007/978-3-030-79382-1_25>, <https://dblp.org/rec/conf/ifip8-1/DeraveSGP21>, <https://doi.org/10.3390/su14042076>;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Core;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/derave2019dpo"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/derave2019dpo"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:45:21.455925627Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:45:21.455925627Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/203d95b5-1957-46ae-9d3b-065da02ada09> dcat:distribution <https://w3id.org/ontouml-models/distribution/9039a548-ba12-422e-addf-e605320e2ede/>, <https://w3id.org/ontouml-models/distribution/06a92ee0-2f9f-48fa-9992-f96a5a153733/>, <https://w3id.org/ontouml-models/distribution/eaaf367d-6c1f-4e00-9b5b-a6bd864570c7/>, <https://w3id.org/ontouml-models/distribution/0f63464f-735c-4f5a-8c69-86d63780d035>, <https://w3id.org/ontouml-models/distribution/8c527b78-9f88-49e4-9abc-de413cfcdd11>, <https://w3id.org/ontouml-models/distribution/1105559e-9e97-4344-aae0-f2218c0a0b33>, <https://w3id.org/ontouml-models/distribution/0968d278-18f1-4285-9de1-f9d6109c6617>, <https://w3id.org/ontouml-models/distribution/bf488e0e-f403-431d-a98a-89c5c3f26855>, <https://w3id.org/ontouml-models/distribution/2300454b-4e5c-49ba-8bbc-5fe944770a45>, <https://w3id.org/ontouml-models/distribution/7fff43fe-820e-44b0-b5a7-27dbb7aeae3c>, <https://w3id.org/ontouml-models/distribution/b70699a2-ef85-4eeb-9934-57031d02b2ab>, <https://w3id.org/ontouml-models/distribution/44dc7a83-f780-4603-8482-0f15ad5f5f37>, <https://w3id.org/ontouml-models/distribution/b1e1f452-da67-4fe1-b79d-18e9b23cd07c>, <https://w3id.org/ontouml-models/distribution/4f17edc5-40ee-40fe-91f7-c7f48dd1299f>, <https://w3id.org/ontouml-models/distribution/0f7efa4b-7991-4468-8439-9926bb476e0a>, <https://w3id.org/ontouml-models/distribution/7568af65-f330-4eb4-b7b0-46da15578486>, <https://w3id.org/ontouml-models/distribution/23f64cba-22e9-4089-b96b-e19ed6c33f52>, <https://w3id.org/ontouml-models/distribution/62832832-2757-47d8-9e6d-5dc60cd3c84b>, <https://w3id.org/ontouml-models/distribution/ca126f51-9114-47b4-9a55-3fdced0b097d>, <https://w3id.org/ontouml-models/distribution/4e4fe469-1d4d-4697-a4d4-4de6ae305725>, <https://w3id.org/ontouml-models/distribution/c4f3d2a6-0f9f-4548-8c34-77cf810ed12b>, <https://w3id.org/ontouml-models/distribution/74320af7-645e-46e7-8749-fb4b236eca24>, <https://w3id.org/ontouml-models/distribution/7b649ade-9b5a-4448-8d29-4c7a8d01e7f4>, <https://w3id.org/ontouml-models/distribution/8aa3b9e8-1511-428c-9d96-0b174fe9713d>, <https://w3id.org/ontouml-models/distribution/e538a22e-83cd-499c-90c9-f05195b0cbab>, <https://w3id.org/ontouml-models/distribution/2deeecd8-87ae-4718-b53b-fa3b50a2a111>, <https://w3id.org/ontouml-models/distribution/77591360-2a84-4018-93ba-4f8aaeabb9de>, <https://w3id.org/ontouml-models/distribution/c6183823-a35d-4d57-86dc-b4b581dd315e>, <https://w3id.org/ontouml-models/distribution/a895c02a-15f7-41e4-a3da-3fe4bb263153>, <https://w3id.org/ontouml-models/distribution/7683f9b1-2623-48b0-9000-334df439a9fa>, <https://w3id.org/ontouml-models/distribution/1f1d7d08-2d7d-48f6-b3a2-6d67968d3f37>, <https://w3id.org/ontouml-models/distribution/620610e9-d005-4789-bee2-d3f4beee6e0d>, <https://w3id.org/ontouml-models/distribution/d9ce1ea2-522b-483f-ae8b-11db5965a016>, <https://w3id.org/ontouml-models/distribution/7b5d5c68-f4d2-4814-8376-86e3db7944c8>, <https://w3id.org/ontouml-models/distribution/776f528a-558f-4d37-b315-38da38d0d43c>, <https://w3id.org/ontouml-models/distribution/54a4c121-1ae3-4fab-af96-ecfc62886b89>, <https://w3id.org/ontouml-models/distribution/754b4766-2861-4a2b-925f-bca3c06c7f0b>, <https://w3id.org/ontouml-models/distribution/cba843e9-4e75-4e91-9c60-911c6b3270d9>, <https://w3id.org/ontouml-models/distribution/657e00b6-9cba-436d-9f7c-aa237666ad8d>, <https://w3id.org/ontouml-models/distribution/16d347c3-f296-4b0a-bfd0-b1ed672ebd15>, <https://w3id.org/ontouml-models/distribution/95a589a3-fd15-4492-a6e1-ed4b7a372aec>, <https://w3id.org/ontouml-models/distribution/efe962b3-e076-4a41-9e4a-221992c957fb>, <https://w3id.org/ontouml-models/distribution/21c4f6b0-6039-4088-ad02-f212d3f25d08>, <https://w3id.org/ontouml-models/distribution/f5f45699-46e3-42a8-a22b-1673861ba5ca>, <https://w3id.org/ontouml-models/distribution/d4ccaf5f-44a7-45bd-b95d-be230b72022e>, <https://w3id.org/ontouml-models/distribution/077da10d-a816-477a-8190-332304f48fe1>, <https://w3id.org/ontouml-models/distribution/cbc59520-dec1-4dc9-8f85-7d900ff6b3aa>, <https://w3id.org/ontouml-models/distribution/1be92fbf-6086-4682-8e58-55c685c83f4d>, <https://w3id.org/ontouml-models/distribution/fd3646db-5d72-4d0f-8d2c-5b59972922ed>, <https://w3id.org/ontouml-models/distribution/886f66a0-8e0e-4c98-9b5b-ce58b4617f8b>, <https://w3id.org/ontouml-models/distribution/35095794-5cba-4c07-9a3c-bb134214b09b>, <https://w3id.org/ontouml-models/distribution/7a86c724-bba8-4f63-820b-0fa18da2a747>, <https://w3id.org/ontouml-models/distribution/82bf7091-947d-4617-a7b3-8ad91b068a50>, <https://w3id.org/ontouml-models/distribution/e2b71181-a7c9-4ff3-8a10-d737b0f1e118>, <https://w3id.org/ontouml-models/distribution/4b73e3af-af22-41ab-8027-aecf1ba90321>, <https://w3id.org/ontouml-models/distribution/4b73e3af-af22-41ab-8027-aecf1ba903212>, <https://w3id.org/ontouml-models/distribution/0bd2ffa3-7d1d-41d0-9b26-08ca061d4757>, <https://w3id.org/ontouml-models/distribution/173ad9a4-842e-4d7f-baad-6790abd95cb1>, <https://w3id.org/ontouml-models/distribution/7537ad7a-77e0-47cd-8daa-089356dc45bf>, <https://w3id.org/ontouml-models/distribution/8392f83f-da58-41b3-afd2-b93b64e30607>, <https://w3id.org/ontouml-models/distribution/2a733b2f-8590-42ec-9b3e-0f7698c78cea>, <https://w3id.org/ontouml-models/distribution/e48a6d81-f6c4-4d82-8403-323c98f8ea51>, <https://w3id.org/ontouml-models/distribution/527fda54-bfb9-4767-9175-69710b2053f8>, <https://w3id.org/ontouml-models/distribution/976da91b-9a69-4b56-8485-cac068b0ece5>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/203d95b5-1957-46ae-9d3b-065da02ada09> dcat:distribution <https://w3id.org/ontouml-models/distribution/9039a548-ba12-422e-addf-e605320e2ede/>,
+                      <https://w3id.org/ontouml-models/distribution/06a92ee0-2f9f-48fa-9992-f96a5a153733/>,
+                      <https://w3id.org/ontouml-models/distribution/eaaf367d-6c1f-4e00-9b5b-a6bd864570c7/>,
+                      <https://w3id.org/ontouml-models/distribution/0f63464f-735c-4f5a-8c69-86d63780d035>,
+                      <https://w3id.org/ontouml-models/distribution/8c527b78-9f88-49e4-9abc-de413cfcdd11>,
+                      <https://w3id.org/ontouml-models/distribution/1105559e-9e97-4344-aae0-f2218c0a0b33>,
+                      <https://w3id.org/ontouml-models/distribution/0968d278-18f1-4285-9de1-f9d6109c6617>,
+                      <https://w3id.org/ontouml-models/distribution/bf488e0e-f403-431d-a98a-89c5c3f26855>,
+                      <https://w3id.org/ontouml-models/distribution/2300454b-4e5c-49ba-8bbc-5fe944770a45>,
+                      <https://w3id.org/ontouml-models/distribution/7fff43fe-820e-44b0-b5a7-27dbb7aeae3c>,
+                      <https://w3id.org/ontouml-models/distribution/b70699a2-ef85-4eeb-9934-57031d02b2ab>,
+                      <https://w3id.org/ontouml-models/distribution/44dc7a83-f780-4603-8482-0f15ad5f5f37>,
+                      <https://w3id.org/ontouml-models/distribution/b1e1f452-da67-4fe1-b79d-18e9b23cd07c>,
+                      <https://w3id.org/ontouml-models/distribution/4f17edc5-40ee-40fe-91f7-c7f48dd1299f>,
+                      <https://w3id.org/ontouml-models/distribution/0f7efa4b-7991-4468-8439-9926bb476e0a>,
+                      <https://w3id.org/ontouml-models/distribution/7568af65-f330-4eb4-b7b0-46da15578486>,
+                      <https://w3id.org/ontouml-models/distribution/23f64cba-22e9-4089-b96b-e19ed6c33f52>,
+                      <https://w3id.org/ontouml-models/distribution/62832832-2757-47d8-9e6d-5dc60cd3c84b>,
+                      <https://w3id.org/ontouml-models/distribution/ca126f51-9114-47b4-9a55-3fdced0b097d>,
+                      <https://w3id.org/ontouml-models/distribution/4e4fe469-1d4d-4697-a4d4-4de6ae305725>,
+                      <https://w3id.org/ontouml-models/distribution/c4f3d2a6-0f9f-4548-8c34-77cf810ed12b>,
+                      <https://w3id.org/ontouml-models/distribution/74320af7-645e-46e7-8749-fb4b236eca24>,
+                      <https://w3id.org/ontouml-models/distribution/7b649ade-9b5a-4448-8d29-4c7a8d01e7f4>,
+                      <https://w3id.org/ontouml-models/distribution/8aa3b9e8-1511-428c-9d96-0b174fe9713d>,
+                      <https://w3id.org/ontouml-models/distribution/e538a22e-83cd-499c-90c9-f05195b0cbab>,
+                      <https://w3id.org/ontouml-models/distribution/2deeecd8-87ae-4718-b53b-fa3b50a2a111>,
+                      <https://w3id.org/ontouml-models/distribution/77591360-2a84-4018-93ba-4f8aaeabb9de>,
+                      <https://w3id.org/ontouml-models/distribution/c6183823-a35d-4d57-86dc-b4b581dd315e>,
+                      <https://w3id.org/ontouml-models/distribution/a895c02a-15f7-41e4-a3da-3fe4bb263153>,
+                      <https://w3id.org/ontouml-models/distribution/7683f9b1-2623-48b0-9000-334df439a9fa>,
+                      <https://w3id.org/ontouml-models/distribution/1f1d7d08-2d7d-48f6-b3a2-6d67968d3f37>,
+                      <https://w3id.org/ontouml-models/distribution/620610e9-d005-4789-bee2-d3f4beee6e0d>,
+                      <https://w3id.org/ontouml-models/distribution/d9ce1ea2-522b-483f-ae8b-11db5965a016>,
+                      <https://w3id.org/ontouml-models/distribution/7b5d5c68-f4d2-4814-8376-86e3db7944c8>,
+                      <https://w3id.org/ontouml-models/distribution/776f528a-558f-4d37-b315-38da38d0d43c>,
+                      <https://w3id.org/ontouml-models/distribution/54a4c121-1ae3-4fab-af96-ecfc62886b89>,
+                      <https://w3id.org/ontouml-models/distribution/754b4766-2861-4a2b-925f-bca3c06c7f0b>,
+                      <https://w3id.org/ontouml-models/distribution/cba843e9-4e75-4e91-9c60-911c6b3270d9>,
+                      <https://w3id.org/ontouml-models/distribution/657e00b6-9cba-436d-9f7c-aa237666ad8d>,
+                      <https://w3id.org/ontouml-models/distribution/16d347c3-f296-4b0a-bfd0-b1ed672ebd15>,
+                      <https://w3id.org/ontouml-models/distribution/95a589a3-fd15-4492-a6e1-ed4b7a372aec>,
+                      <https://w3id.org/ontouml-models/distribution/efe962b3-e076-4a41-9e4a-221992c957fb>,
+                      <https://w3id.org/ontouml-models/distribution/21c4f6b0-6039-4088-ad02-f212d3f25d08>,
+                      <https://w3id.org/ontouml-models/distribution/f5f45699-46e3-42a8-a22b-1673861ba5ca>,
+                      <https://w3id.org/ontouml-models/distribution/d4ccaf5f-44a7-45bd-b95d-be230b72022e>,
+                      <https://w3id.org/ontouml-models/distribution/077da10d-a816-477a-8190-332304f48fe1>,
+                      <https://w3id.org/ontouml-models/distribution/cbc59520-dec1-4dc9-8f85-7d900ff6b3aa>,
+                      <https://w3id.org/ontouml-models/distribution/1be92fbf-6086-4682-8e58-55c685c83f4d>,
+                      <https://w3id.org/ontouml-models/distribution/fd3646db-5d72-4d0f-8d2c-5b59972922ed>,
+                      <https://w3id.org/ontouml-models/distribution/886f66a0-8e0e-4c98-9b5b-ce58b4617f8b>,
+                      <https://w3id.org/ontouml-models/distribution/35095794-5cba-4c07-9a3c-bb134214b09b>,
+                      <https://w3id.org/ontouml-models/distribution/7a86c724-bba8-4f63-820b-0fa18da2a747>,
+                      <https://w3id.org/ontouml-models/distribution/82bf7091-947d-4617-a7b3-8ad91b068a50>,
+                      <https://w3id.org/ontouml-models/distribution/e2b71181-a7c9-4ff3-8a10-d737b0f1e118>,
+                      <https://w3id.org/ontouml-models/distribution/4b73e3af-af22-41ab-8027-aecf1ba90321>,
+                      <https://w3id.org/ontouml-models/distribution/4b73e3af-af22-41ab-8027-aecf1ba903212>,
+                      <https://w3id.org/ontouml-models/distribution/0bd2ffa3-7d1d-41d0-9b26-08ca061d4757>,
+                      <https://w3id.org/ontouml-models/distribution/173ad9a4-842e-4d7f-baad-6790abd95cb1>,
+                      <https://w3id.org/ontouml-models/distribution/7537ad7a-77e0-47cd-8daa-089356dc45bf>,
+                      <https://w3id.org/ontouml-models/distribution/8392f83f-da58-41b3-afd2-b93b64e30607>,
+                      <https://w3id.org/ontouml-models/distribution/2a733b2f-8590-42ec-9b3e-0f7698c78cea>,
+                      <https://w3id.org/ontouml-models/distribution/e48a6d81-f6c4-4d82-8403-323c98f8ea51>,
+                      <https://w3id.org/ontouml-models/distribution/527fda54-bfb9-4767-9175-69710b2053f8>,
+                      <https://w3id.org/ontouml-models/distribution/976da91b-9a69-4b56-8485-cac068b0ece5>,
+                      <https://w3id.org/ontouml-models/distribution/42060869-6cd1-4ccf-b346-1c306b306c8f> .

--- a/models/digitaldoctor2022/metadata.ttl
+++ b/models/digitaldoctor2022/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/f898284f-601b-4492-a515-cc39de252d1c/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -20,11 +19,20 @@
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dcat:keyword "healthcare"@en;
-    mod:designedForTask ocmv:SoftwareEngineering, ocmv:Learning;
+    mod:designedForTask ocmv:SoftwareEngineering,
+                        ocmv:Learning;
     ocmv:context ocmv:Classroom;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/digitaldoctor2022"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/digitaldoctor2022"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:47:06.131419285Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:47:06.131419285Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/f898284f-601b-4492-a515-cc39de252d1c> dcat:distribution <https://w3id.org/ontouml-models/distribution/7c79b244-496b-47a2-8bc0-1e9b16c71d0a/>, <https://w3id.org/ontouml-models/distribution/34ba922b-2709-48f5-981f-4a785f2f70d2/>, <https://w3id.org/ontouml-models/distribution/3052b8af-0e57-4d49-90d8-28d0b58ef479/>, <https://w3id.org/ontouml-models/distribution/8ec27c6b-9b5f-45a3-9bf3-f763e5c9a897>, <https://w3id.org/ontouml-models/distribution/8ec27c6b-9b5f-45a3-9bf3-f763e5c9a897trigger>, <https://w3id.org/ontouml-models/distribution/585f2497-a4b0-4dbf-93ff-acc15bb6875d>, <https://w3id.org/ontouml-models/distribution/b73a887f-2564-4d83-8b48-afadadeac447>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/f898284f-601b-4492-a515-cc39de252d1c> dcat:distribution <https://w3id.org/ontouml-models/distribution/7c79b244-496b-47a2-8bc0-1e9b16c71d0a/>,
+                      <https://w3id.org/ontouml-models/distribution/34ba922b-2709-48f5-981f-4a785f2f70d2/>,
+                      <https://w3id.org/ontouml-models/distribution/3052b8af-0e57-4d49-90d8-28d0b58ef479/>,
+                      <https://w3id.org/ontouml-models/distribution/8ec27c6b-9b5f-45a3-9bf3-f763e5c9a897>,
+                      <https://w3id.org/ontouml-models/distribution/8ec27c6b-9b5f-45a3-9bf3-f763e5c9a897trigger>,
+                      <https://w3id.org/ontouml-models/distribution/585f2497-a4b0-4dbf-93ff-acc15bb6875d>,
+                      <https://w3id.org/ontouml-models/distribution/b73a887f-2564-4d83-8b48-afadadeac447>,
+                      <https://w3id.org/ontouml-models/distribution/def8f484-a869-4d1b-aa2c-82a7b8c9de67> .

--- a/models/dpo2017/metadata.ttl
+++ b/models/dpo2017/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/b7c158b4-2fce-4ab6-a53b-db8ef28f5883/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -21,14 +20,26 @@
     dct:language "en";
     dcat:landingPage <https://dev.nemo.inf.ufes.br/seon/DPO.html>;
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:contributor <https://dblp.org/pid/37/528>, <https://dblp.org/pid/229/4259>, <https://dblp.org/pid/97/7540>, <https://dblp.org/pid/189/5932>, <https://dblp.org/pid/11/78>;
-    dcat:keyword "design process"@en, "software"@en, "software engineering"@en;
+    dct:contributor <https://dblp.org/pid/37/528>,
+                    <https://dblp.org/pid/229/4259>,
+                    <https://dblp.org/pid/97/7540>,
+                    <https://dblp.org/pid/189/5932>,
+                    <https://dblp.org/pid/11/78>;
+    dcat:keyword "design process"@en,
+                 "software"@en,
+                 "software engineering"@en;
+    dct:source <https://nemo.inf.ufes.br/wp-content/papercite-data/pdf/software_engineering_standards_harmonization__an_ontology_based_approach_2017.pdf>,
+               <https://doi.org/10.1007/978-3-319-49004-5_34>;
     mod:designedForTask ocmv:ConceptualClarification;
     ocmv:context ocmv:Research;
-    dct:source <https://nemo.inf.ufes.br/wp-content/papercite-data/pdf/software_engineering_standards_harmonization__an_ontology_based_approach_2017.pdf>, <https://doi.org/10.1007/978-3-319-49004-5_34>;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/dpo2017"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/dpo2017"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:47:18.579408555Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:47:18.579408555Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/b7c158b4-2fce-4ab6-a53b-db8ef28f5883> dcat:distribution <https://w3id.org/ontouml-models/distribution/4c1c1a76-955e-4e4a-82a3-e3bba910fe75/>, <https://w3id.org/ontouml-models/distribution/ff3ebcc6-6017-4823-80d8-24ba100fcb58/>, <https://w3id.org/ontouml-models/distribution/f8326d0f-8657-4f2b-9ba1-f94dd0e486f9/>, <https://w3id.org/ontouml-models/distribution/91f00b02-99a1-4fb7-bc45-1e14ff077cb3>, <https://w3id.org/ontouml-models/distribution/ec111e77-8181-4d18-af89-4dd535432d70>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/b7c158b4-2fce-4ab6-a53b-db8ef28f5883> dcat:distribution <https://w3id.org/ontouml-models/distribution/4c1c1a76-955e-4e4a-82a3-e3bba910fe75/>,
+                      <https://w3id.org/ontouml-models/distribution/ff3ebcc6-6017-4823-80d8-24ba100fcb58/>,
+                      <https://w3id.org/ontouml-models/distribution/f8326d0f-8657-4f2b-9ba1-f94dd0e486f9/>,
+                      <https://w3id.org/ontouml-models/distribution/91f00b02-99a1-4fb7-bc45-1e14ff077cb3>,
+                      <https://w3id.org/ontouml-models/distribution/ec111e77-8181-4d18-af89-4dd535432d70> .

--- a/models/duarte2018osdef/metadata.ttl
+++ b/models/duarte2018osdef/metadata.ttl
@@ -1,18 +1,16 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/bfc2ffb6-b4bb-4f6c-9f8f-cc522d13dc94/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:title "Ontology of Software Defects, Errors and Failures";
     mod:acronym "OSDEF";
     dct:issued "2018"^^xsd:gYear;
@@ -20,14 +18,26 @@
     dcat:theme lcc:T;
     skos:editorialNote "The ontology was documented based on the version on the journal publication.";
     dct:language "en";
-    dct:contributor <https://dblp.org/pid/182/7298>, <https://dblp.org/pid/11/78>, <https://dblp.org/pid/72/3662>, <https://dblp.org/pid/229/4259>, <https://dblp.org/pid/75/5043>;
-    dcat:keyword "software development"@en, "software quality"@en;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    dct:contributor <https://dblp.org/pid/182/7298>,
+                    <https://dblp.org/pid/11/78>,
+                    <https://dblp.org/pid/72/3662>,
+                    <https://dblp.org/pid/229/4259>,
+                    <https://dblp.org/pid/75/5043>;
+    dcat:keyword "software development"@en,
+                 "software quality"@en;
+    dct:source <https://doi.org/10.1007/978-3-030-00847-5_25>,
+               <https://doi.org/10.1016/j.datak.2021.101892>;
     mod:designedForTask ocmv:ConceptualClarification;
     ocmv:context ocmv:Research;
-    dct:source <https://doi.org/10.1007/978-3-030-00847-5_25>, <https://doi.org/10.1016/j.datak.2021.101892>;
     ocmv:representationStyle ocmv:UfoStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/duarte2018osdef"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/duarte2018osdef"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:47:27.537555722Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:47:27.537555722Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/bfc2ffb6-b4bb-4f6c-9f8f-cc522d13dc94> dcat:distribution <https://w3id.org/ontouml-models/distribution/3e52de2d-b288-4ffe-beef-83b21351d7fc/>, <https://w3id.org/ontouml-models/distribution/fae9307b-d1c1-40ac-a5fb-0768a84edf32/>, <https://w3id.org/ontouml-models/distribution/aca81987-a89e-4cda-aa53-966f6fa1fbdc/>, <https://w3id.org/ontouml-models/distribution/5d998891-2390-4b9a-a8f6-63157006a3cb>, <https://w3id.org/ontouml-models/distribution/41cad05e-324c-4129-813f-b2cc22e7525b>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/bfc2ffb6-b4bb-4f6c-9f8f-cc522d13dc94> dcat:distribution <https://w3id.org/ontouml-models/distribution/3e52de2d-b288-4ffe-beef-83b21351d7fc/>,
+                      <https://w3id.org/ontouml-models/distribution/fae9307b-d1c1-40ac-a5fb-0768a84edf32/>,
+                      <https://w3id.org/ontouml-models/distribution/aca81987-a89e-4cda-aa53-966f6fa1fbdc/>,
+                      <https://w3id.org/ontouml-models/distribution/5d998891-2390-4b9a-a8f6-63157006a3cb>,
+                      <https://w3id.org/ontouml-models/distribution/41cad05e-324c-4129-813f-b2cc22e7525b> .

--- a/models/duarte2018reqon/metadata.ttl
+++ b/models/duarte2018reqon/metadata.ttl
@@ -1,18 +1,16 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/10c716c3-7da2-4457-9e40-9f847d4cf37d/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:title "Requirements Engineering Ontology";
     mod:acronym "ReqON";
     dct:issued "2018"^^xsd:gYear;
@@ -20,14 +18,30 @@
     dcat:theme lcc:T;
     skos:editorialNote "The \"Information Item\" class was duplicated. We merged both of its occurrences into a single one.";
     dct:language "en";
-    dct:contributor <https://dblp.org/pid/182/7298>, <https://dblp.org/pid/11/78>, <https://dblp.org/pid/72/3662>, <https://dblp.org/pid/229/4259>, <https://dblp.org/pid/80/10831>, <https://dblp.org/pid/75/5043>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    dct:contributor <https://dblp.org/pid/182/7298>,
+                    <https://dblp.org/pid/11/78>,
+                    <https://dblp.org/pid/72/3662>,
+                    <https://dblp.org/pid/229/4259>,
+                    <https://dblp.org/pid/80/10831>,
+                    <https://dblp.org/pid/75/5043>;
     dcat:keyword "requirements engineering"@en;
+    dct:source <https://doi.org/10.3233/AO-180197>;
     mod:designedForTask ocmv:ConceptualClarification;
     ocmv:context ocmv:Research;
-    dct:source <https://doi.org/10.3233/AO-180197>;
     ocmv:representationStyle ocmv:UfoStyle;
-    ocmv:ontologyType ocmv:Domain, ocmv:Application;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/duarte2018reqon"^^xsd:anyURI ;
+    ocmv:ontologyType ocmv:Domain,
+                      ocmv:Application;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/duarte2018reqon"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:47:36.725797738Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:47:36.725797738Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/10c716c3-7da2-4457-9e40-9f847d4cf37d> dcat:distribution <https://w3id.org/ontouml-models/distribution/4c864267-b753-49e6-b4e0-95d54a1ad48a/>, <https://w3id.org/ontouml-models/distribution/d77de162-c9ef-4cdf-afc0-f0e98b23f06e/>, <https://w3id.org/ontouml-models/distribution/6b84273f-7365-4799-9705-ca877e7d445b/>, <https://w3id.org/ontouml-models/distribution/cd0aefd3-9927-49ce-9d61-1beb97f304ad>, <https://w3id.org/ontouml-models/distribution/82668a8b-f364-4a30-b8d1-28d58cfe102a>, <https://w3id.org/ontouml-models/distribution/8cc8c4f2-3952-478a-a01f-7c8a177c0026>, <https://w3id.org/ontouml-models/distribution/a9697c4f-26fa-430a-ae90-8d1e21f89523>, <https://w3id.org/ontouml-models/distribution/a9bd83f0-e95a-4b60-817b-a0ca875788a3>, <https://w3id.org/ontouml-models/distribution/3528a4d8-1c0a-4152-a673-6b4563d0ca80>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/10c716c3-7da2-4457-9e40-9f847d4cf37d> dcat:distribution <https://w3id.org/ontouml-models/distribution/4c864267-b753-49e6-b4e0-95d54a1ad48a/>,
+                      <https://w3id.org/ontouml-models/distribution/d77de162-c9ef-4cdf-afc0-f0e98b23f06e/>,
+                      <https://w3id.org/ontouml-models/distribution/6b84273f-7365-4799-9705-ca877e7d445b/>,
+                      <https://w3id.org/ontouml-models/distribution/cd0aefd3-9927-49ce-9d61-1beb97f304ad>,
+                      <https://w3id.org/ontouml-models/distribution/82668a8b-f364-4a30-b8d1-28d58cfe102a>,
+                      <https://w3id.org/ontouml-models/distribution/8cc8c4f2-3952-478a-a01f-7c8a177c0026>,
+                      <https://w3id.org/ontouml-models/distribution/a9697c4f-26fa-430a-ae90-8d1e21f89523>,
+                      <https://w3id.org/ontouml-models/distribution/a9bd83f0-e95a-4b60-817b-a0ca875788a3>,
+                      <https://w3id.org/ontouml-models/distribution/3528a4d8-1c0a-4152-a673-6b4563d0ca80> .

--- a/models/duarte2020jogabilidade/metadata.ttl
+++ b/models/duarte2020jogabilidade/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/059dca17-0539-4e2c-8f50-fccc4e243242/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -20,12 +19,19 @@
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:contributor <https://www.linkedin.com/in/leonardo-sales-ribeiro-duarte-34aa75144>;
     dcat:keyword "games"@en;
+    dct:source <https://app.uff.br/riuff/handle/1/14831>;
     mod:designedForTask ocmv:ConceptualClarification;
     ocmv:context ocmv:Research;
-    dct:source <https://app.uff.br/riuff/handle/1/14831>;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/duarte2020jogabilidade"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/duarte2020jogabilidade"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:47:53.302587543Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:47:53.302587543Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/059dca17-0539-4e2c-8f50-fccc4e243242> dcat:distribution <https://w3id.org/ontouml-models/distribution/1f5c8844-cf52-424f-9566-253b21c5e986/>, <https://w3id.org/ontouml-models/distribution/354dfd39-61a2-47e2-a757-7f9e2233c516/>, <https://w3id.org/ontouml-models/distribution/8ea3c63c-8502-47ff-ba9c-a4a7788789b6/>, <https://w3id.org/ontouml-models/distribution/08d8bc56-2fec-41f4-ab45-a114da8db1a8>, <https://w3id.org/ontouml-models/distribution/d571fc65-a73a-4289-b320-d4fca168649f>, <https://w3id.org/ontouml-models/distribution/68cba0e8-3bd3-4401-b44c-7662387b5231>, <https://w3id.org/ontouml-models/distribution/98b84bbd-2fa4-443c-bfd0-7c6376c88802>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/059dca17-0539-4e2c-8f50-fccc4e243242> dcat:distribution <https://w3id.org/ontouml-models/distribution/1f5c8844-cf52-424f-9566-253b21c5e986/>,
+                      <https://w3id.org/ontouml-models/distribution/354dfd39-61a2-47e2-a757-7f9e2233c516/>,
+                      <https://w3id.org/ontouml-models/distribution/8ea3c63c-8502-47ff-ba9c-a4a7788789b6/>,
+                      <https://w3id.org/ontouml-models/distribution/08d8bc56-2fec-41f4-ab45-a114da8db1a8>,
+                      <https://w3id.org/ontouml-models/distribution/d571fc65-a73a-4289-b320-d4fca168649f>,
+                      <https://w3id.org/ontouml-models/distribution/68cba0e8-3bd3-4401-b44c-7662387b5231>,
+                      <https://w3id.org/ontouml-models/distribution/98b84bbd-2fa4-443c-bfd0-7c6376c88802> .

--- a/models/duarte2021ross/metadata.ttl
+++ b/models/duarte2021ross/metadata.ttl
@@ -1,18 +1,16 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/3adf4afc-9f96-403d-914a-72e41547f673/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:title "Reference Ontology of Software Systems";
     mod:acronym "ROSS";
     dct:issued "2021"^^xsd:gYear;
@@ -20,14 +18,31 @@
     dcat:theme lcc:T;
     skos:editorialNote "The paper identified as the main reference contains two ontologies: Ontology of Software Defects, Errors, and Faults (OSDEF) and the Reference Ontology of Software Systems (ROSS).";
     dct:language "en";
-    dct:contributor <https://dblp.org/pid/182/7298>, <https://dblp.org/pid/11/78>, <https://dblp.org/pid/72/3662>, <https://dblp.org/pid/229/4259>, <https://dblp.org/pid/75/5043>;
-    dcat:keyword "software systems"@en, "software"@en;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    dct:contributor <https://dblp.org/pid/182/7298>,
+                    <https://dblp.org/pid/11/78>,
+                    <https://dblp.org/pid/72/3662>,
+                    <https://dblp.org/pid/229/4259>,
+                    <https://dblp.org/pid/75/5043>;
+    dcat:keyword "software systems"@en,
+                 "software"@en;
+    dct:source <https://doi.org/10.1016/j.datak.2021.101892>;
     mod:designedForTask ocmv:ConceptualClarification;
     ocmv:context ocmv:Research;
-    dct:source <https://doi.org/10.1016/j.datak.2021.101892>;
     ocmv:representationStyle ocmv:UfoStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/duarte2021ross"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/duarte2021ross"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:48:05.774060027Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:48:05.774060027Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/3adf4afc-9f96-403d-914a-72e41547f673> dcat:distribution <https://w3id.org/ontouml-models/distribution/48151b6e-a47c-422a-932c-2cc0d141dae2/>, <https://w3id.org/ontouml-models/distribution/42793b9c-2cea-4252-bc24-2124d8405515/>, <https://w3id.org/ontouml-models/distribution/594e4432-4153-4ef5-892e-36dca41de0a3/>, <https://w3id.org/ontouml-models/distribution/67d4cd33-db9a-44aa-823e-a13ffd91cb88>, <https://w3id.org/ontouml-models/distribution/eced4c7b-4bdd-44b6-bc03-4a2e4e6c152f>, <https://w3id.org/ontouml-models/distribution/c2284a4f-6272-4ce9-8d08-22b6e4b5cd14>, <https://w3id.org/ontouml-models/distribution/5614c367-5efd-4d21-9eb7-0fe1e0c375ab>, <https://w3id.org/ontouml-models/distribution/cc2fd660-4e55-4e2a-a6d8-678498e5c614>, <https://w3id.org/ontouml-models/distribution/3ee098a3-27bd-498d-ae3a-c69f112384b0>, <https://w3id.org/ontouml-models/distribution/de1872c6-dc9c-4f75-8d9b-f910d42dba1f>, <https://w3id.org/ontouml-models/distribution/89a71d40-70cc-4256-9343-56c1860808e3>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/3adf4afc-9f96-403d-914a-72e41547f673> dcat:distribution <https://w3id.org/ontouml-models/distribution/48151b6e-a47c-422a-932c-2cc0d141dae2/>,
+                      <https://w3id.org/ontouml-models/distribution/42793b9c-2cea-4252-bc24-2124d8405515/>,
+                      <https://w3id.org/ontouml-models/distribution/594e4432-4153-4ef5-892e-36dca41de0a3/>,
+                      <https://w3id.org/ontouml-models/distribution/67d4cd33-db9a-44aa-823e-a13ffd91cb88>,
+                      <https://w3id.org/ontouml-models/distribution/eced4c7b-4bdd-44b6-bc03-4a2e4e6c152f>,
+                      <https://w3id.org/ontouml-models/distribution/c2284a4f-6272-4ce9-8d08-22b6e4b5cd14>,
+                      <https://w3id.org/ontouml-models/distribution/5614c367-5efd-4d21-9eb7-0fe1e0c375ab>,
+                      <https://w3id.org/ontouml-models/distribution/cc2fd660-4e55-4e2a-a6d8-678498e5c614>,
+                      <https://w3id.org/ontouml-models/distribution/3ee098a3-27bd-498d-ae3a-c69f112384b0>,
+                      <https://w3id.org/ontouml-models/distribution/de1872c6-dc9c-4f75-8d9b-f910d42dba1f>,
+                      <https://w3id.org/ontouml-models/distribution/89a71d40-70cc-4256-9343-56c1860808e3> .

--- a/models/elghosh2020cargos/metadata.ttl
+++ b/models/elghosh2020cargos/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/644b5d61-61df-429a-983b-5862fef2ff2a/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -19,14 +18,20 @@
     skos:editorialNote "The ontology was documented based on the version on the journal publication";
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:contributor <https://dblp.org/pid/199/9510>, <https://dblp.org/pid/58/2780>;
+    dct:contributor <https://dblp.org/pid/199/9510>,
+                    <https://dblp.org/pid/58/2780>;
     dcat:keyword "international maritime law"@en;
+    dct:source <https://doi.org/10.3233/FAIA200882>;
     mod:designedForTask ocmv:ConceptualClarification;
     ocmv:context ocmv:Research;
-    dct:source <https://doi.org/10.3233/FAIA200882>;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Application;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/elghosh2020cargos"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/elghosh2020cargos"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:48:24.5197638Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:48:24.5197638Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/644b5d61-61df-429a-983b-5862fef2ff2a> dcat:distribution <https://w3id.org/ontouml-models/distribution/9f388762-ba0e-42ce-8b63-11d2c07fee60/>, <https://w3id.org/ontouml-models/distribution/aa168c04-02fe-4477-ae5b-19dc61ac675e/>, <https://w3id.org/ontouml-models/distribution/378de102-324c-4793-835c-80f6890ba3d1/>, <https://w3id.org/ontouml-models/distribution/4694165d-f6d6-4afb-a53f-b09e759edca3>, <https://w3id.org/ontouml-models/distribution/fd1b75e2-9fa4-450f-9025-6430fe3f5ef5>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/644b5d61-61df-429a-983b-5862fef2ff2a> dcat:distribution <https://w3id.org/ontouml-models/distribution/9f388762-ba0e-42ce-8b63-11d2c07fee60/>,
+                      <https://w3id.org/ontouml-models/distribution/aa168c04-02fe-4477-ae5b-19dc61ac675e/>,
+                      <https://w3id.org/ontouml-models/distribution/378de102-324c-4793-835c-80f6890ba3d1/>,
+                      <https://w3id.org/ontouml-models/distribution/4694165d-f6d6-4afb-a53f-b09e759edca3>,
+                      <https://w3id.org/ontouml-models/distribution/fd1b75e2-9fa4-450f-9025-6430fe3f5ef5> .

--- a/models/elghosh2024eucaim/metadata.ttl
+++ b/models/elghosh2024eucaim/metadata.ttl
@@ -1,15 +1,16 @@
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/model/elghosh2024eucaim/> a dcat:Dataset, mod:SemanticArtefact;
+<https://w3id.org/ontouml-models/model/elghosh2024eucaim/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
+    dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
     dct:title "EUCAIM's Hyper-Ontology (Core Layer)";
     dct:issued "2024"^^xsd:gYear;
     dcat:theme lcc:R;
@@ -17,22 +18,35 @@
     dct:language "en";
     dcat:landingPage <https://doi.org/10.5281/zenodo.11109765>;
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:contributor <https://dblp.org/pid/199/9510.html>, <https://dblp.org/pid/118/0942.html>, <https://dblp.org/pid/43/1967.html>, <https://dblp.org/pid/d/ChristelDanielLeBozec.html>, <https://dblp.org/pid/96/1080.html>, <https://dblp.org/pid/12/11202.html>, <https://dblp.org/pid/83/4811.html>, <https://dblp.org/pid/47/2102.html>, <https://dblp.org/pid/20/3693.html>;
-    mod:designedForTask ocmv:ConceptualClarification, ocmv:Interoperability, ocmv:OntologicalAnalysis;
-    ocmv:context ocmv:Research, ocmv:Industry;
-    dct:source <https://www.utwente.nl/en/eemcs/fois2024/resources/papers/el-ghosh-et-al-towards-semantic-interoperability-among-heterogeneous-cancer-data-models-using-a-layered-modular-hyper-ontology.pdf>, <https://www.utwente.nl/en/eemcs/fois2024/resources/papers/el-ghosh-et-al-grounding-a-hyper-ontology-on-mcode-ontological-conceptual-model-and-foundational-ontologies-for-semantic-interoperability-in-the-oncology-domain.pdf>.
-<https://w3id.org/ontouml-models/model/elghosh2024eucaim/> dcat:distribution <https://w3id.org/ontouml-models/model/elghosh2024eucaim/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/elghosh2024eucaim/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"EUCAIM's Hyper-Ontology (Core Layer)\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/elghosh2024eucaim/ontology.ttl>.
-<https://w3id.org/ontouml-models/model/elghosh2024eucaim/> dcat:distribution <https://w3id.org/ontouml-models/model/elghosh2024eucaim/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/elghosh2024eucaim/distribution/ttl> a dcat:Distribution;
-    dct:title "JSON distribution of \"EUCAIM's Hyper-Ontology (Core Layer)\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/elghosh2024eucaim/ontology.json>.
-<https://w3id.org/ontouml-models/model/elghosh2024eucaim/> dcat:distribution <https://w3id.org/ontouml-models/model/elghosh2024eucaim/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/elghosh2024eucaim/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"EUCAIM's Hyper-Ontology (Core Layer)\""@en;
-    dcat:mediaType <https://www.visual-paradigm.com/vpp>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/elghosh2024eucaim/ontology.vpp>.
+    dct:contributor <https://dblp.org/pid/199/9510.html>,
+                    <https://dblp.org/pid/118/0942.html>,
+                    <https://dblp.org/pid/43/1967.html>,
+                    <https://dblp.org/pid/d/ChristelDanielLeBozec.html>,
+                    <https://dblp.org/pid/96/1080.html>,
+                    <https://dblp.org/pid/12/11202.html>,
+                    <https://dblp.org/pid/83/4811.html>,
+                    <https://dblp.org/pid/47/2102.html>,
+                    <https://dblp.org/pid/20/3693.html>;
+    dcat:keyword "oncology"@en;
+    dct:source <https://www.utwente.nl/en/eemcs/fois2024/resources/papers/el-ghosh-et-al-towards-semantic-interoperability-among-heterogeneous-cancer-data-models-using-a-layered-modular-hyper-ontology.pdf>,
+               <https://www.utwente.nl/en/eemcs/fois2024/resources/papers/el-ghosh-et-al-grounding-a-hyper-ontology-on-mcode-ontological-conceptual-model-and-foundational-ontologies-for-semantic-interoperability-in-the-oncology-domain.pdf>;
+    mod:designedForTask ocmv:ConceptualClarification,
+                        ocmv:Interoperability,
+                        ocmv:OntologicalAnalysis;
+    ocmv:context ocmv:Research,
+                 ocmv:Industry;
+    ocmv:representationStyle ocmv:OntoumlStyle;
+    ocmv:ontologyType ocmv:Core,
+                      ocmv:Application;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/elghosh2024eucaim"^^xsd:anyURI;
+    fdpo:metadataIssued "2026-06-23T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/elghosh2024eucaim/> dcat:distribution <https://w3id.org/ontouml-models/model/elghosh2024eucaim/distribution/ttl>,
+                      <https://www.iana.org/assignments/media-types/text/turtle>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/elghosh2024eucaim/ontology.ttl>,
+                      <https://w3id.org/ontouml-models/model/elghosh2024eucaim/>,
+                      <https://www.iana.org/assignments/media-types/application/json>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/elghosh2024eucaim/ontology.json>,
+                      <https://www.visual-paradigm.com/vpp>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/elghosh2024eucaim/ontology.vpp> .

--- a/models/elghosh2025crimonto/metadata.ttl
+++ b/models/elghosh2025crimonto/metadata.ttl
@@ -1,37 +1,48 @@
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/model/elghosh2025crimonto/> a dcat:Dataset, mod:SemanticArtefact;
+<https://w3id.org/ontouml-models/model/elghosh2025crimonto/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
+    dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
     dct:title "Criminal Modular Ontology";
     mod:acronym "CriMOnto";
     dct:issued "2025"^^xsd:gYear;
     dcat:theme lcc:K;
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:contributor <https://dblp.org/pid/199/9510>, <https://dblp.org/pid/58/2780>, <https://dblp.org/pid/38/6459>, <https://dblp.org/pid/64/3385>;
+    dct:contributor <https://dblp.org/pid/199/9510>,
+                    <https://dblp.org/pid/58/2780>,
+                    <https://dblp.org/pid/38/6459>,
+                    <https://dblp.org/pid/64/3385>;
+    dcat:keyword "criminal law"@en,
+                 "procedural norms"@en,
+                 "offense"@en,
+                 "penalty"@en,
+                 "responsibility"@en,
+                 "liability"@en;
+    dct:source <https://doi.org/10.1016/j.datak.2025.102419>;
     mod:designedForTask ocmv:DecisionSupportSystem;
     ocmv:context ocmv:Research;
-    dct:source <https://doi.org/10.1016/j.datak.2025.102419>.
-<https://w3id.org/ontouml-models/model/elghosh2025crimonto/> dcat:distribution <https://w3id.org/ontouml-models/model/elghosh2025crimonto/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/elghosh2025crimonto/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Criminal Modular Ontology\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/elghosh2025crimonto/ontology.ttl>.
-<https://w3id.org/ontouml-models/model/elghosh2025crimonto/> dcat:distribution <https://w3id.org/ontouml-models/model/elghosh2025crimonto/distribution/json>.
-<https://w3id.org/ontouml-models/model/elghosh2025crimonto/distribution/json> a dcat:Distribution;
-    dct:title "JSON distribution of \"Criminal Modular Ontology\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/elghosh2025crimonto/ontology.json>.
-<https://w3id.org/ontouml-models/model/elghosh2025crimonto/> dcat:distribution <https://w3id.org/ontouml-models/model/elghosh2025crimonto/distribution/vpp>.
-<https://w3id.org/ontouml-models/model/elghosh2025crimonto/distribution/vpp> a dcat:Distribution;
-    dct:title "Visual Paradigm distribution of \"Criminal Modular Ontology\""@en;
-    dcat:mediaType <https://www.visual-paradigm.com/vpp>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/elghosh2025crimonto/ontology.vpp>.
+    ocmv:representationStyle ocmv:OntoumlStyle;
+    ocmv:ontologyType ocmv:Application;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/elghosh2025crimonto"^^xsd:anyURI;
+    fdpo:metadataIssued "2026-06-23T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/elghosh2025crimonto/> dcat:distribution <https://w3id.org/ontouml-models/model/elghosh2025crimonto/distribution/ttl>,
+                      <https://www.iana.org/assignments/media-types/text/turtle>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/elghosh2025crimonto/ontology.ttl>,
+                      <https://w3id.org/ontouml-models/model/elghosh2025crimonto/>,
+                      <https://w3id.org/ontouml-models/model/elghosh2025crimonto/distribution/json>,
+                      <https://www.iana.org/assignments/media-types/application/json>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/elghosh2025crimonto/ontology.json>,
+                      <https://w3id.org/ontouml-models/model/elghosh2025crimonto/distribution/vpp>,
+                      <https://www.visual-paradigm.com/vpp>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/elghosh2025crimonto/ontology.vpp> .

--- a/models/elikan2018brand-identity/metadata.ttl
+++ b/models/elikan2018brand-identity/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/ebdd4665-72c7-4c33-aa4a-d31b5c088981/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -16,17 +15,29 @@
     dct:issued "2018"^^xsd:gYear;
     dct:modified "2019"^^xsd:gYear;
     dcat:theme lcc:H;
-    skos:editorialNote "The original ontology's diagram contains multiple derivations of the same relator. The association class element of UML cannot be used for this and, as such, one of the derivations had to be represented through a dependency link.\nPackages were inferred from the text rather than the diagram in the source work.\n";
+    skos:editorialNote """The original ontology's diagram contains multiple derivations of the same relator. The association class element of UML cannot be used for this and, as such, one of the derivations had to be represented through a dependency link.
+Packages were inferred from the text rather than the diagram in the source work.
+""";
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:contributor <https://dblp.org/pid/220/4496>, <https://dblp.org/pid/10/2240>;
-    dcat:keyword "business"@en, "branding"@en, "marketing"@en, "startup"@en;
+    dct:contributor <https://dblp.org/pid/220/4496>,
+                    <https://dblp.org/pid/10/2240>;
+    dcat:keyword "business"@en,
+                 "branding"@en,
+                 "marketing"@en,
+                 "startup"@en;
+    dct:source <https://dblp.org/rec/conf/vmbo/ElikanP18>,
+               <https://serval.unil.ch/en/notice/serval:BIB_33C796025F84>;
     mod:designedForTask ocmv:ConceptualClarification;
     ocmv:context ocmv:Research;
-    dct:source <https://dblp.org/rec/conf/vmbo/ElikanP18>, <https://serval.unil.ch/en/notice/serval:BIB_33C796025F84>;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/elikan2018brand-identity"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/elikan2018brand-identity"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:48:33.608954495Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:48:33.608954495Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/ebdd4665-72c7-4c33-aa4a-d31b5c088981> dcat:distribution <https://w3id.org/ontouml-models/distribution/6c606e4b-d92c-4a95-a7a5-9d9cce5eba55/>, <https://w3id.org/ontouml-models/distribution/12602c70-0749-4fee-ac9d-5a649665225f/>, <https://w3id.org/ontouml-models/distribution/0e480ca5-cbed-47d1-968b-8dfb10ff9a26/>, <https://w3id.org/ontouml-models/distribution/bfe8cfed-fd07-4226-9d06-03a38303776d>, <https://w3id.org/ontouml-models/distribution/291cee48-55c1-4f0f-8249-d1406633218c>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/ebdd4665-72c7-4c33-aa4a-d31b5c088981> dcat:distribution <https://w3id.org/ontouml-models/distribution/6c606e4b-d92c-4a95-a7a5-9d9cce5eba55/>,
+                      <https://w3id.org/ontouml-models/distribution/12602c70-0749-4fee-ac9d-5a649665225f/>,
+                      <https://w3id.org/ontouml-models/distribution/0e480ca5-cbed-47d1-968b-8dfb10ff9a26/>,
+                      <https://w3id.org/ontouml-models/distribution/bfe8cfed-fd07-4226-9d06-03a38303776d>,
+                      <https://w3id.org/ontouml-models/distribution/291cee48-55c1-4f0f-8249-d1406633218c> .

--- a/models/eu-rent-refactored2022/metadata.ttl
+++ b/models/eu-rent-refactored2022/metadata.ttl
@@ -1,32 +1,38 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/e4940b3f-a31f-4341-a21d-494423c8d876/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:title "EU-Rent Car Rentals Refactored";
     dct:issued "2022"^^xsd:gYear;
     dct:modified "2022"^^xsd:gYear;
     dcat:theme lcc:H;
     skos:editorialNote "This model was created by partially refactoring and adapting the case study EU-Rent Car Rentals Specification (https://upcommons.upc.edu/bitstream/handle/2117/97816/R03-59.pdf), by Leonor Frias, Anna Queralt and Antoni Olivé.";
     dct:language "en";
-    dct:contributor <https://dblp.org/pid/134/4947>, <https://dblp.org/pid/222/8406>, <https://dblp.org/pid/131/1200>, <https://dblp.org/pid/11/78>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    dct:contributor <https://dblp.org/pid/134/4947>,
+                    <https://dblp.org/pid/222/8406>,
+                    <https://dblp.org/pid/131/1200>,
+                    <https://dblp.org/pid/11/78>;
     dcat:keyword "car rental"@en;
+    dct:source <https://upcommons.upc.edu/handle/2117/97816>;
     mod:designedForTask ocmv:Example;
     ocmv:context ocmv:Research;
-    dct:source <https://upcommons.upc.edu/handle/2117/97816>;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/eu-rent-refactored2022"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/eu-rent-refactored2022"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:48:42.875935993Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:48:42.875935993Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/e4940b3f-a31f-4341-a21d-494423c8d876> dcat:distribution <https://w3id.org/ontouml-models/distribution/5ce51d8b-2238-4d10-bfa1-20e36880ba6a/>, <https://w3id.org/ontouml-models/distribution/5d29593f-7d68-46ad-b8e1-52ae1e461ea9/>, <https://w3id.org/ontouml-models/distribution/da2551d1-e3b3-488a-8335-a075c57e1823/>, <https://w3id.org/ontouml-models/distribution/63816bb0-dca2-4ab4-86d5-a0741b03c435>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/e4940b3f-a31f-4341-a21d-494423c8d876> dcat:distribution <https://w3id.org/ontouml-models/distribution/5ce51d8b-2238-4d10-bfa1-20e36880ba6a/>,
+                      <https://w3id.org/ontouml-models/distribution/5d29593f-7d68-46ad-b8e1-52ae1e461ea9/>,
+                      <https://w3id.org/ontouml-models/distribution/da2551d1-e3b3-488a-8335-a075c57e1823/>,
+                      <https://w3id.org/ontouml-models/distribution/63816bb0-dca2-4ab4-86d5-a0741b03c435> .

--- a/models/experiment2013/metadata.ttl
+++ b/models/experiment2013/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/34ed86ed-d667-41d2-9eef-cbe8f238e1f9/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -24,7 +23,12 @@
     ocmv:context ocmv:Classroom;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/experiment2013"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/experiment2013"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:48:51.320766634Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:48:51.320766634Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/34ed86ed-d667-41d2-9eef-cbe8f238e1f9> dcat:distribution <https://w3id.org/ontouml-models/distribution/8221fc87-d4d9-49b1-b67e-1e672f9f2724/>, <https://w3id.org/ontouml-models/distribution/68c85e81-ae62-4a09-aafb-79545a360312/>, <https://w3id.org/ontouml-models/distribution/a88b9fd9-70d7-402e-94df-bb773cf792cb/>, <https://w3id.org/ontouml-models/distribution/0a5bbc67-bfe4-46a6-aee1-277ef6270e5d>, <https://w3id.org/ontouml-models/distribution/e14e35e1-d5c7-43cb-8a8f-6c10236ec3d5>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/34ed86ed-d667-41d2-9eef-cbe8f238e1f9> dcat:distribution <https://w3id.org/ontouml-models/distribution/8221fc87-d4d9-49b1-b67e-1e672f9f2724/>,
+                      <https://w3id.org/ontouml-models/distribution/68c85e81-ae62-4a09-aafb-79545a360312/>,
+                      <https://w3id.org/ontouml-models/distribution/a88b9fd9-70d7-402e-94df-bb773cf792cb/>,
+                      <https://w3id.org/ontouml-models/distribution/0a5bbc67-bfe4-46a6-aee1-277ef6270e5d>,
+                      <https://w3id.org/ontouml-models/distribution/e14e35e1-d5c7-43cb-8a8f-6c10236ec3d5> .

--- a/models/falduci2022non-consensual-pornography/metadata.ttl
+++ b/models/falduci2022non-consensual-pornography/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/1f701487-b0c6-4647-883d-5ca5fae94a24/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -17,14 +16,28 @@
     dcat:theme lcc:K;
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:contributor <https://dblp.org/pid/244/4959>, <https://dblp.org/pid/168/0045>;
-    dcat:keyword "Law"@en, "Criminal Law"@en, "Cybercrime"@en, "non-consensual pornography"@en;
-    mod:designedForTask ocmv:ConceptualClarification, ocmv:DecisionSupportSystem, ocmv:Interoperability;
-    ocmv:context ocmv:Research;
+    dct:contributor <https://dblp.org/pid/244/4959>,
+                    <https://dblp.org/pid/168/0045>;
+    dcat:keyword "Law"@en,
+                 "Criminal Law"@en,
+                 "Cybercrime"@en,
+                 "non-consensual pornography"@en;
     dct:source <https://doi.org/10.1007/978-3-031-17995-2_27>;
+    mod:designedForTask ocmv:ConceptualClarification,
+                        ocmv:DecisionSupportSystem,
+                        ocmv:Interoperability;
+    ocmv:context ocmv:Research;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/falduci2022non-consensual-pornography"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/falduci2022non-consensual-pornography"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:49:01.139475944Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:49:01.139475944Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/1f701487-b0c6-4647-883d-5ca5fae94a24> dcat:distribution <https://w3id.org/ontouml-models/distribution/ce90ff3d-dc2b-4cbb-ad6b-c1e20b156647/>, <https://w3id.org/ontouml-models/distribution/b25f1e27-1e35-4cf7-a2f9-38359e1bcad2/>, <https://w3id.org/ontouml-models/distribution/798d4bcb-f19d-49ae-839b-bc67cb5fbdce/>, <https://w3id.org/ontouml-models/distribution/2b6a2e2b-137f-49b8-babb-e165037b422b>, <https://w3id.org/ontouml-models/distribution/c9e32a4b-20a9-4d5e-81b5-6e8fc4c4a537>, <https://w3id.org/ontouml-models/distribution/eabe7792-9425-48ef-bfc5-448a70232ace>, <https://w3id.org/ontouml-models/distribution/127b3ced-3f13-42d5-a359-fc2d86607e7c>, <https://w3id.org/ontouml-models/distribution/7ad69096-5399-413c-989a-500161117aa6>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/1f701487-b0c6-4647-883d-5ca5fae94a24> dcat:distribution <https://w3id.org/ontouml-models/distribution/ce90ff3d-dc2b-4cbb-ad6b-c1e20b156647/>,
+                      <https://w3id.org/ontouml-models/distribution/b25f1e27-1e35-4cf7-a2f9-38359e1bcad2/>,
+                      <https://w3id.org/ontouml-models/distribution/798d4bcb-f19d-49ae-839b-bc67cb5fbdce/>,
+                      <https://w3id.org/ontouml-models/distribution/2b6a2e2b-137f-49b8-babb-e165037b422b>,
+                      <https://w3id.org/ontouml-models/distribution/c9e32a4b-20a9-4d5e-81b5-6e8fc4c4a537>,
+                      <https://w3id.org/ontouml-models/distribution/eabe7792-9425-48ef-bfc5-448a70232ace>,
+                      <https://w3id.org/ontouml-models/distribution/127b3ced-3f13-42d5-a359-fc2d86607e7c>,
+                      <https://w3id.org/ontouml-models/distribution/7ad69096-5399-413c-989a-500161117aa6> .

--- a/models/fernandez-cejas2022curie-o/metadata.ttl
+++ b/models/fernandez-cejas2022curie-o/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/a1eaeceb-2031-4095-8bd0-92767646919c/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -20,14 +19,21 @@
     skos:editorialNote "The authors built the ontology using Visual Paradigm and, hence, there is no new diagram to be generated.";
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:contributor <https://orcid.org/0000-0003-0149-4789>, <https://dblp.org/pid/94/9359>, <https://dblp.org/pid/33/2285>, <https://dblp.org/pid/87/6007>;
+    dct:contributor <https://orcid.org/0000-0003-0149-4789>,
+                    <https://dblp.org/pid/94/9359>,
+                    <https://dblp.org/pid/33/2285>,
+                    <https://dblp.org/pid/87/6007>;
     dcat:keyword "customer relationship management"@en;
+    dct:source <https://doi.org/10.1007/s12599-022-00744-0>;
     mod:designedForTask ocmv:ConceptualClarification;
     ocmv:context ocmv:Research;
-    dct:source <https://doi.org/10.1007/s12599-022-00744-0>;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/fernandez-cejas2022curie-o"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/fernandez-cejas2022curie-o"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:49:15.25088385Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:49:15.25088385Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/a1eaeceb-2031-4095-8bd0-92767646919c> dcat:distribution <https://w3id.org/ontouml-models/distribution/ae67e1d5-85d2-4970-8d64-52c690500998/>, <https://w3id.org/ontouml-models/distribution/cb1e87dd-79c6-4234-89f6-49bac1199a92/>, <https://w3id.org/ontouml-models/distribution/eff05f0c-a09a-4ab2-a28f-a95520461f4a/>, <https://w3id.org/ontouml-models/distribution/cf33fa1f-1b59-4dc0-963d-817d8bdfbc95>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/a1eaeceb-2031-4095-8bd0-92767646919c> dcat:distribution <https://w3id.org/ontouml-models/distribution/ae67e1d5-85d2-4970-8d64-52c690500998/>,
+                      <https://w3id.org/ontouml-models/distribution/cb1e87dd-79c6-4234-89f6-49bac1199a92/>,
+                      <https://w3id.org/ontouml-models/distribution/eff05f0c-a09a-4ab2-a28f-a95520461f4a/>,
+                      <https://w3id.org/ontouml-models/distribution/cf33fa1f-1b59-4dc0-963d-817d8bdfbc95> .

--- a/models/ferreira2015ontoemergeplan/metadata.ttl
+++ b/models/ferreira2015ontoemergeplan/metadata.ttl
@@ -1,18 +1,16 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/dddeec28-4c7c-4e5f-b22e-b536fa79ac72/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:title "Ontology for Emergency Plans";
     mod:acronym "OntoEmergePlan";
     dct:issued "2013"^^xsd:gYear;
@@ -20,14 +18,46 @@
     dcat:theme lcc:H;
     skos:editorialNote "The VP model was built over obtained XMI file. The complete model has more diagrams than the ones here modeled, however, just 9 of these were presented in the publications - these were the only ones that were re-modeled using VP. Some associations redefinitions and subsettings were not possible to be modeled because the related association end roles were not found. When imported from the XMI file, duplicated classes were identified and merged. The author comments in Portuguese were removed. Classes without any view were also removed. The class Geographical Region had two different stereotypes in two diagrams - Kind and Category. For the better representation we defined it only as a category. Some classes were defined in two different packages - the duplicates were removed. During the importation some classes were defined in the incorrect package - these were moved to their correct package.";
     dct:language "en";
-    dct:contributor <https://dblp.org/pid/183/7439>, <https://dblp.org/pid/74/7740>, <https://dblp.org/pid/78/4279>, <https://dblp.org/pid/42/7543>, <https://dblp.org/pid/134/4947>, <https://dblp.org/pid/43/7740>, <https://dblp.org/pid/99/2500>;
-    dcat:keyword "emergency"@en, "risk"@en, "security"@en, "emergency management"@en;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    dct:contributor <https://dblp.org/pid/183/7439>,
+                    <https://dblp.org/pid/74/7740>,
+                    <https://dblp.org/pid/78/4279>,
+                    <https://dblp.org/pid/42/7543>,
+                    <https://dblp.org/pid/134/4947>,
+                    <https://dblp.org/pid/43/7740>,
+                    <https://dblp.org/pid/99/2500>;
+    dcat:keyword "emergency"@en,
+                 "risk"@en,
+                 "security"@en,
+                 "emergency management"@en;
+    dct:source <https://dblp.org/rec/conf/iscram/FerreiraMCBSCB15>,
+               <http://objdig.ufrj.br/15/teses/867022.pdf>;
     mod:designedForTask ocmv:ConceptualClarification;
     ocmv:context ocmv:Research;
-    dct:source <https://dblp.org/rec/conf/iscram/FerreiraMCBSCB15>, <http://objdig.ufrj.br/15/teses/867022.pdf>;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/ferreira2015ontoemergeplan"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/ferreira2015ontoemergeplan"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:49:23.176465527Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:49:23.176465527Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/dddeec28-4c7c-4e5f-b22e-b536fa79ac72> dcat:distribution <https://w3id.org/ontouml-models/distribution/b38da854-2538-4a87-a80b-5ad7aa609db4/>, <https://w3id.org/ontouml-models/distribution/5e0b2be9-5c02-474d-871b-439641499a82/>, <https://w3id.org/ontouml-models/distribution/81a5ff35-218d-44d0-9f21-271c5f70c84b/>, <https://w3id.org/ontouml-models/distribution/20ed5c49-3fd3-421f-875c-a78425e1e072>, <https://w3id.org/ontouml-models/distribution/22734a4d-891b-462f-9b9a-cad71b6c173a>, <https://w3id.org/ontouml-models/distribution/4235afb8-8200-43eb-b493-ed3809330dd9>, <https://w3id.org/ontouml-models/distribution/c03c79d4-1443-4c83-9c1f-0f86504afd11>, <https://w3id.org/ontouml-models/distribution/b789a904-2445-4ba3-ae5a-d3527bb06e02>, <https://w3id.org/ontouml-models/distribution/42dc25ed-7380-4816-a35e-23ace140ae51>, <https://w3id.org/ontouml-models/distribution/2785bc7c-adee-410a-a4bd-ef4fb46eacd9>, <https://w3id.org/ontouml-models/distribution/53fa74d9-3a0c-4167-83db-a7eedb3a8ead>, <https://w3id.org/ontouml-models/distribution/54d47bd2-14b4-43c2-8772-a4629e80faac>, <https://w3id.org/ontouml-models/distribution/e2fb53f8-824d-4b65-a527-8ebe2c812a9a>, <https://w3id.org/ontouml-models/distribution/394220b1-8fef-42ea-ba27-d3d63b698a07>, <https://w3id.org/ontouml-models/distribution/07206b07-1e74-4542-b70c-8b9d0e68b949>, <https://w3id.org/ontouml-models/distribution/de84e5fa-f880-4ca9-ae78-46ba4a0d4ceb>, <https://w3id.org/ontouml-models/distribution/eb2f1e37-fb88-43bb-bfbc-0d7a3d3e1b03>, <https://w3id.org/ontouml-models/distribution/2a1d825b-6374-46ec-b8e0-fc96e69a21f1>, <https://w3id.org/ontouml-models/distribution/5557c6ae-be4e-40e1-a6e3-65609f0c9db6>, <https://w3id.org/ontouml-models/distribution/ec6f6404-5cd6-4815-b67e-c8ceb9802eed>, <https://w3id.org/ontouml-models/distribution/cef48fdc-7b1f-43e1-9cae-6b0094d8802a>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/dddeec28-4c7c-4e5f-b22e-b536fa79ac72> dcat:distribution <https://w3id.org/ontouml-models/distribution/b38da854-2538-4a87-a80b-5ad7aa609db4/>,
+                      <https://w3id.org/ontouml-models/distribution/5e0b2be9-5c02-474d-871b-439641499a82/>,
+                      <https://w3id.org/ontouml-models/distribution/81a5ff35-218d-44d0-9f21-271c5f70c84b/>,
+                      <https://w3id.org/ontouml-models/distribution/20ed5c49-3fd3-421f-875c-a78425e1e072>,
+                      <https://w3id.org/ontouml-models/distribution/22734a4d-891b-462f-9b9a-cad71b6c173a>,
+                      <https://w3id.org/ontouml-models/distribution/4235afb8-8200-43eb-b493-ed3809330dd9>,
+                      <https://w3id.org/ontouml-models/distribution/c03c79d4-1443-4c83-9c1f-0f86504afd11>,
+                      <https://w3id.org/ontouml-models/distribution/b789a904-2445-4ba3-ae5a-d3527bb06e02>,
+                      <https://w3id.org/ontouml-models/distribution/42dc25ed-7380-4816-a35e-23ace140ae51>,
+                      <https://w3id.org/ontouml-models/distribution/2785bc7c-adee-410a-a4bd-ef4fb46eacd9>,
+                      <https://w3id.org/ontouml-models/distribution/53fa74d9-3a0c-4167-83db-a7eedb3a8ead>,
+                      <https://w3id.org/ontouml-models/distribution/54d47bd2-14b4-43c2-8772-a4629e80faac>,
+                      <https://w3id.org/ontouml-models/distribution/e2fb53f8-824d-4b65-a527-8ebe2c812a9a>,
+                      <https://w3id.org/ontouml-models/distribution/394220b1-8fef-42ea-ba27-d3d63b698a07>,
+                      <https://w3id.org/ontouml-models/distribution/07206b07-1e74-4542-b70c-8b9d0e68b949>,
+                      <https://w3id.org/ontouml-models/distribution/de84e5fa-f880-4ca9-ae78-46ba4a0d4ceb>,
+                      <https://w3id.org/ontouml-models/distribution/eb2f1e37-fb88-43bb-bfbc-0d7a3d3e1b03>,
+                      <https://w3id.org/ontouml-models/distribution/2a1d825b-6374-46ec-b8e0-fc96e69a21f1>,
+                      <https://w3id.org/ontouml-models/distribution/5557c6ae-be4e-40e1-a6e3-65609f0c9db6>,
+                      <https://w3id.org/ontouml-models/distribution/ec6f6404-5cd6-4815-b67e-c8ceb9802eed>,
+                      <https://w3id.org/ontouml-models/distribution/cef48fdc-7b1f-43e1-9cae-6b0094d8802a> .

--- a/models/ferreira2024ontopix/metadata.ttl
+++ b/models/ferreira2024ontopix/metadata.ttl
@@ -1,36 +1,49 @@
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/model/ferreira2024ontopix/> a dcat:Dataset, mod:SemanticArtefact;
+<https://w3id.org/ontouml-models/model/ferreira2024ontopix/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
+    dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
     dct:title "OntoPIX";
     dct:issued "2024"^^xsd:gYear;
-    dcat:theme lcc:T;
+    dcat:theme lcc:H;
     dct:language "pt-br";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:contributor <https://www.linkedin.com/in/gabferreira-/>, <https://orcid.org/0009-0005-4081-6615>, <https://dblp.org/pid/309/4924>, <https://dblp.org/pid/b/FAraujoBaiao>;
-    mod:designedForTask ocmv:ConceptualClarification, ocmv:Interoperability, ocmv:OntologicalAnalysis;
+    dct:contributor <https://www.linkedin.com/in/gabferreira-/>,
+                    <https://orcid.org/0009-0005-4081-6615>,
+                    <https://dblp.org/pid/309/4924>,
+                    <https://dblp.org/pid/b/FAraujoBaiao>;
+    dcat:keyword "instant payment systems"@en,
+                 "brazilian financial system"@en,
+                 "monetary transactions"@en,
+                 "payment methods"@en,
+                 "financial services"@en,
+                 "banking operations"@en;
+    dct:source <https://ceur-ws.org/Vol-3905/short2.pdf>;
+    mod:designedForTask ocmv:ConceptualClarification,
+                        ocmv:Interoperability,
+                        ocmv:OntologicalAnalysis;
     ocmv:context ocmv:Research;
-    dct:source <https://ceur-ws.org/Vol-3905/short2.pdf>.
-<https://w3id.org/ontouml-models/model/ferreira2024ontopix/> dcat:distribution <https://w3id.org/ontouml-models/model/ferreira2024ontopix/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/ferreira2024ontopix/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"OntoPIX\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/ferreira2024ontopix/ontology.ttl>.
-<https://w3id.org/ontouml-models/model/ferreira2024ontopix/> dcat:distribution <https://w3id.org/ontouml-models/model/ferreira2024ontopix/distribution/json>.
-<https://w3id.org/ontouml-models/model/ferreira2024ontopix/distribution/json> a dcat:Distribution;
-    dct:title "JSON distribution of \"OntoPIX\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/ferreira2024ontopix/ontology.json>.
-<https://w3id.org/ontouml-models/model/ferreira2024ontopix/> dcat:distribution <https://w3id.org/ontouml-models/model/ferreira2024ontopix/distribution/vpp>.
-<https://w3id.org/ontouml-models/model/ferreira2024ontopix/distribution/vpp> a dcat:Distribution;
-    dct:title "Visual Paradigm distribution of \"OntoPIX\""@en;
-    dcat:mediaType <https://www.visual-paradigm.com/vpp>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/ferreira2024ontopix/ontology.vpp>.
+    ocmv:representationStyle ocmv:OntoumlStyle;
+    ocmv:ontologyType ocmv:Domain;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/ferreira2024ontopix"^^xsd:anyURI;
+    fdpo:metadataIssued "2026-06-23T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/ferreira2024ontopix/> dcat:distribution <https://w3id.org/ontouml-models/model/ferreira2024ontopix/distribution/ttl>,
+                      <https://www.iana.org/assignments/media-types/text/turtle>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/ferreira2024ontopix/ontology.ttl>,
+                      <https://w3id.org/ontouml-models/model/ferreira2024ontopix/>,
+                      <https://w3id.org/ontouml-models/model/ferreira2024ontopix/distribution/json>,
+                      <https://www.iana.org/assignments/media-types/application/json>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/ferreira2024ontopix/ontology.json>,
+                      <https://w3id.org/ontouml-models/model/ferreira2024ontopix/distribution/vpp>,
+                      <https://www.visual-paradigm.com/vpp>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/ferreira2024ontopix/ontology.vpp> .

--- a/models/fischer2018ontorea/metadata.ttl
+++ b/models/fischer2018ontorea/metadata.ttl
@@ -1,32 +1,48 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/dca91792-d4d7-4233-a62b-50040c242cf0/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:title "OntoREA© Accounting and Finance Model";
     dct:issued "2017"^^xsd:gYear;
     dct:modified "2019"^^xsd:gYear;
     dcat:theme lcc:H;
     skos:editorialNote "This model corresponds to the one proposed in the 2019 paper by Schwaiger et al.";
     dct:language "en";
-    dct:contributor <https://dblp.org/pid/07/4333>, <https://dblp.org/pid/253/7047>, <https://dblp.org/pid/79/1814>, <https://dblp.org/pid/204/1567>, <https://dblp.org/pid/253/7045>, <https://dblp.org/pid/229/6915>;
-    dcat:keyword "finance"@en, "accounting"@en, "economics"@en;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    dct:contributor <https://dblp.org/pid/07/4333>,
+                    <https://dblp.org/pid/253/7047>,
+                    <https://dblp.org/pid/79/1814>,
+                    <https://dblp.org/pid/204/1567>,
+                    <https://dblp.org/pid/253/7045>,
+                    <https://dblp.org/pid/229/6915>;
+    dcat:keyword "finance"@en,
+                 "accounting"@en,
+                 "economics"@en;
+    dct:source <https://doi.org/10.1007/978-3-030-35151-9_4>,
+               <https://dblp.org/rec/conf/vmbo/Fischer-Pauzenberger18>,
+               <https://doi.org/10.1007/978-3-030-02302-7_24>,
+               <https://doi.org/10.1007/978-3-319-70241-4_6>,
+               <https://doi.org/10.1007/978-3-319-69904-2_38>,
+               <https://doi.org/10.7250/csimq.2017-11.02>;
     mod:designedForTask ocmv:ConceptualClarification;
     ocmv:context ocmv:Research;
-    dct:source <https://doi.org/10.1007/978-3-030-35151-9_4>, <https://dblp.org/rec/conf/vmbo/Fischer-Pauzenberger18>, <https://doi.org/10.1007/978-3-030-02302-7_24>, <https://doi.org/10.1007/978-3-319-70241-4_6>, <https://doi.org/10.1007/978-3-319-69904-2_38>, <https://doi.org/10.7250/csimq.2017-11.02>;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/fischer2018ontorea"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/fischer2018ontorea"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:49:57.669102692Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:49:57.669102692Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/dca91792-d4d7-4233-a62b-50040c242cf0> dcat:distribution <https://w3id.org/ontouml-models/distribution/17762858-8496-463a-92d0-8ae74867f317/>, <https://w3id.org/ontouml-models/distribution/b80a291e-2808-4e4a-95e0-d6d5a3582ca8/>, <https://w3id.org/ontouml-models/distribution/7b869938-0ef3-490a-8e88-bfd46b84bcb5/>, <https://w3id.org/ontouml-models/distribution/6589623e-dc23-48c6-9773-91fdb9682202>, <https://w3id.org/ontouml-models/distribution/ff0ece76-1edc-4547-a222-a91067c60252>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/dca91792-d4d7-4233-a62b-50040c242cf0> dcat:distribution <https://w3id.org/ontouml-models/distribution/17762858-8496-463a-92d0-8ae74867f317/>,
+                      <https://w3id.org/ontouml-models/distribution/b80a291e-2808-4e4a-95e0-d6d5a3582ca8/>,
+                      <https://w3id.org/ontouml-models/distribution/7b869938-0ef3-490a-8e88-bfd46b84bcb5/>,
+                      <https://w3id.org/ontouml-models/distribution/6589623e-dc23-48c6-9773-91fdb9682202>,
+                      <https://w3id.org/ontouml-models/distribution/ff0ece76-1edc-4547-a222-a91067c60252> .

--- a/models/fonseca2022incorporating/metadata.ttl
+++ b/models/fonseca2022incorporating/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/ad016e7d-9ec8-42e3-b3e1-6d60cf178a78/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -18,14 +17,30 @@
     skos:editorialNote "Collection of examples created for the paper.";
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:contributor <https://dblp.org/pid/169/2246>, <https://dblp.org/pid/11/78>, <https://dblp.org/pid/91/3408>, <https://dblp.org/pid/134/4947>, <https://dblp.org/pid/33/8219>;
-    dcat:keyword "bird"@en, "creative work"@en, "ship"@en;
+    dct:contributor <https://dblp.org/pid/169/2246>,
+                    <https://dblp.org/pid/11/78>,
+                    <https://dblp.org/pid/91/3408>,
+                    <https://dblp.org/pid/134/4947>,
+                    <https://dblp.org/pid/33/8219>;
+    dcat:keyword "bird"@en,
+                 "creative work"@en,
+                 "ship"@en;
+    dct:source <https://doi.org/10.1007/978-3-031-17995-2_2>;
     mod:designedForTask ocmv:Example;
     ocmv:context ocmv:Research;
-    dct:source <https://doi.org/10.1007/978-3-031-17995-2_2>;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/fonseca2022incorporating"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/fonseca2022incorporating"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:50:06.977433495Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:50:06.977433495Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/ad016e7d-9ec8-42e3-b3e1-6d60cf178a78> dcat:distribution <https://w3id.org/ontouml-models/distribution/a0fce354-b5b4-4894-90a0-2632662060e3/>, <https://w3id.org/ontouml-models/distribution/cf1def54-3256-4f9d-a43b-7648ad200574/>, <https://w3id.org/ontouml-models/distribution/7e15ee08-d2d1-479a-8701-7a3d3ba8334d/>, <https://w3id.org/ontouml-models/distribution/4898aa41-1a05-4cea-aae7-d8040e5f172d>, <https://w3id.org/ontouml-models/distribution/49a100ce-220e-485b-b572-8779c045f13c>, <https://w3id.org/ontouml-models/distribution/923c5ae8-1602-44bc-a5f9-2cb0a5f42da7>, <https://w3id.org/ontouml-models/distribution/4cbac7c1-8bd2-4f78-9a1a-54acca2ad5f8>, <https://w3id.org/ontouml-models/distribution/654d755c-3a49-46e6-abb2-28fbb61bf0ba>, <https://w3id.org/ontouml-models/distribution/2a0b19da-a83d-46b7-8b31-dde343573735>, <https://w3id.org/ontouml-models/distribution/1fd0db4f-5ef6-42b7-8694-ceee4768ad09>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/ad016e7d-9ec8-42e3-b3e1-6d60cf178a78> dcat:distribution <https://w3id.org/ontouml-models/distribution/a0fce354-b5b4-4894-90a0-2632662060e3/>,
+                      <https://w3id.org/ontouml-models/distribution/cf1def54-3256-4f9d-a43b-7648ad200574/>,
+                      <https://w3id.org/ontouml-models/distribution/7e15ee08-d2d1-479a-8701-7a3d3ba8334d/>,
+                      <https://w3id.org/ontouml-models/distribution/4898aa41-1a05-4cea-aae7-d8040e5f172d>,
+                      <https://w3id.org/ontouml-models/distribution/49a100ce-220e-485b-b572-8779c045f13c>,
+                      <https://w3id.org/ontouml-models/distribution/923c5ae8-1602-44bc-a5f9-2cb0a5f42da7>,
+                      <https://w3id.org/ontouml-models/distribution/4cbac7c1-8bd2-4f78-9a1a-54acca2ad5f8>,
+                      <https://w3id.org/ontouml-models/distribution/654d755c-3a49-46e6-abb2-28fbb61bf0ba>,
+                      <https://w3id.org/ontouml-models/distribution/2a0b19da-a83d-46b7-8b31-dde343573735>,
+                      <https://w3id.org/ontouml-models/distribution/1fd0db4f-5ef6-42b7-8694-ceee4768ad09> .

--- a/models/formula-one2023/metadata.ttl
+++ b/models/formula-one2023/metadata.ttl
@@ -1,35 +1,38 @@
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/model/formula-one2023/> a dcat:Dataset, mod:SemanticArtefact;
+<https://w3id.org/ontouml-models/model/formula-one2023/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
+    dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
     dct:title "Formula One Example Ontology";
     mod:acronym "Formula One";
     dct:issued "2023"^^xsd:gYear;
     dcat:theme lcc:G;
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    dcat:keyword "formula one"@en,
+                 "racing"@en,
+                 "motorsport"@en;
     mod:designedForTask ocmv:Example;
-    ocmv:context ocmv:Research.
-<https://w3id.org/ontouml-models/model/formula-one2023/> dcat:distribution <https://w3id.org/ontouml-models/model/formula-one2023/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/formula-one2023/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Formula One Example Ontology\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/formula-one2023/ontology.ttl>.
-<https://w3id.org/ontouml-models/model/formula-one2023/> dcat:distribution <https://w3id.org/ontouml-models/model/formula-one2023/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/formula-one2023/distribution/ttl> a dcat:Distribution;
-    dct:title "JSON distribution of \"Formula One Example Ontology\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/formula-one2023/ontology.json>.
-<https://w3id.org/ontouml-models/model/formula-one2023/> dcat:distribution <https://w3id.org/ontouml-models/model/formula-one2023/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/formula-one2023/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Formula One Example Ontology\""@en;
-    dcat:mediaType <https://www.visual-paradigm.com/vpp>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/formula-one2023/ontology.vpp>.
+    ocmv:context ocmv:Research;
+    ocmv:representationStyle ocmv:OntoumlStyle;
+    ocmv:ontologyType ocmv:Domain;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/formula-one2023"^^xsd:anyURI;
+    fdpo:metadataIssued "2026-06-23T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/formula-one2023/> dcat:distribution <https://w3id.org/ontouml-models/model/formula-one2023/distribution/ttl>,
+                      <https://www.iana.org/assignments/media-types/text/turtle>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/formula-one2023/ontology.ttl>,
+                      <https://w3id.org/ontouml-models/model/formula-one2023/>,
+                      <https://www.iana.org/assignments/media-types/application/json>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/formula-one2023/ontology.json>,
+                      <https://www.visual-paradigm.com/vpp>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/formula-one2023/ontology.vpp> .

--- a/models/fraller2019abc/metadata.ttl
+++ b/models/fraller2019abc/metadata.ttl
@@ -1,31 +1,50 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/dbd5fed6-8332-458f-90ec-b9270e7b6fdc/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:title "Capacity-Based Activity-Based Costing System Model";
     dct:issued "2019"^^xsd:gYear;
     dct:modified "2019"^^xsd:gYear;
     dcat:theme lcc:T;
     dct:language "en";
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:contributor <https://repositum.tuwien.at/cris/rp/rp05529>;
-    dcat:keyword "activity-based costing"@en, "accounting"@en, "economics"@en;
-    mod:designedForTask ocmv:ConceptualClarification, ocmv:Interoperability;
-    ocmv:context ocmv:Research;
+    dcat:keyword "activity-based costing"@en,
+                 "accounting"@en,
+                 "economics"@en;
     dct:source <https://doi.org/10.34726/hss.2019.61925>;
+    mod:designedForTask ocmv:ConceptualClarification,
+                        ocmv:Interoperability;
+    ocmv:context ocmv:Research;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/fraller2019abc"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/fraller2019abc"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:50:24.471735854Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:50:24.471735854Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/dbd5fed6-8332-458f-90ec-b9270e7b6fdc> dcat:distribution <https://w3id.org/ontouml-models/distribution/5511de05-7efc-49bc-bd8a-b76e16667238/>, <https://w3id.org/ontouml-models/distribution/8741ccfc-4280-498c-8dc7-e5592d52c124/>, <https://w3id.org/ontouml-models/distribution/f2e33d06-ed1d-462b-bc91-00f7c1ae1c40/>, <https://w3id.org/ontouml-models/distribution/56c8fc41-d637-4b88-a912-9e35256a746a>, <https://w3id.org/ontouml-models/distribution/511c1b64-d7ca-4ae0-81f1-0b43bb487d09>, <https://w3id.org/ontouml-models/distribution/5e7992a5-de61-4ca8-8f05-e413c269b0f5>, <https://w3id.org/ontouml-models/distribution/62d2296c-a8b1-43e0-9553-5e496f1957d9>, <https://w3id.org/ontouml-models/distribution/c64b7622-5109-42b0-bec6-ccd03e51a149>, <https://w3id.org/ontouml-models/distribution/3097791e-2783-464d-8416-130012288959>, <https://w3id.org/ontouml-models/distribution/61652c4a-8079-4835-83cb-d85f4358c33c>, <https://w3id.org/ontouml-models/distribution/6d54045d-8849-4aa1-9768-54a001e5e889>, <https://w3id.org/ontouml-models/distribution/282be313-117e-448c-b5c1-b5f8fc3fc448>, <https://w3id.org/ontouml-models/distribution/bed45a0c-c530-4433-9be0-494b338d6e0c>, <https://w3id.org/ontouml-models/distribution/94ac4675-115c-4165-81db-2ce2b4178489>, <https://w3id.org/ontouml-models/distribution/edbde8c7-9dfd-4619-8a7c-0f1d6be95be8>, <https://w3id.org/ontouml-models/distribution/9e618de4-d201-4cab-a754-0d562750144d>, <https://w3id.org/ontouml-models/distribution/08c5b28e-c7a5-46da-ad93-99495e7ecf5e>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/dbd5fed6-8332-458f-90ec-b9270e7b6fdc> dcat:distribution <https://w3id.org/ontouml-models/distribution/5511de05-7efc-49bc-bd8a-b76e16667238/>,
+                      <https://w3id.org/ontouml-models/distribution/8741ccfc-4280-498c-8dc7-e5592d52c124/>,
+                      <https://w3id.org/ontouml-models/distribution/f2e33d06-ed1d-462b-bc91-00f7c1ae1c40/>,
+                      <https://w3id.org/ontouml-models/distribution/56c8fc41-d637-4b88-a912-9e35256a746a>,
+                      <https://w3id.org/ontouml-models/distribution/511c1b64-d7ca-4ae0-81f1-0b43bb487d09>,
+                      <https://w3id.org/ontouml-models/distribution/5e7992a5-de61-4ca8-8f05-e413c269b0f5>,
+                      <https://w3id.org/ontouml-models/distribution/62d2296c-a8b1-43e0-9553-5e496f1957d9>,
+                      <https://w3id.org/ontouml-models/distribution/c64b7622-5109-42b0-bec6-ccd03e51a149>,
+                      <https://w3id.org/ontouml-models/distribution/3097791e-2783-464d-8416-130012288959>,
+                      <https://w3id.org/ontouml-models/distribution/61652c4a-8079-4835-83cb-d85f4358c33c>,
+                      <https://w3id.org/ontouml-models/distribution/6d54045d-8849-4aa1-9768-54a001e5e889>,
+                      <https://w3id.org/ontouml-models/distribution/282be313-117e-448c-b5c1-b5f8fc3fc448>,
+                      <https://w3id.org/ontouml-models/distribution/bed45a0c-c530-4433-9be0-494b338d6e0c>,
+                      <https://w3id.org/ontouml-models/distribution/94ac4675-115c-4165-81db-2ce2b4178489>,
+                      <https://w3id.org/ontouml-models/distribution/edbde8c7-9dfd-4619-8a7c-0f1d6be95be8>,
+                      <https://w3id.org/ontouml-models/distribution/9e618de4-d201-4cab-a754-0d562750144d>,
+                      <https://w3id.org/ontouml-models/distribution/08c5b28e-c7a5-46da-ad93-99495e7ecf5e> .

--- a/models/franco2018rpg/metadata.ttl
+++ b/models/franco2018rpg/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/0aa4b475-184e-4452-a030-56b7bd4fd931/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -18,14 +17,27 @@
     dcat:theme lcc:G;
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:contributor <https://dblp.org/pid/142/4729>, <https://dblp.org/pid/242/2687>, <https://dblp.org/pid/275/8015>, <https://dblp.org/pid/204/1724>, <https://dblp.org/pid/98/4928>, <https://dblp.org/pid/g/FernandodeCarvalhoGomes>, <https://dblp.org/pid/37/3973>, <https://dblp.org/pid/57/6283>;
+    dct:contributor <https://dblp.org/pid/142/4729>,
+                    <https://dblp.org/pid/242/2687>,
+                    <https://dblp.org/pid/275/8015>,
+                    <https://dblp.org/pid/204/1724>,
+                    <https://dblp.org/pid/98/4928>,
+                    <https://dblp.org/pid/g/FernandodeCarvalhoGomes>,
+                    <https://dblp.org/pid/37/3973>,
+                    <https://dblp.org/pid/57/6283>;
     dcat:keyword "games"@en;
-    mod:designedForTask ocmv:ConceptualClarification, ocmv:Interoperability;
-    ocmv:context ocmv:Research;
     dct:source <http://www.sbgames.org/sbgames2018/files/papers/ComputacaoShort/188294.pdf>;
+    mod:designedForTask ocmv:ConceptualClarification,
+                        ocmv:Interoperability;
+    ocmv:context ocmv:Research;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/franco2018rpg"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/franco2018rpg"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:50:53.734972107Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:50:53.734972107Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/0aa4b475-184e-4452-a030-56b7bd4fd931> dcat:distribution <https://w3id.org/ontouml-models/distribution/bc948025-aae9-463a-af79-a70b2c80f885/>, <https://w3id.org/ontouml-models/distribution/c38e95ac-9523-4435-990b-fd654dc4efca/>, <https://w3id.org/ontouml-models/distribution/f4f4c7c4-6fb6-425e-ad47-ad65da5a121a/>, <https://w3id.org/ontouml-models/distribution/e24e6d0b-2844-4894-a881-62d9fdbf54c5>, <https://w3id.org/ontouml-models/distribution/692da264-db2e-4ba1-b846-a4f035d21371>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/0aa4b475-184e-4452-a030-56b7bd4fd931> dcat:distribution <https://w3id.org/ontouml-models/distribution/bc948025-aae9-463a-af79-a70b2c80f885/>,
+                      <https://w3id.org/ontouml-models/distribution/c38e95ac-9523-4435-990b-fd654dc4efca/>,
+                      <https://w3id.org/ontouml-models/distribution/f4f4c7c4-6fb6-425e-ad47-ad65da5a121a/>,
+                      <https://w3id.org/ontouml-models/distribution/e24e6d0b-2844-4894-a881-62d9fdbf54c5>,
+                      <https://w3id.org/ontouml-models/distribution/692da264-db2e-4ba1-b846-a4f035d21371> .

--- a/models/freshbz2023/metadata.ttl
+++ b/models/freshbz2023/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/243da519-dae6-40d8-923b-064b50bce14c/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -18,12 +17,22 @@
     skos:editorialNote "Sent by the modeler who chose to remain anonymous.";
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0>;
-    dcat:keyword "university"@en, "information system"@en;
+    dcat:keyword "university"@en,
+                 "information system"@en;
     mod:designedForTask ocmv:SoftwareEngineering;
     ocmv:context ocmv:Classroom;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Application;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/freshbz2023"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/freshbz2023"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:51:04.540482438Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:51:04.540482438Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/243da519-dae6-40d8-923b-064b50bce14c> dcat:distribution <https://w3id.org/ontouml-models/distribution/9e27f11b-ed1a-400d-a0dd-01246adfffbc/>, <https://w3id.org/ontouml-models/distribution/fd4280c6-18b2-4acf-96d3-2f9011442767/>, <https://w3id.org/ontouml-models/distribution/9cb1aa57-f514-4d6b-9fcd-5ec4eb7d1bff/>, <https://w3id.org/ontouml-models/distribution/d67691c7-8ce4-4e51-8001-18397be1e212>, <https://w3id.org/ontouml-models/distribution/5032e318-a45a-4b3b-844b-e545aa17dc0d>, <https://w3id.org/ontouml-models/distribution/0c228990-cbec-445c-897a-7a19ac06e4a1>, <https://w3id.org/ontouml-models/distribution/9f0e34f2-0176-4996-8ceb-2905b2a5579a>, <https://w3id.org/ontouml-models/distribution/dba40944-7d60-478f-9667-e1299080505d>, <https://w3id.org/ontouml-models/distribution/9751adef-50af-4c5c-bd2a-5e46ee57a14f>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/243da519-dae6-40d8-923b-064b50bce14c> dcat:distribution <https://w3id.org/ontouml-models/distribution/9e27f11b-ed1a-400d-a0dd-01246adfffbc/>,
+                      <https://w3id.org/ontouml-models/distribution/fd4280c6-18b2-4acf-96d3-2f9011442767/>,
+                      <https://w3id.org/ontouml-models/distribution/9cb1aa57-f514-4d6b-9fcd-5ec4eb7d1bff/>,
+                      <https://w3id.org/ontouml-models/distribution/d67691c7-8ce4-4e51-8001-18397be1e212>,
+                      <https://w3id.org/ontouml-models/distribution/5032e318-a45a-4b3b-844b-e545aa17dc0d>,
+                      <https://w3id.org/ontouml-models/distribution/0c228990-cbec-445c-897a-7a19ac06e4a1>,
+                      <https://w3id.org/ontouml-models/distribution/9f0e34f2-0176-4996-8ceb-2905b2a5579a>,
+                      <https://w3id.org/ontouml-models/distribution/dba40944-7d60-478f-9667-e1299080505d>,
+                      <https://w3id.org/ontouml-models/distribution/9751adef-50af-4c5c-bd2a-5e46ee57a14f> .

--- a/models/fumagalli2022criminal-investigation/metadata.ttl
+++ b/models/fumagalli2022criminal-investigation/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/8353ae58-e924-4b13-8cbe-7078e59830ac/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -18,14 +17,22 @@
     skos:editorialNote "The original diagram in vpp format was sent by the author. The diagram name was changed to correspond to the paper's one.";
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:contributor <https://dblp.org/pid/161/4517>, <https://dblp.org/pid/134/4947>, <https://dblp.org/pid/b/FAraujoBaiao>, <https://dblp.org/pid/11/78>;
-    dcat:keyword "crime"@en, "investigation"@en;
+    dct:contributor <https://dblp.org/pid/161/4517>,
+                    <https://dblp.org/pid/134/4947>,
+                    <https://dblp.org/pid/b/FAraujoBaiao>,
+                    <https://dblp.org/pid/11/78>;
+    dcat:keyword "crime"@en,
+                 "investigation"@en;
+    dct:source <https://doi.org/10.1016/j.datak.2022.102040>;
     mod:designedForTask ocmv:Example;
     ocmv:context ocmv:Research;
-    dct:source <https://doi.org/10.1016/j.datak.2022.102040>;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/fumagalli2022criminal-investigation"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/fumagalli2022criminal-investigation"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:51:20.341343389Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:51:20.341343389Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/8353ae58-e924-4b13-8cbe-7078e59830ac> dcat:distribution <https://w3id.org/ontouml-models/distribution/74bb1cb5-3c79-4b91-8c51-2907287519fd/>, <https://w3id.org/ontouml-models/distribution/2fe28a11-d2f0-4cac-bdef-b71788369fd9/>, <https://w3id.org/ontouml-models/distribution/b8687fb1-d444-43f1-a4e8-37e894f98a5a/>, <https://w3id.org/ontouml-models/distribution/6f1246f7-6091-4130-b872-06be5a749f72>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/8353ae58-e924-4b13-8cbe-7078e59830ac> dcat:distribution <https://w3id.org/ontouml-models/distribution/74bb1cb5-3c79-4b91-8c51-2907287519fd/>,
+                      <https://w3id.org/ontouml-models/distribution/2fe28a11-d2f0-4cac-bdef-b71788369fd9/>,
+                      <https://w3id.org/ontouml-models/distribution/b8687fb1-d444-43f1-a4e8-37e894f98a5a/>,
+                      <https://w3id.org/ontouml-models/distribution/6f1246f7-6091-4130-b872-06be5a749f72> .

--- a/models/g809-2015/metadata.ttl
+++ b/models/g809-2015/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/886bc5e1-a538-449e-9235-5ef0cc1cadf0/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -18,13 +17,19 @@
     skos:editorialNote "The ontology is the outcome of classroom activity on the representation to the recommendation G.809 of the International Telecommunication Union on the standardization \"Functional architecture of connectionless layer networks. Among the references, we have included the ITU-T recommendation G.809 which should be the basis of the documented ontology.";
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dcat:keyword "networking"@en, "transmission systems"@en;
+    dcat:keyword "networking"@en,
+                 "transmission systems"@en;
+    dct:source <https://www.itu.int/rec/T-REC-G.809-200303-I/en>;
     mod:designedForTask ocmv:ConceptualClarification;
     ocmv:context ocmv:Classroom;
-    dct:source <https://www.itu.int/rec/T-REC-G.809-200303-I/en>;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/g809-2015"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/g809-2015"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:51:28.182947142Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:51:28.182947142Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/886bc5e1-a538-449e-9235-5ef0cc1cadf0> dcat:distribution <https://w3id.org/ontouml-models/distribution/84120461-ab7c-49ab-8b47-6fc8d8b89b4c/>, <https://w3id.org/ontouml-models/distribution/a84da830-540f-42bc-962e-4579332dff32/>, <https://w3id.org/ontouml-models/distribution/93b76c2f-1d7b-41c5-9617-d72173ebf104/>, <https://w3id.org/ontouml-models/distribution/68189b62-0cdb-45fe-a4fa-8b509c9c4c68>, <https://w3id.org/ontouml-models/distribution/eec3e579-2464-4034-ab8e-ae2f30c49aeb>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/886bc5e1-a538-449e-9235-5ef0cc1cadf0> dcat:distribution <https://w3id.org/ontouml-models/distribution/84120461-ab7c-49ab-8b47-6fc8d8b89b4c/>,
+                      <https://w3id.org/ontouml-models/distribution/a84da830-540f-42bc-962e-4579332dff32/>,
+                      <https://w3id.org/ontouml-models/distribution/93b76c2f-1d7b-41c5-9617-d72173ebf104/>,
+                      <https://w3id.org/ontouml-models/distribution/68189b62-0cdb-45fe-a4fa-8b509c9c4c68>,
+                      <https://w3id.org/ontouml-models/distribution/eec3e579-2464-4034-ab8e-ae2f30c49aeb> .

--- a/models/gailly2016value/metadata.ttl
+++ b/models/gailly2016value/metadata.ttl
@@ -1,32 +1,38 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/27838506-29aa-4445-a1fe-73e710c9c186/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:title "Core Value Ontology";
     dct:issued "2016"^^xsd:gYear;
     dct:modified "2016"^^xsd:gYear;
     dcat:theme lcc:H;
     skos:editorialNote "The paper first presents the Core Value Ontology (Fig. 9) and then presents an instantiation of this ontology for the healthcare domain (Fig. 10). Both diagrams were reproduced.";
     dct:language "en";
-    dct:contributor <https://dblp.org/pid/95/6356>, <https://dblp.org/pid/131/1200>, <https://dblp.org/pid/11/78>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    dct:contributor <https://dblp.org/pid/95/6356>,
+                    <https://dblp.org/pid/131/1200>,
+                    <https://dblp.org/pid/11/78>;
     dcat:keyword "value"@en;
+    dct:source <https://doi.org/10.1007/978-3-319-47717-6_16>;
     mod:designedForTask ocmv:ConceptualClarification;
     ocmv:context ocmv:Research;
-    dct:source <https://doi.org/10.1007/978-3-319-47717-6_16>;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Core;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/gailly2016value"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/gailly2016value"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:51:37.704953847Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:51:37.704953847Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/27838506-29aa-4445-a1fe-73e710c9c186> dcat:distribution <https://w3id.org/ontouml-models/distribution/9535f276-2f73-4268-893e-5778df89b8ce/>, <https://w3id.org/ontouml-models/distribution/b63c3030-9de1-4272-bcb6-05ca764001db/>, <https://w3id.org/ontouml-models/distribution/a3e752a4-6990-4d4d-8730-b19a92441fbe/>, <https://w3id.org/ontouml-models/distribution/b4dcfd16-d911-47a5-9922-d2896c943176>, <https://w3id.org/ontouml-models/distribution/e97baa9a-9831-404b-8b43-982b78aae293>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/27838506-29aa-4445-a1fe-73e710c9c186> dcat:distribution <https://w3id.org/ontouml-models/distribution/9535f276-2f73-4268-893e-5778df89b8ce/>,
+                      <https://w3id.org/ontouml-models/distribution/b63c3030-9de1-4272-bcb6-05ca764001db/>,
+                      <https://w3id.org/ontouml-models/distribution/a3e752a4-6990-4d4d-8730-b19a92441fbe/>,
+                      <https://w3id.org/ontouml-models/distribution/b4dcfd16-d911-47a5-9922-d2896c943176>,
+                      <https://w3id.org/ontouml-models/distribution/e97baa9a-9831-404b-8b43-982b78aae293> .

--- a/models/garcia2022human-genome-events/metadata.ttl
+++ b/models/garcia2022human-genome-events/metadata.ttl
@@ -1,32 +1,43 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/765516ef-53fe-4933-a0e5-0a38079d25c3/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:title "Ontologically enriched version of Conceptual Schema of the Human Genome";
     mod:acronym "CSHG";
     dct:issued "2022"^^xsd:gYear;
     dcat:theme lcc:Q;
     skos:editorialNote "The original diagram in vpp format was sent by the author. The only necessary action was the substitution of the generic categories by the same ones from the vp ontouml plugin. Metadata validated by the model author.";
     dct:language "en";
-    dct:contributor <https://dblp.org/pid/201/2998.html>, <https://dblp.org/pid/11/78>, <https://dblp.org/pid/p/OscarPastor>, <https://dblp.org/pid/41/1781>, <https://dblp.org/pid/25/929-2>;
-    dcat:keyword "human genome"@en, "biological event"@en, "biological pathways"@en;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    dct:contributor <https://dblp.org/pid/201/2998.html>,
+                    <https://dblp.org/pid/11/78>,
+                    <https://dblp.org/pid/p/OscarPastor>,
+                    <https://dblp.org/pid/41/1781>,
+                    <https://dblp.org/pid/25/929-2>;
+    dcat:keyword "human genome"@en,
+                 "biological event"@en,
+                 "biological pathways"@en;
+    dct:source <https://doi.org/10.1007/978-3-031-07481-3_4>,
+               <https://doi.org/10.1109/access.2020.3034793>;
     mod:designedForTask ocmv:ConceptualClarification;
     ocmv:context ocmv:Research;
-    dct:source <https://doi.org/10.1007/978-3-031-07481-3_4>, <https://doi.org/10.1109/access.2020.3034793>;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/garcia2022human-genome-events"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/garcia2022human-genome-events"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:51:47.230441279Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:51:47.230441279Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/765516ef-53fe-4933-a0e5-0a38079d25c3> dcat:distribution <https://w3id.org/ontouml-models/distribution/6d9762e4-6f5e-413d-aa9a-aaaeebc5f070/>, <https://w3id.org/ontouml-models/distribution/c398450e-3de4-4f5e-8504-86ad9977fd22/>, <https://w3id.org/ontouml-models/distribution/e061842e-e597-49c1-8c55-b80ae19eb3a4/>, <https://w3id.org/ontouml-models/distribution/08eafe8a-3279-43bc-93ca-affd8d2f4a75>, <https://w3id.org/ontouml-models/distribution/35bdbc97-7a8e-4b06-a0db-0e102b867966>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/765516ef-53fe-4933-a0e5-0a38079d25c3> dcat:distribution <https://w3id.org/ontouml-models/distribution/6d9762e4-6f5e-413d-aa9a-aaaeebc5f070/>,
+                      <https://w3id.org/ontouml-models/distribution/c398450e-3de4-4f5e-8504-86ad9977fd22/>,
+                      <https://w3id.org/ontouml-models/distribution/e061842e-e597-49c1-8c55-b80ae19eb3a4/>,
+                      <https://w3id.org/ontouml-models/distribution/08eafe8a-3279-43bc-93ca-affd8d2f4a75>,
+                      <https://w3id.org/ontouml-models/distribution/35bdbc97-7a8e-4b06-a0db-0e102b867966> .

--- a/models/genealogy2013/metadata.ttl
+++ b/models/genealogy2013/metadata.ttl
@@ -1,35 +1,38 @@
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/model/genealogy2013/> a dcat:Dataset, mod:SemanticArtefact;
+<https://w3id.org/ontouml-models/model/genealogy2013/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
+    dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
     dct:title "Simple Genealogy Ontology";
     dct:issued "2013"^^xsd:gYear;
     dcat:theme lcc:C;
     skos:editorialNote "Ontology created during an Ontology Engineering lecture by students who wanted to remain anonymous. The ontology was build in a different editor tool and imported to Visual Paradigm, the current diagrammation may not exactly match the original one.";
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    mod:designedForTask ocmv:ConceptualClarification, ocmv:Learning;
-    ocmv:context ocmv:Classroom.
-<https://w3id.org/ontouml-models/model/genealogy2013/> dcat:distribution <https://w3id.org/ontouml-models/model/genealogy2013/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/genealogy2013/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Simple Genealogy Ontology\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/genealogy2013/ontology.ttl>.
-<https://w3id.org/ontouml-models/model/genealogy2013/> dcat:distribution <https://w3id.org/ontouml-models/model/genealogy2013/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/genealogy2013/distribution/ttl> a dcat:Distribution;
-    dct:title "JSON distribution of \"Simple Genealogy Ontology\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/genealogy2013/ontology.json>.
-<https://w3id.org/ontouml-models/model/genealogy2013/> dcat:distribution <https://w3id.org/ontouml-models/model/genealogy2013/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/genealogy2013/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Simple Genealogy Ontology\""@en;
-    dcat:mediaType <https://www.visual-paradigm.com/vpp>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/genealogy2013/ontology.vpp>.
+    dcat:keyword "genealogy"@en,
+                 "family"@en;
+    mod:designedForTask ocmv:ConceptualClarification,
+                        ocmv:Learning;
+    ocmv:context ocmv:Classroom;
+    ocmv:representationStyle ocmv:OntoumlStyle;
+    ocmv:ontologyType ocmv:Domain;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/genealogy2013"^^xsd:anyURI;
+    fdpo:metadataIssued "2026-06-23T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/genealogy2013/> dcat:distribution <https://w3id.org/ontouml-models/model/genealogy2013/distribution/ttl>,
+                      <https://www.iana.org/assignments/media-types/text/turtle>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/genealogy2013/ontology.ttl>,
+                      <https://w3id.org/ontouml-models/model/genealogy2013/>,
+                      <https://www.iana.org/assignments/media-types/application/json>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/genealogy2013/ontology.json>,
+                      <https://www.visual-paradigm.com/vpp>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/genealogy2013/ontology.vpp> .

--- a/models/gi2mo/metadata.ttl
+++ b/models/gi2mo/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/bbc30d79-0cea-4f92-bdbb-827d5c4c54e5/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -19,12 +18,24 @@
     skos:editorialNote "This model was done as an assignment for a course. The author required to remain anonymous. There is no information about the ontology development year. The original model exported in XMI was imported and edited with the OntoUML plugin to correspond to the diagrams' images. A class without any reference was removed (Class_1).";
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dcat:keyword "creative work"@en, "idea management"@en;
+    dcat:keyword "creative work"@en,
+                 "idea management"@en;
     mod:designedForTask ocmv:ConceptualClarification;
     ocmv:context ocmv:Classroom;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/gi2mo"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/gi2mo"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:51:56.252169222Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:51:56.252169222Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/bbc30d79-0cea-4f92-bdbb-827d5c4c54e5> dcat:distribution <https://w3id.org/ontouml-models/distribution/a81c0f04-d421-4fc8-adb9-548e294b9ee0/>, <https://w3id.org/ontouml-models/distribution/8a4c30e3-e53e-4682-836e-d1adafb609f6/>, <https://w3id.org/ontouml-models/distribution/5b292e04-815f-4bfd-92b5-abf783f1b19d/>, <https://w3id.org/ontouml-models/distribution/26d21bf7-a1a4-48e6-a46c-7f92defa22bd>, <https://w3id.org/ontouml-models/distribution/8f8da242-3c70-4b28-b55d-d8d7ba21edc0>, <https://w3id.org/ontouml-models/distribution/e5796ba6-2090-4162-bdd1-d1021878afd3>, <https://w3id.org/ontouml-models/distribution/3b90e7ae-7555-4305-89c4-0851a6d49391>, <https://w3id.org/ontouml-models/distribution/58f94d29-ea95-4f6f-be72-4fbad923f9a8>, <https://w3id.org/ontouml-models/distribution/19fc1b38-7868-41e9-a79d-b9720438f833>, <https://w3id.org/ontouml-models/distribution/aa8e0b22-bcc0-4df3-9d2d-2e08803ddf71>, <https://w3id.org/ontouml-models/distribution/c570add7-7699-4ca6-ad77-3553b5c64293>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/bbc30d79-0cea-4f92-bdbb-827d5c4c54e5> dcat:distribution <https://w3id.org/ontouml-models/distribution/a81c0f04-d421-4fc8-adb9-548e294b9ee0/>,
+                      <https://w3id.org/ontouml-models/distribution/8a4c30e3-e53e-4682-836e-d1adafb609f6/>,
+                      <https://w3id.org/ontouml-models/distribution/5b292e04-815f-4bfd-92b5-abf783f1b19d/>,
+                      <https://w3id.org/ontouml-models/distribution/26d21bf7-a1a4-48e6-a46c-7f92defa22bd>,
+                      <https://w3id.org/ontouml-models/distribution/8f8da242-3c70-4b28-b55d-d8d7ba21edc0>,
+                      <https://w3id.org/ontouml-models/distribution/e5796ba6-2090-4162-bdd1-d1021878afd3>,
+                      <https://w3id.org/ontouml-models/distribution/3b90e7ae-7555-4305-89c4-0851a6d49391>,
+                      <https://w3id.org/ontouml-models/distribution/58f94d29-ea95-4f6f-be72-4fbad923f9a8>,
+                      <https://w3id.org/ontouml-models/distribution/19fc1b38-7868-41e9-a79d-b9720438f833>,
+                      <https://w3id.org/ontouml-models/distribution/aa8e0b22-bcc0-4df3-9d2d-2e08803ddf71>,
+                      <https://w3id.org/ontouml-models/distribution/c570add7-7699-4ca6-ad77-3553b5c64293> .

--- a/models/gomes2022digital-technology/metadata.ttl
+++ b/models/gomes2022digital-technology/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/b4b680b4-5bf6-47cd-9d53-b89277ca1ae3/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -17,14 +16,23 @@
     dcat:theme lcc:T;
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:contributor <https://dblp.org/pid/256/1508>, <https://dblp.org/pid/33/6173>, <https://dblp.org/pid/99/745>;
-    dcat:keyword "digital technology"@en, "digital object"@en, "syntactic object"@en, "bitstring"@en;
+    dct:contributor <https://dblp.org/pid/256/1508>,
+                    <https://dblp.org/pid/33/6173>,
+                    <https://dblp.org/pid/99/745>;
+    dcat:keyword "digital technology"@en,
+                 "digital object"@en,
+                 "syntactic object"@en,
+                 "bitstring"@en;
+    dct:source <https://doi.org/10.1007/978-3-031-17995-2_7>;
     mod:designedForTask ocmv:ConceptualClarification;
     ocmv:context ocmv:Research;
-    dct:source <https://doi.org/10.1007/978-3-031-17995-2_7>;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/gomes2022digital-technology"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/gomes2022digital-technology"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:52:15.48303727Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:52:15.48303727Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/b4b680b4-5bf6-47cd-9d53-b89277ca1ae3> dcat:distribution <https://w3id.org/ontouml-models/distribution/80b00c56-c5aa-4ea2-9186-522bc006bdce/>, <https://w3id.org/ontouml-models/distribution/a4f591a6-5e99-4e49-9717-f78da3ee0461/>, <https://w3id.org/ontouml-models/distribution/7497f2fc-66a6-49b5-815d-fe06ff82df90/>, <https://w3id.org/ontouml-models/distribution/a7c532ac-725c-4305-906c-f5e62fecdff3>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/b4b680b4-5bf6-47cd-9d53-b89277ca1ae3> dcat:distribution <https://w3id.org/ontouml-models/distribution/80b00c56-c5aa-4ea2-9186-522bc006bdce/>,
+                      <https://w3id.org/ontouml-models/distribution/a4f591a6-5e99-4e49-9717-f78da3ee0461/>,
+                      <https://w3id.org/ontouml-models/distribution/7497f2fc-66a6-49b5-815d-fe06ff82df90/>,
+                      <https://w3id.org/ontouml-models/distribution/a7c532ac-725c-4305-906c-f5e62fecdff3> .

--- a/models/goncalves2011ecg/metadata.ttl
+++ b/models/goncalves2011ecg/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/ad222e18-67f9-4393-b6c4-8da9c003bc74/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -19,14 +18,53 @@
     skos:editorialNote "For the meta-properties immutable part and immutable whole, the part and whole association end, respectively, were set as readOnly. LeftAtriumAsAPump and RightAtriumAsAPump specializations were corrected. Diagrams from different papers used different notations, for consistency, I converted all to upper camel case for classes and lower camel case for associations (used in the first source). Information presented in newer diagrams overwrites the ones in old diagrams. There is no information about packages for newer diagrams, so they were set in already existing packages according to their content. This model version is a conversion to OntoUML 2.0 of the previously published model.";
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0>;
-    dct:contributor <https://dblp.org/pid/35/1880>, <https://dblp.org/pid/39/1708>, <https://dblp.org/pid/11/78>, <https://dblp.org/pid/36/6967>;
-    dcat:keyword "electrocardiography"@en, "heart"@en, "medicine"@en;
-    mod:designedForTask ocmv:ConceptualClarification, ocmv:Interoperability, ocmv:OntologicalAnalysis, ocmv:SoftwareEngineering;
+    dct:contributor <https://dblp.org/pid/35/1880>,
+                    <https://dblp.org/pid/39/1708>,
+                    <https://dblp.org/pid/11/78>,
+                    <https://dblp.org/pid/36/6967>;
+    dcat:keyword "electrocardiography"@en,
+                 "heart"@en,
+                 "medicine"@en;
+    dct:source <https://doi.org/10.1016/j.jbi.2010.08.007>,
+               <https://repositorio.ufes.br/handle/10/6409>,
+               <https://doi.org/10.3395/reciis.v3i1.819>,
+               <https://www.researchgate.net/publication/228761668_An_electrocardiogram_ECG_domain_ontology>;
+    mod:designedForTask ocmv:ConceptualClarification,
+                        ocmv:Interoperability,
+                        ocmv:OntologicalAnalysis,
+                        ocmv:SoftwareEngineering;
     ocmv:context ocmv:Research;
-    dct:source <https://doi.org/10.1016/j.jbi.2010.08.007>, <https://repositorio.ufes.br/handle/10/6409>, <https://doi.org/10.3395/reciis.v3i1.819>, <https://www.researchgate.net/publication/228761668_An_electrocardiogram_ECG_domain_ontology>;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/goncalves2011ecg"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/goncalves2011ecg"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:52:23.4012368Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:52:23.4012368Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/ad222e18-67f9-4393-b6c4-8da9c003bc74> dcat:distribution <https://w3id.org/ontouml-models/distribution/b7cff426-16b4-4276-af6a-c4b4106343b5/>, <https://w3id.org/ontouml-models/distribution/3d538271-5741-48d3-ab0c-a96e32cbdf34/>, <https://w3id.org/ontouml-models/distribution/4778be57-9cb8-466a-8a6c-9cee4b1aa2d4/>, <https://w3id.org/ontouml-models/distribution/b7b86022-33e8-4490-a491-1321b774c63d>, <https://w3id.org/ontouml-models/distribution/1f422581-a49c-4a3e-811a-93bc64a6ea17>, <https://w3id.org/ontouml-models/distribution/8993dc0d-9c5e-425a-b50e-f53f10fd0667>, <https://w3id.org/ontouml-models/distribution/0bbf9e94-c981-4ea2-a5cf-2a5dac5b396d>, <https://w3id.org/ontouml-models/distribution/0f8606e3-741e-4786-9a41-e1c1fd50ad15>, <https://w3id.org/ontouml-models/distribution/160371fa-ae85-4c62-9f33-518b0d6bf0de>, <https://w3id.org/ontouml-models/distribution/e3a4b98b-b12f-4737-bd32-62a14385cfd3>, <https://w3id.org/ontouml-models/distribution/60251aa3-d8e1-4052-9291-d350ed399e43>, <https://w3id.org/ontouml-models/distribution/b0377e7d-43b6-4256-a5b7-ddf41ab10130>, <https://w3id.org/ontouml-models/distribution/61d2a50a-520b-484a-b7c6-857059c31bc6>, <https://w3id.org/ontouml-models/distribution/956c653a-54e0-4246-bac8-ad85ceaffe8e>, <https://w3id.org/ontouml-models/distribution/19a834e4-8920-4d8f-bb1a-5ffc31dc9134>, <https://w3id.org/ontouml-models/distribution/a03a1003-b122-4a8a-9394-6bcaca76125d>, <https://w3id.org/ontouml-models/distribution/6ee298dc-b3af-4c3c-8a18-9ba88f8fb27c>, <https://w3id.org/ontouml-models/distribution/5a892a96-63d2-4492-9486-d758886b5c51>, <https://w3id.org/ontouml-models/distribution/09f97d84-3882-4b52-a1e5-976005e5926e>, <https://w3id.org/ontouml-models/distribution/27834526-1353-40e4-9e17-437fb793a978>, <https://w3id.org/ontouml-models/distribution/eb101ae1-3d24-4b2d-86ba-38956c67a229>, <https://w3id.org/ontouml-models/distribution/65f651bd-3b9c-4504-9b68-c973e80025e6>, <https://w3id.org/ontouml-models/distribution/d9b86c61-0d29-43b6-b27b-a7d5a8ab10c8>, <https://w3id.org/ontouml-models/distribution/328e01a7-8e05-4973-8449-1476ca294f94>, <https://w3id.org/ontouml-models/distribution/df365799-300a-4913-9fc4-5589a3784f9c>, <https://w3id.org/ontouml-models/distribution/f9d73be8-99f8-4636-b15b-1ad492e048e2>, <https://w3id.org/ontouml-models/distribution/f933869b-15a7-4da6-a85b-a7fc612f3387>, <https://w3id.org/ontouml-models/distribution/1fa17ae0-c1d5-4bec-8539-e4d4e4b9a300>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/ad222e18-67f9-4393-b6c4-8da9c003bc74> dcat:distribution <https://w3id.org/ontouml-models/distribution/b7cff426-16b4-4276-af6a-c4b4106343b5/>,
+                      <https://w3id.org/ontouml-models/distribution/3d538271-5741-48d3-ab0c-a96e32cbdf34/>,
+                      <https://w3id.org/ontouml-models/distribution/4778be57-9cb8-466a-8a6c-9cee4b1aa2d4/>,
+                      <https://w3id.org/ontouml-models/distribution/b7b86022-33e8-4490-a491-1321b774c63d>,
+                      <https://w3id.org/ontouml-models/distribution/1f422581-a49c-4a3e-811a-93bc64a6ea17>,
+                      <https://w3id.org/ontouml-models/distribution/8993dc0d-9c5e-425a-b50e-f53f10fd0667>,
+                      <https://w3id.org/ontouml-models/distribution/0bbf9e94-c981-4ea2-a5cf-2a5dac5b396d>,
+                      <https://w3id.org/ontouml-models/distribution/0f8606e3-741e-4786-9a41-e1c1fd50ad15>,
+                      <https://w3id.org/ontouml-models/distribution/160371fa-ae85-4c62-9f33-518b0d6bf0de>,
+                      <https://w3id.org/ontouml-models/distribution/e3a4b98b-b12f-4737-bd32-62a14385cfd3>,
+                      <https://w3id.org/ontouml-models/distribution/60251aa3-d8e1-4052-9291-d350ed399e43>,
+                      <https://w3id.org/ontouml-models/distribution/b0377e7d-43b6-4256-a5b7-ddf41ab10130>,
+                      <https://w3id.org/ontouml-models/distribution/61d2a50a-520b-484a-b7c6-857059c31bc6>,
+                      <https://w3id.org/ontouml-models/distribution/956c653a-54e0-4246-bac8-ad85ceaffe8e>,
+                      <https://w3id.org/ontouml-models/distribution/19a834e4-8920-4d8f-bb1a-5ffc31dc9134>,
+                      <https://w3id.org/ontouml-models/distribution/a03a1003-b122-4a8a-9394-6bcaca76125d>,
+                      <https://w3id.org/ontouml-models/distribution/6ee298dc-b3af-4c3c-8a18-9ba88f8fb27c>,
+                      <https://w3id.org/ontouml-models/distribution/5a892a96-63d2-4492-9486-d758886b5c51>,
+                      <https://w3id.org/ontouml-models/distribution/09f97d84-3882-4b52-a1e5-976005e5926e>,
+                      <https://w3id.org/ontouml-models/distribution/27834526-1353-40e4-9e17-437fb793a978>,
+                      <https://w3id.org/ontouml-models/distribution/eb101ae1-3d24-4b2d-86ba-38956c67a229>,
+                      <https://w3id.org/ontouml-models/distribution/65f651bd-3b9c-4504-9b68-c973e80025e6>,
+                      <https://w3id.org/ontouml-models/distribution/d9b86c61-0d29-43b6-b27b-a7d5a8ab10c8>,
+                      <https://w3id.org/ontouml-models/distribution/328e01a7-8e05-4973-8449-1476ca294f94>,
+                      <https://w3id.org/ontouml-models/distribution/df365799-300a-4913-9fc4-5589a3784f9c>,
+                      <https://w3id.org/ontouml-models/distribution/f9d73be8-99f8-4636-b15b-1ad492e048e2>,
+                      <https://w3id.org/ontouml-models/distribution/f933869b-15a7-4da6-a85b-a7fc612f3387>,
+                      <https://w3id.org/ontouml-models/distribution/1fa17ae0-c1d5-4bec-8539-e4d4e4b9a300> .

--- a/models/grueau2013towards/metadata.ttl
+++ b/models/grueau2013towards/metadata.ttl
@@ -1,32 +1,38 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/12a721da-35ae-460f-9417-a2cf55e0f203/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:title "MAS/LUCC Domain Ontology (excerpt - the agents' layer)";
     dct:issued "2014"^^xsd:gYear;
     dct:modified "2014"^^xsd:gYear;
     dcat:theme lcc:T;
-    skos:editorialNote "This ontology uses an unexpected set of stereotypes, but it is UFO-based. The publication the authors drive their stereotypes from is the following: https://doi.org/10.1109/WSC.2011.6147757\n";
+    skos:editorialNote """This ontology uses an unexpected set of stereotypes, but it is UFO-based. The publication the authors drive their stereotypes from is the following: https://doi.org/10.1109/WSC.2011.6147757
+""";
     dct:language "en";
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:contributor <https://dblp.org/pid/129/2240>;
     dcat:keyword "language engineering"@en;
-    mod:designedForTask ocmv:ConceptualClarification, ocmv:OntologicalAnalysis;
-    ocmv:context ocmv:Research;
     dct:source <https://doi.org/10.1007/978-3-319-14139-8_28>;
+    mod:designedForTask ocmv:ConceptualClarification,
+                        ocmv:OntologicalAnalysis;
+    ocmv:context ocmv:Research;
     ocmv:representationStyle ocmv:UfoStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/grueau2013towards"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/grueau2013towards"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:53:09.390212546Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:53:09.390212546Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/12a721da-35ae-460f-9417-a2cf55e0f203> dcat:distribution <https://w3id.org/ontouml-models/distribution/e309f16f-4618-4502-ab00-bf37008c6967/>, <https://w3id.org/ontouml-models/distribution/689fa9dc-a3d2-4626-8b7a-79d771b9abae/>, <https://w3id.org/ontouml-models/distribution/fabb2c65-b519-4507-9f0b-305d317924b1/>, <https://w3id.org/ontouml-models/distribution/1abf7d46-1c05-4fd2-bd05-758e2e70455b>, <https://w3id.org/ontouml-models/distribution/6688027b-d89a-4749-8b71-6f848a7bae7d>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/12a721da-35ae-460f-9417-a2cf55e0f203> dcat:distribution <https://w3id.org/ontouml-models/distribution/e309f16f-4618-4502-ab00-bf37008c6967/>,
+                      <https://w3id.org/ontouml-models/distribution/689fa9dc-a3d2-4626-8b7a-79d771b9abae/>,
+                      <https://w3id.org/ontouml-models/distribution/fabb2c65-b519-4507-9f0b-305d317924b1/>,
+                      <https://w3id.org/ontouml-models/distribution/1abf7d46-1c05-4fd2-bd05-758e2e70455b>,
+                      <https://w3id.org/ontouml-models/distribution/6688027b-d89a-4749-8b71-6f848a7bae7d> .

--- a/models/guarino2016value/metadata.ttl
+++ b/models/guarino2016value/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/2a5b8924-d39a-40fc-8c68-cf1be0dd694e/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -19,14 +18,24 @@
     skos:editorialNote "dependencies mapped into \"formal\" associations";
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:contributor <https://dblp.org/pid/23/4576>, <https://dblp.org/pid/65/6778>, <https://dblp.org/pid/j/PaulJohannesson>, <https://dblp.org/pid/137/8670>;
-    dcat:keyword "enterprise"@en, "value modeling"@en;
-    mod:designedForTask ocmv:ConceptualClarification, ocmv:Interoperability;
-    ocmv:context ocmv:Research;
+    dct:contributor <https://dblp.org/pid/23/4576>,
+                    <https://dblp.org/pid/65/6778>,
+                    <https://dblp.org/pid/j/PaulJohannesson>,
+                    <https://dblp.org/pid/137/8670>;
+    dcat:keyword "enterprise"@en,
+                 "value modeling"@en;
     dct:source <https://doi.org/10.3233/978-1-61499-660-6-331>;
+    mod:designedForTask ocmv:ConceptualClarification,
+                        ocmv:Interoperability;
+    ocmv:context ocmv:Research;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Core;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/guarino2016value"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/guarino2016value"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:53:19.895485164Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:53:19.895485164Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/2a5b8924-d39a-40fc-8c68-cf1be0dd694e> dcat:distribution <https://w3id.org/ontouml-models/distribution/9aa1be44-137f-48c1-a48d-2f89e11ab6d6/>, <https://w3id.org/ontouml-models/distribution/ae3368cb-4a77-4207-bb4f-f4ea359540ae/>, <https://w3id.org/ontouml-models/distribution/d7c40d12-84c5-404c-a23c-a6bef381ffce/>, <https://w3id.org/ontouml-models/distribution/c7b77ca2-557f-4a9c-9941-a5fbdd44254e>, <https://w3id.org/ontouml-models/distribution/25b1a69b-e8f5-42e1-b585-1d2d5889e3a7>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/2a5b8924-d39a-40fc-8c68-cf1be0dd694e> dcat:distribution <https://w3id.org/ontouml-models/distribution/9aa1be44-137f-48c1-a48d-2f89e11ab6d6/>,
+                      <https://w3id.org/ontouml-models/distribution/ae3368cb-4a77-4207-bb4f-f4ea359540ae/>,
+                      <https://w3id.org/ontouml-models/distribution/d7c40d12-84c5-404c-a23c-a6bef381ffce/>,
+                      <https://w3id.org/ontouml-models/distribution/c7b77ca2-557f-4a9c-9941-a5fbdd44254e>,
+                      <https://w3id.org/ontouml-models/distribution/25b1a69b-e8f5-42e1-b585-1d2d5889e3a7> .

--- a/models/guarino2018rea/metadata.ttl
+++ b/models/guarino2018rea/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/3f07650f-fc02-409b-9101-35063fce9692/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -18,14 +17,24 @@
     dcat:theme lcc:H;
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:contributor <https://dblp.org/pid/65/6778>, <https://dblp.org/pid/11/78>, <https://dblp.org/pid/134/4947>;
-    dcat:keyword "REA"@en, "finance"@en, "accounting"@en, "economics"@en;
+    dct:contributor <https://dblp.org/pid/65/6778>,
+                    <https://dblp.org/pid/11/78>,
+                    <https://dblp.org/pid/134/4947>;
+    dcat:keyword "REA"@en,
+                 "finance"@en,
+                 "accounting"@en,
+                 "economics"@en;
+    dct:source <https://dblp.org/rec/conf/vmbo/GuarinoGS18>;
     mod:designedForTask ocmv:ConceptualClarification;
     ocmv:context ocmv:Research;
-    dct:source <https://dblp.org/rec/conf/vmbo/GuarinoGS18>;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Core;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/guarino2018rea"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/guarino2018rea"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:53:29.102292Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:53:29.102292Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/3f07650f-fc02-409b-9101-35063fce9692> dcat:distribution <https://w3id.org/ontouml-models/distribution/91345ba4-e724-4593-ad3a-cc41d99b77f6/>, <https://w3id.org/ontouml-models/distribution/7ecabe5d-774e-4e36-a87b-8beee85038df/>, <https://w3id.org/ontouml-models/distribution/7dc67587-70b9-4aaf-836e-e236d0b97f46/>, <https://w3id.org/ontouml-models/distribution/d5879ad8-0e05-4490-9906-531eda15e0a1>, <https://w3id.org/ontouml-models/distribution/ee0c7212-381a-444f-8928-e00306e6dcee>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/3f07650f-fc02-409b-9101-35063fce9692> dcat:distribution <https://w3id.org/ontouml-models/distribution/91345ba4-e724-4593-ad3a-cc41d99b77f6/>,
+                      <https://w3id.org/ontouml-models/distribution/7ecabe5d-774e-4e36-a87b-8beee85038df/>,
+                      <https://w3id.org/ontouml-models/distribution/7dc67587-70b9-4aaf-836e-e236d0b97f46/>,
+                      <https://w3id.org/ontouml-models/distribution/d5879ad8-0e05-4490-9906-531eda15e0a1>,
+                      <https://w3id.org/ontouml-models/distribution/ee0c7212-381a-444f-8928-e00306e6dcee> .

--- a/models/guizzardi2005ontological/metadata.ttl
+++ b/models/guizzardi2005ontological/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/f829c6e9-1dd6-48ce-8403-421efbe15f25/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -19,13 +18,20 @@
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:contributor <https://dblp.org/pid/11/78>;
-    dcat:keyword "agenthood"@en, "organization"@en, "location"@en;
+    dcat:keyword "agenthood"@en,
+                 "organization"@en,
+                 "location"@en;
+    dct:source <http://doc.utwente.nl/50826>;
     mod:designedForTask ocmv:Example;
     ocmv:context ocmv:Research;
-    dct:source <http://doc.utwente.nl/50826>;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/guizzardi2005ontological"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/guizzardi2005ontological"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:53:38.368628574Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:53:38.368628574Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/f829c6e9-1dd6-48ce-8403-421efbe15f25> dcat:distribution <https://w3id.org/ontouml-models/distribution/2a797116-72db-4193-873d-54f2f4e63972/>, <https://w3id.org/ontouml-models/distribution/373840f6-a399-4e28-8a87-7a0db2c71bae/>, <https://w3id.org/ontouml-models/distribution/0492b692-3ddf-4356-b887-48b3e103dc3c/>, <https://w3id.org/ontouml-models/distribution/d636bb5c-fed6-454b-9f24-8e2c640ab813>, <https://w3id.org/ontouml-models/distribution/a3e83380-6caa-454a-8a33-717ed6ce9e65>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/f829c6e9-1dd6-48ce-8403-421efbe15f25> dcat:distribution <https://w3id.org/ontouml-models/distribution/2a797116-72db-4193-873d-54f2f4e63972/>,
+                      <https://w3id.org/ontouml-models/distribution/373840f6-a399-4e28-8a87-7a0db2c71bae/>,
+                      <https://w3id.org/ontouml-models/distribution/0492b692-3ddf-4356-b887-48b3e103dc3c/>,
+                      <https://w3id.org/ontouml-models/distribution/d636bb5c-fed6-454b-9f24-8e2c640ab813>,
+                      <https://w3id.org/ontouml-models/distribution/a3e83380-6caa-454a-8a33-717ed6ce9e65> .

--- a/models/guizzardi2014nfr/metadata.ttl
+++ b/models/guizzardi2014nfr/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/0e262d1c-b8aa-49ec-8ad7-12f97ecb3269/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -19,14 +18,25 @@
     skos:editorialNote "The ontology was documented as shown in the conference paper.";
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:contributor <https://dblp.org/pid/75/5043>, <https://dblp.org/pid/31/7637>, <https://dblp.org/pid/b/ABorgida>, <https://dblp.org/pid/11/78>, <https://dblp.org/pid/92/5983>, <https://dblp.org/pid/m/JohnMylopoulos>;
+    dct:contributor <https://dblp.org/pid/75/5043>,
+                    <https://dblp.org/pid/31/7637>,
+                    <https://dblp.org/pid/b/ABorgida>,
+                    <https://dblp.org/pid/11/78>,
+                    <https://dblp.org/pid/92/5983>,
+                    <https://dblp.org/pid/m/JohnMylopoulos>;
     dcat:keyword "non-functional requirements"@en;
-    mod:designedForTask ocmv:OntologicalAnalysis, ocmv:ConceptualClarification;
-    ocmv:context ocmv:Research;
     dct:source <https://doi.org/10.3233/978-1-61499-438-1-344>;
+    mod:designedForTask ocmv:OntologicalAnalysis,
+                        ocmv:ConceptualClarification;
+    ocmv:context ocmv:Research;
     ocmv:representationStyle ocmv:UfoStyle;
     ocmv:ontologyType ocmv:Core;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/guizzardi2014nfr"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/guizzardi2014nfr"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:53:47.651446154Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:53:47.651446154Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/0e262d1c-b8aa-49ec-8ad7-12f97ecb3269> dcat:distribution <https://w3id.org/ontouml-models/distribution/19f963af-95c2-40ce-ab4d-6e9360c66e82/>, <https://w3id.org/ontouml-models/distribution/f989349c-111a-44ff-820d-f28038e574c6/>, <https://w3id.org/ontouml-models/distribution/8ace50ef-36d9-4b84-ae92-ab87454195eb/>, <https://w3id.org/ontouml-models/distribution/2b4abbeb-6082-410a-ad49-d2c12a601165>, <https://w3id.org/ontouml-models/distribution/230dbcee-0518-4d6b-9475-cd94e85f22af>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/0e262d1c-b8aa-49ec-8ad7-12f97ecb3269> dcat:distribution <https://w3id.org/ontouml-models/distribution/19f963af-95c2-40ce-ab4d-6e9360c66e82/>,
+                      <https://w3id.org/ontouml-models/distribution/f989349c-111a-44ff-820d-f28038e574c6/>,
+                      <https://w3id.org/ontouml-models/distribution/8ace50ef-36d9-4b84-ae92-ab87454195eb/>,
+                      <https://w3id.org/ontouml-models/distribution/2b4abbeb-6082-410a-ad49-d2c12a601165>,
+                      <https://w3id.org/ontouml-models/distribution/230dbcee-0518-4d6b-9475-cd94e85f22af> .

--- a/models/guizzardi2020decision-making/metadata.ttl
+++ b/models/guizzardi2020decision-making/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/4daaeace-2d0c-4341-a5fb-b00c320201df/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -16,17 +15,29 @@
     dct:issued "2020"^^xsd:gYear;
     dct:modified "2020"^^xsd:gYear;
     dcat:theme lcc:H;
-    skos:editorialNote "The Visual Paradigm file has been provided by the authors after the publication of the associated paper. Differences between them have yet to be published as an update of the ontology.\n";
+    skos:editorialNote """The Visual Paradigm file has been provided by the authors after the publication of the associated paper. Differences between them have yet to be published as an update of the ontology.
+""";
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:contributor <https://dblp.org/pid/75/5043>, <https://dblp.org/pid/278/1407>, <https://dblp.org/pid/33/8219>, <https://dblp.org/pid/11/78>;
+    dct:contributor <https://dblp.org/pid/75/5043>,
+                    <https://dblp.org/pid/278/1407>,
+                    <https://dblp.org/pid/33/8219>,
+                    <https://dblp.org/pid/11/78>;
     dcat:keyword "decision making"@en;
+    dct:source <https://dblp.org/rec/conf/ontobras/GuizzardiCPG20>;
     mod:designedForTask ocmv:ConceptualClarification;
     ocmv:context ocmv:Research;
-    dct:source <https://dblp.org/rec/conf/ontobras/GuizzardiCPG20>;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Core;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/guizzardi2020decision-making"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/guizzardi2020decision-making"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:53:56.918782626Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:53:56.918782626Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/4daaeace-2d0c-4341-a5fb-b00c320201df> dcat:distribution <https://w3id.org/ontouml-models/distribution/bbe8a2c5-cf74-402a-854e-6e02bc892af8/>, <https://w3id.org/ontouml-models/distribution/e026748d-6efa-47e0-a220-f829654166f9/>, <https://w3id.org/ontouml-models/distribution/92fdf752-8056-45b7-9514-9a14c9a61b27/>, <https://w3id.org/ontouml-models/distribution/78783b37-8a48-46da-bdc5-91c026818831>, <https://w3id.org/ontouml-models/distribution/5f661639-3036-4c75-91b5-b35ba64a8e73>, <https://w3id.org/ontouml-models/distribution/2adc6d95-b918-4abe-b491-49f4dd444d07>, <https://w3id.org/ontouml-models/distribution/6329da45-ae69-46af-a7f6-548f3d825270>, <https://w3id.org/ontouml-models/distribution/21054479-be1d-4513-a5d2-8255396d73a3>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/4daaeace-2d0c-4341-a5fb-b00c320201df> dcat:distribution <https://w3id.org/ontouml-models/distribution/bbe8a2c5-cf74-402a-854e-6e02bc892af8/>,
+                      <https://w3id.org/ontouml-models/distribution/e026748d-6efa-47e0-a220-f829654166f9/>,
+                      <https://w3id.org/ontouml-models/distribution/92fdf752-8056-45b7-9514-9a14c9a61b27/>,
+                      <https://w3id.org/ontouml-models/distribution/78783b37-8a48-46da-bdc5-91c026818831>,
+                      <https://w3id.org/ontouml-models/distribution/5f661639-3036-4c75-91b5-b35ba64a8e73>,
+                      <https://w3id.org/ontouml-models/distribution/2adc6d95-b918-4abe-b491-49f4dd444d07>,
+                      <https://w3id.org/ontouml-models/distribution/6329da45-ae69-46af-a7f6-548f3d825270>,
+                      <https://w3id.org/ontouml-models/distribution/21054479-be1d-4513-a5d2-8255396d73a3> .

--- a/models/guizzardi2022ufo/metadata.ttl
+++ b/models/guizzardi2022ufo/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/86597da3-8afe-45e4-b836-03fc9ecb6ffc/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -18,14 +17,33 @@
     dct:language "en";
     dcat:landingPage <https://content.iospress.com/articles/applied-ontology/ao210256>;
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:contributor <https://dblp.org/pid/169/2246>, <https://dblp.org/pid/11/78>, <https://dblp.org/pid/91/3408>, <https://dblp.org/pid/134/4947>, <https://dblp.org/pid/33/8219>, <https://dblp.org/pid/40/6577>;
-    dcat:keyword "table"@en, "conjugal relationship"@en, "walk"@en, "jog"@en, "flower"@en, "school"@en;
+    dct:contributor <https://dblp.org/pid/169/2246>,
+                    <https://dblp.org/pid/11/78>,
+                    <https://dblp.org/pid/91/3408>,
+                    <https://dblp.org/pid/134/4947>,
+                    <https://dblp.org/pid/33/8219>,
+                    <https://dblp.org/pid/40/6577>;
+    dcat:keyword "table"@en,
+                 "conjugal relationship"@en,
+                 "walk"@en,
+                 "jog"@en,
+                 "flower"@en,
+                 "school"@en;
+    dct:source <https://doi.org/10.3233/AO-210256>;
     mod:designedForTask ocmv:Example;
     ocmv:context ocmv:Research;
-    dct:source <https://doi.org/10.3233/AO-210256>;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/guizzardi2022ufo"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/guizzardi2022ufo"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:54:12.105726362Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:54:12.105726362Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/86597da3-8afe-45e4-b836-03fc9ecb6ffc> dcat:distribution <https://w3id.org/ontouml-models/distribution/f6e46f5c-98a7-492c-b101-1485882847e6/>, <https://w3id.org/ontouml-models/distribution/33ac7637-de1b-4ad5-af44-00eaca0deb6e/>, <https://w3id.org/ontouml-models/distribution/5d3c22ff-f1a7-411a-b390-65d394a27a80/>, <https://w3id.org/ontouml-models/distribution/75de6c65-5b06-4ece-b3b4-c3605c701edb>, <https://w3id.org/ontouml-models/distribution/5fdf88d7-fa9e-47e6-8bf0-a0108b17267a>, <https://w3id.org/ontouml-models/distribution/3f020359-20cf-4e2c-b27b-40ce42fc406d>, <https://w3id.org/ontouml-models/distribution/155801eb-45a6-4d0d-8d51-48ed125045f0>, <https://w3id.org/ontouml-models/distribution/e6fd4702-46d4-4ed2-936c-a2305fe6a9b1>, <https://w3id.org/ontouml-models/distribution/a87d0c03-550e-4c23-a3ce-098ae79bbd81>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/86597da3-8afe-45e4-b836-03fc9ecb6ffc> dcat:distribution <https://w3id.org/ontouml-models/distribution/f6e46f5c-98a7-492c-b101-1485882847e6/>,
+                      <https://w3id.org/ontouml-models/distribution/33ac7637-de1b-4ad5-af44-00eaca0deb6e/>,
+                      <https://w3id.org/ontouml-models/distribution/5d3c22ff-f1a7-411a-b390-65d394a27a80/>,
+                      <https://w3id.org/ontouml-models/distribution/75de6c65-5b06-4ece-b3b4-c3605c701edb>,
+                      <https://w3id.org/ontouml-models/distribution/5fdf88d7-fa9e-47e6-8bf0-a0108b17267a>,
+                      <https://w3id.org/ontouml-models/distribution/3f020359-20cf-4e2c-b27b-40ce42fc406d>,
+                      <https://w3id.org/ontouml-models/distribution/155801eb-45a6-4d0d-8d51-48ed125045f0>,
+                      <https://w3id.org/ontouml-models/distribution/e6fd4702-46d4-4ed2-936c-a2305fe6a9b1>,
+                      <https://w3id.org/ontouml-models/distribution/a87d0c03-550e-4c23-a3ce-098ae79bbd81> .

--- a/models/haridy2021egyptian-e-government/metadata.ttl
+++ b/models/haridy2021egyptian-e-government/metadata.ttl
@@ -1,32 +1,41 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/5f85d9aa-67ac-4315-b60d-0212ea910320/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:title "Egyptian E-Government Conceptual Model";
     dct:issued "2021"^^xsd:gYear;
     dct:modified "2021"^^xsd:gYear;
     dcat:theme lcc:J;
     skos:editorialNote "The diagrams represent the accessible subfragments of the full model, about the \"traveler\" and \"student\" case studies";
     dct:language "en";
-    dct:contributor <https://dblp.org/pid/123/8870>, <https://dblp.org/pid/123/9738>, <https://dblp.org/pid/123/9749>, <https://dblp.org/pid/60/2571>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    dct:contributor <https://dblp.org/pid/123/8870>,
+                    <https://dblp.org/pid/123/9738>,
+                    <https://dblp.org/pid/123/9749>,
+                    <https://dblp.org/pid/60/2571>;
     dcat:keyword "e-government"@en;
+    dct:source <https://doi.org/10.1109/ICICIS52592.2021.9694122>;
     mod:designedForTask ocmv:ConceptualClarification;
     ocmv:context ocmv:Industry;
-    dct:source <https://doi.org/10.1109/ICICIS52592.2021.9694122>;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/haridy2021egyptian-e-government"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/haridy2021egyptian-e-government"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:54:29.053597861Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:54:29.053597861Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/5f85d9aa-67ac-4315-b60d-0212ea910320> dcat:distribution <https://w3id.org/ontouml-models/distribution/280910f3-6369-4c2e-9785-ea4ad1588e1f/>, <https://w3id.org/ontouml-models/distribution/74deef99-cf3e-43ad-905f-1fb158585e00/>, <https://w3id.org/ontouml-models/distribution/3622ad7a-fad1-4301-a57e-5ea7829a9d46/>, <https://w3id.org/ontouml-models/distribution/9a5e36cd-a1fc-4e7f-b134-139a79aa5cd1>, <https://w3id.org/ontouml-models/distribution/edc423f7-30bc-400b-a8bf-741f53cfd7f1>, <https://w3id.org/ontouml-models/distribution/4a0f35ac-cc48-4596-9c27-a3c387d03b88>, <https://w3id.org/ontouml-models/distribution/e9c9f2e2-8e76-437f-874a-318ba5a3c73e>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/5f85d9aa-67ac-4315-b60d-0212ea910320> dcat:distribution <https://w3id.org/ontouml-models/distribution/280910f3-6369-4c2e-9785-ea4ad1588e1f/>,
+                      <https://w3id.org/ontouml-models/distribution/74deef99-cf3e-43ad-905f-1fb158585e00/>,
+                      <https://w3id.org/ontouml-models/distribution/3622ad7a-fad1-4301-a57e-5ea7829a9d46/>,
+                      <https://w3id.org/ontouml-models/distribution/9a5e36cd-a1fc-4e7f-b134-139a79aa5cd1>,
+                      <https://w3id.org/ontouml-models/distribution/edc423f7-30bc-400b-a8bf-741f53cfd7f1>,
+                      <https://w3id.org/ontouml-models/distribution/4a0f35ac-cc48-4596-9c27-a3c387d03b88>,
+                      <https://w3id.org/ontouml-models/distribution/e9c9f2e2-8e76-437f-874a-318ba5a3c73e> .

--- a/models/health-organizations/metadata.ttl
+++ b/models/health-organizations/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/c6d2e61a-4904-47ec-8935-2e2e56669220/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -17,12 +16,18 @@
     dcat:theme lcc:R;
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dcat:keyword "healthcare"@en, "enterprise"@en;
+    dcat:keyword "healthcare"@en,
+                 "enterprise"@en;
     mod:designedForTask ocmv:Learning;
     ocmv:context ocmv:Classroom;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/health-organizations"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/health-organizations"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:54:42.123428087Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:54:42.123428087Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/c6d2e61a-4904-47ec-8935-2e2e56669220> dcat:distribution <https://w3id.org/ontouml-models/distribution/6b943f53-9faf-4526-9dcc-fcaecb133821/>, <https://w3id.org/ontouml-models/distribution/a3013f40-395d-43e7-a3a9-25f8429fa3da/>, <https://w3id.org/ontouml-models/distribution/cf6a96d3-f409-452b-9b30-43073fbd575f/>, <https://w3id.org/ontouml-models/distribution/d9d43e88-911f-456d-be76-9530074dbd85>, <https://w3id.org/ontouml-models/distribution/34977fd7-d922-4760-be52-a73e86684e1a>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/c6d2e61a-4904-47ec-8935-2e2e56669220> dcat:distribution <https://w3id.org/ontouml-models/distribution/6b943f53-9faf-4526-9dcc-fcaecb133821/>,
+                      <https://w3id.org/ontouml-models/distribution/a3013f40-395d-43e7-a3a9-25f8429fa3da/>,
+                      <https://w3id.org/ontouml-models/distribution/cf6a96d3-f409-452b-9b30-43073fbd575f/>,
+                      <https://w3id.org/ontouml-models/distribution/d9d43e88-911f-456d-be76-9530074dbd85>,
+                      <https://w3id.org/ontouml-models/distribution/34977fd7-d922-4760-be52-a73e86684e1a> .

--- a/models/heirbrant2023boekbazaar/metadata.ttl
+++ b/models/heirbrant2023boekbazaar/metadata.ttl
@@ -1,38 +1,46 @@
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/model/heirbrant2023boekbazaar/> a dcat:Dataset, mod:SemanticArtefact;
+<https://w3id.org/ontouml-models/model/heirbrant2023boekbazaar/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
+    dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
     dct:title "Boekbazaar Ontology";
     dct:issued "2023"^^xsd:gYear;
     dcat:theme lcc:H;
-    skos:editorialNote "Ontology created during an Ontology Engineering lecture by students who wanted to remain anonymous. The ontology was build in a different editor tool and imported to Visual Paradigm, the current diagrammation may not exactly match the original one.";
     dct:language "en";
     dcat:landingPage <https://boekbazaar.be/home>;
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:contributor <https://www.linkedin.com/in/joachim-heirbrant-532aa1233/>, <https://dblp.org/pid/251/5991>, <https://dblp.org/pid/95/6356>;
-    mod:designedForTask ocmv:ConceptualClarification, ocmv:InformationRetrieval, ocmv:SoftwareEngineering;
-    ocmv:context ocmv:Industry, ocmv:Research;
-    dct:source <https://lib.ugent.be/catalog/rug01:003144709>, <https://lib.ugent.be/fulltxt/RUG01/003/144/709/RUG01-003144709_2023_0001_AC.pdf>.
-<https://w3id.org/ontouml-models/model/heirbrant2023boekbazaar/> dcat:distribution <https://w3id.org/ontouml-models/model/heirbrant2023boekbazaar/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/heirbrant2023boekbazaar/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Boekbazaar Ontology\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/heirbrant2023boekbazaar/ontology.ttl>.
-<https://w3id.org/ontouml-models/model/heirbrant2023boekbazaar/> dcat:distribution <https://w3id.org/ontouml-models/model/heirbrant2023boekbazaar/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/heirbrant2023boekbazaar/distribution/ttl> a dcat:Distribution;
-    dct:title "JSON distribution of \"Boekbazaar Ontology\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/heirbrant2023boekbazaar/ontology.json>.
-<https://w3id.org/ontouml-models/model/heirbrant2023boekbazaar/> dcat:distribution <https://w3id.org/ontouml-models/model/heirbrant2023boekbazaar/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/heirbrant2023boekbazaar/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Boekbazaar Ontology\""@en;
-    dcat:mediaType <https://www.visual-paradigm.com/vpp>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/heirbrant2023boekbazaar/ontology.vpp>.
+    dct:contributor <https://www.linkedin.com/in/joachim-heirbrant-532aa1233/>,
+                    <https://dblp.org/pid/251/5991>,
+                    <https://dblp.org/pid/95/6356>;
+    dcat:keyword "book"@en,
+                 "marketplace"@en,
+                 "bookstore"@en;
+    dct:source <https://lib.ugent.be/catalog/rug01:003144709>;
+    mod:designedForTask ocmv:ConceptualClarification,
+                        ocmv:InformationRetrieval,
+                        ocmv:SoftwareEngineering;
+    ocmv:context ocmv:Industry,
+                 ocmv:Research;
+    ocmv:representationStyle ocmv:OntoumlStyle;
+    ocmv:ontologyType ocmv:Domain,
+                      ocmv:Application;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/heirbrant2023boekbazaar"^^xsd:anyURI;
+    fdpo:metadataIssued "2026-06-23T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/heirbrant2023boekbazaar/> dcat:distribution <https://w3id.org/ontouml-models/model/heirbrant2023boekbazaar/distribution/ttl>,
+                      <https://www.iana.org/assignments/media-types/text/turtle>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/heirbrant2023boekbazaar/ontology.ttl>,
+                      <https://w3id.org/ontouml-models/model/heirbrant2023boekbazaar/>,
+                      <https://www.iana.org/assignments/media-types/application/json>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/heirbrant2023boekbazaar/ontology.json>,
+                      <https://www.visual-paradigm.com/vpp>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/heirbrant2023boekbazaar/ontology.vpp> .

--- a/models/idaf2013/metadata.ttl
+++ b/models/idaf2013/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/291e45be-4c9d-41b1-a237-f3f47714226d/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -25,7 +24,14 @@
     ocmv:context ocmv:Classroom;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/idaf2013"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/idaf2013"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:54:51.504258676Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:54:51.504258676Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/291e45be-4c9d-41b1-a237-f3f47714226d> dcat:distribution <https://w3id.org/ontouml-models/distribution/e21e8a3e-17dd-40e0-9c26-5f643723fcd7/>, <https://w3id.org/ontouml-models/distribution/d2a2f8be-4b30-4c50-a6e8-c16a7637d7ca/>, <https://w3id.org/ontouml-models/distribution/5c6adab4-ec1d-4071-b912-33c9947840b6/>, <https://w3id.org/ontouml-models/distribution/5987276c-5365-4213-ba1e-01685aff9a1c>, <https://w3id.org/ontouml-models/distribution/cf0b86f0-aadc-471a-b7b5-37c1f5ed8e70>, <https://w3id.org/ontouml-models/distribution/34a28f7f-c532-40ee-9091-1103eb8e6ac0>, <https://w3id.org/ontouml-models/distribution/c5641404-6c78-46c7-a931-66fbe5699123>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/291e45be-4c9d-41b1-a237-f3f47714226d> dcat:distribution <https://w3id.org/ontouml-models/distribution/e21e8a3e-17dd-40e0-9c26-5f643723fcd7/>,
+                      <https://w3id.org/ontouml-models/distribution/d2a2f8be-4b30-4c50-a6e8-c16a7637d7ca/>,
+                      <https://w3id.org/ontouml-models/distribution/5c6adab4-ec1d-4071-b912-33c9947840b6/>,
+                      <https://w3id.org/ontouml-models/distribution/5987276c-5365-4213-ba1e-01685aff9a1c>,
+                      <https://w3id.org/ontouml-models/distribution/cf0b86f0-aadc-471a-b7b5-37c1f5ed8e70>,
+                      <https://w3id.org/ontouml-models/distribution/34a28f7f-c532-40ee-9091-1103eb8e6ac0>,
+                      <https://w3id.org/ontouml-models/distribution/c5641404-6c78-46c7-a931-66fbe5699123> .

--- a/models/internal-affairs2013/metadata.ttl
+++ b/models/internal-affairs2013/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/c150fd37-6fa4-4b0a-a2d0-7aff5e6a6cde/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -19,12 +18,23 @@
     skos:editorialNote "This model was done as an assignment for a course. The author required to remain anonymous. There is no information about the ontology's development year.";
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dcat:keyword "internal affairs"@en, "military"@en, "organization"@en;
+    dcat:keyword "internal affairs"@en,
+                 "military"@en,
+                 "organization"@en;
     mod:designedForTask ocmv:Learning;
     ocmv:context ocmv:Classroom;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/internal-affairs2013"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/internal-affairs2013"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:55:04.316852371Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:55:04.316852371Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/c150fd37-6fa4-4b0a-a2d0-7aff5e6a6cde> dcat:distribution <https://w3id.org/ontouml-models/distribution/2a2976ce-dbbc-4462-a1fd-bc061dcfae2f/>, <https://w3id.org/ontouml-models/distribution/8f645eab-6b09-4bda-98cb-0648e9c37791/>, <https://w3id.org/ontouml-models/distribution/357c76a8-cc36-464b-b76f-d54f06cf45c8/>, <https://w3id.org/ontouml-models/distribution/b324a26a-e851-436a-99dc-df990abb1e82>, <https://w3id.org/ontouml-models/distribution/4a534bb7-328f-4965-a176-c69686c19764>, <https://w3id.org/ontouml-models/distribution/34e0331d-ce77-4c80-a6d7-110b1ce0bf2e>, <https://w3id.org/ontouml-models/distribution/c18a265a-d7a9-4f06-9a3f-5cd63bddc269>, <https://w3id.org/ontouml-models/distribution/87a7197d-c961-4ee0-b120-6fe8465dd146>, <https://w3id.org/ontouml-models/distribution/e5c22c29-fda9-497b-a13f-47231e0af513>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/c150fd37-6fa4-4b0a-a2d0-7aff5e6a6cde> dcat:distribution <https://w3id.org/ontouml-models/distribution/2a2976ce-dbbc-4462-a1fd-bc061dcfae2f/>,
+                      <https://w3id.org/ontouml-models/distribution/8f645eab-6b09-4bda-98cb-0648e9c37791/>,
+                      <https://w3id.org/ontouml-models/distribution/357c76a8-cc36-464b-b76f-d54f06cf45c8/>,
+                      <https://w3id.org/ontouml-models/distribution/b324a26a-e851-436a-99dc-df990abb1e82>,
+                      <https://w3id.org/ontouml-models/distribution/4a534bb7-328f-4965-a176-c69686c19764>,
+                      <https://w3id.org/ontouml-models/distribution/34e0331d-ce77-4c80-a6d7-110b1ce0bf2e>,
+                      <https://w3id.org/ontouml-models/distribution/c18a265a-d7a9-4f06-9a3f-5cd63bddc269>,
+                      <https://w3id.org/ontouml-models/distribution/87a7197d-c961-4ee0-b120-6fe8465dd146>,
+                      <https://w3id.org/ontouml-models/distribution/e5c22c29-fda9-497b-a13f-47231e0af513> .

--- a/models/internship/metadata.ttl
+++ b/models/internship/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/b6660078-f212-4051-b469-279863bb5e33/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -23,7 +22,12 @@
     ocmv:context ocmv:Classroom;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/internship"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/internship"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:55:21.574008302Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:55:21.574008302Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/b6660078-f212-4051-b469-279863bb5e33> dcat:distribution <https://w3id.org/ontouml-models/distribution/afae5dde-8be6-4122-b0e8-c6b447789de9/>, <https://w3id.org/ontouml-models/distribution/212cb5e1-a6ed-43e8-bde5-75d1b5d671b0/>, <https://w3id.org/ontouml-models/distribution/3f082a6f-fe6f-4141-837f-f4e39755a8f8/>, <https://w3id.org/ontouml-models/distribution/769d34cb-8b1c-4743-8768-6f66318a4a93>, <https://w3id.org/ontouml-models/distribution/f1790e4f-605b-436b-80c0-39e9e35ef7c2>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/b6660078-f212-4051-b469-279863bb5e33> dcat:distribution <https://w3id.org/ontouml-models/distribution/afae5dde-8be6-4122-b0e8-c6b447789de9/>,
+                      <https://w3id.org/ontouml-models/distribution/212cb5e1-a6ed-43e8-bde5-75d1b5d671b0/>,
+                      <https://w3id.org/ontouml-models/distribution/3f082a6f-fe6f-4141-837f-f4e39755a8f8/>,
+                      <https://w3id.org/ontouml-models/distribution/769d34cb-8b1c-4743-8768-6f66318a4a93>,
+                      <https://w3id.org/ontouml-models/distribution/f1790e4f-605b-436b-80c0-39e9e35ef7c2> .

--- a/models/it-infrastructure/metadata.ttl
+++ b/models/it-infrastructure/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/3c25eb5e-58d7-43cf-8027-31bd0827044e/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -18,11 +17,17 @@
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0>;
     dcat:keyword "it infrastructure"@en;
-    mod:designedForTask ocmv:ConceptualClarification, ocmv:Learning;
+    mod:designedForTask ocmv:ConceptualClarification,
+                        ocmv:Learning;
     ocmv:context ocmv:Classroom;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/it-infrastructure"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/it-infrastructure"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:55:31.456581686Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:55:31.456581686Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/3c25eb5e-58d7-43cf-8027-31bd0827044e> dcat:distribution <https://w3id.org/ontouml-models/distribution/cdaa0242-2fd2-4d5b-b54a-06e70629160d/>, <https://w3id.org/ontouml-models/distribution/b18a0d63-ef7f-45fb-bce2-e867e615501f/>, <https://w3id.org/ontouml-models/distribution/953428fe-61d6-4a46-ba55-087edee45343/>, <https://w3id.org/ontouml-models/distribution/d5e79a3d-c331-490a-99fc-bd24e5eb1ebb>, <https://w3id.org/ontouml-models/distribution/d5e79a3d-c331-490a-99fc-bd24e5eb1ebb>, <https://w3id.org/ontouml-models/distribution/70363fb3-6585-42c9-a253-7ec7f0de358a>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/3c25eb5e-58d7-43cf-8027-31bd0827044e> dcat:distribution <https://w3id.org/ontouml-models/distribution/cdaa0242-2fd2-4d5b-b54a-06e70629160d/>,
+                      <https://w3id.org/ontouml-models/distribution/b18a0d63-ef7f-45fb-bce2-e867e615501f/>,
+                      <https://w3id.org/ontouml-models/distribution/953428fe-61d6-4a46-ba55-087edee45343/>,
+                      <https://w3id.org/ontouml-models/distribution/d5e79a3d-c331-490a-99fc-bd24e5eb1ebb>,
+                      <https://w3id.org/ontouml-models/distribution/70363fb3-6585-42c9-a253-7ec7f0de358a> .

--- a/models/jacobs2022sdpontology/metadata.ttl
+++ b/models/jacobs2022sdpontology/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/d6c9a835-4c50-42a2-a383-952cd9de8497/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -19,14 +18,24 @@
     dct:language "en";
     dcat:landingPage <https://purl.utwente.nl/essays/93228>;
     dct:license <https://creativecommons.org/licenses/by/4.0>;
-    dct:contributor <https://www.linkedin.com/in/marc-jacobs/>, <https://dblp.org/pid/13/7640.html>, <https://dblp.org/pid/74/7740.html>;
-    dcat:keyword "technology"@en, "software development"@en;
-    mod:designedForTask ocmv:DecisionSupportSystem;
-    ocmv:context ocmv:Research, ocmv:Industry;
+    dct:contributor <https://www.linkedin.com/in/marc-jacobs/>,
+                    <https://dblp.org/pid/13/7640.html>,
+                    <https://dblp.org/pid/74/7740.html>;
+    dcat:keyword "technology"@en,
+                 "software development"@en;
     dct:source <http://essay.utwente.nl/93228/1/Jacobs_MA_EEMCS.pdf>;
+    mod:designedForTask ocmv:DecisionSupportSystem;
+    ocmv:context ocmv:Research,
+                 ocmv:Industry;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/jacobs2022sdpontology"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/jacobs2022sdpontology"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:55:41.202203183Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:55:41.202203183Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/d6c9a835-4c50-42a2-a383-952cd9de8497> dcat:distribution <https://w3id.org/ontouml-models/distribution/e7762868-a760-4436-8d95-8f30014886fc/>, <https://w3id.org/ontouml-models/distribution/55847996-1bc1-4c78-a012-9436fd44c215/>, <https://w3id.org/ontouml-models/distribution/1c7cb20c-2e46-4afc-a246-6a9013c03e1e/>, <https://w3id.org/ontouml-models/distribution/6cd9be72-784e-4921-8848-52fda1fd473f>, <https://w3id.org/ontouml-models/distribution/e96c7d36-e6c6-4d2f-bae0-092b840c1d88>, <https://w3id.org/ontouml-models/distribution/8aeb12cc-33aa-4071-84d2-a9f1463a017a>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/d6c9a835-4c50-42a2-a383-952cd9de8497> dcat:distribution <https://w3id.org/ontouml-models/distribution/e7762868-a760-4436-8d95-8f30014886fc/>,
+                      <https://w3id.org/ontouml-models/distribution/55847996-1bc1-4c78-a012-9436fd44c215/>,
+                      <https://w3id.org/ontouml-models/distribution/1c7cb20c-2e46-4afc-a246-6a9013c03e1e/>,
+                      <https://w3id.org/ontouml-models/distribution/6cd9be72-784e-4921-8848-52fda1fd473f>,
+                      <https://w3id.org/ontouml-models/distribution/e96c7d36-e6c6-4d2f-bae0-092b840c1d88>,
+                      <https://w3id.org/ontouml-models/distribution/8aeb12cc-33aa-4071-84d2-a9f1463a017a> .

--- a/models/junior2018o4c/metadata.ttl
+++ b/models/junior2018o4c/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/4768da76-c638-4fb1-b0c8-5a4f98872ef4/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -20,14 +19,24 @@
     skos:editorialNote "This is an interesting application of OntoUML which is essentially used to drive the development of a metamodel for automated modeling appproach. Some diagrams show the application of the ontology's concepts as a UML-based language using stereotypes.";
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:contributor <https://dblp.org/pid/23/7677>, <https://dblp.org/pid/p/RosangelaPenteado>;
-    dcat:keyword "aspect-oriented requirements engineering"@en, "requirements engineering"@en, "software engineering"@en, "concerns"@en, "cross-cutting concerns"@en;
+    dct:contributor <https://dblp.org/pid/23/7677>,
+                    <https://dblp.org/pid/p/RosangelaPenteado>;
+    dcat:keyword "aspect-oriented requirements engineering"@en,
+                 "requirements engineering"@en,
+                 "software engineering"@en,
+                 "concerns"@en,
+                 "cross-cutting concerns"@en;
+    dct:source <https://doi.org/10.1186/s13173-017-0067-6>;
     mod:designedForTask ocmv:SoftwareEngineering;
     ocmv:context ocmv:Research;
-    dct:source <https://doi.org/10.1186/s13173-017-0067-6>;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/junior2018o4c"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/junior2018o4c"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:55:53.501867523Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:55:53.501867523Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/4768da76-c638-4fb1-b0c8-5a4f98872ef4> dcat:distribution <https://w3id.org/ontouml-models/distribution/fde1054c-f762-4fe4-8f67-47d286d11b5b/>, <https://w3id.org/ontouml-models/distribution/9cec5304-f105-4a8e-a18a-cf340e8ad533/>, <https://w3id.org/ontouml-models/distribution/7ef8bf76-0173-468f-bbca-d178786d5d99/>, <https://w3id.org/ontouml-models/distribution/06ba2a4e-5ee2-47bf-991f-1d6b6507935b>, <https://w3id.org/ontouml-models/distribution/7b4e9a81-35a7-490b-ad2d-45c5d083221e>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/4768da76-c638-4fb1-b0c8-5a4f98872ef4> dcat:distribution <https://w3id.org/ontouml-models/distribution/fde1054c-f762-4fe4-8f67-47d286d11b5b/>,
+                      <https://w3id.org/ontouml-models/distribution/9cec5304-f105-4a8e-a18a-cf340e8ad533/>,
+                      <https://w3id.org/ontouml-models/distribution/7ef8bf76-0173-468f-bbca-d178786d5d99/>,
+                      <https://w3id.org/ontouml-models/distribution/06ba2a4e-5ee2-47bf-991f-1d6b6507935b>,
+                      <https://w3id.org/ontouml-models/distribution/7b4e9a81-35a7-490b-ad2d-45c5d083221e> .

--- a/models/khantong2020ontology/metadata.ttl
+++ b/models/khantong2020ontology/metadata.ttl
@@ -1,32 +1,39 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/5a426516-e211-4e7b-abc5-dca6b11d2d6a/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:title "Disaster Response Ontology - Flood Response Scenarios";
     dct:issued "2019"^^xsd:gYear;
     dct:modified "2020"^^xsd:gYear;
     dcat:theme lcc:H;
     skos:editorialNote "The ontology was documented based on the version on the journal publication. It employs UFO for endurants, but employs DEMO theory of speech acts for perdurants.";
     dct:language "en";
-    dct:contributor <https://dblp.org/pid/262/2006>, <https://dblp.org/pid/66/4875>, <https://dblp.org/pid/35/3072>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    dct:contributor <https://dblp.org/pid/262/2006>,
+                    <https://dblp.org/pid/66/4875>,
+                    <https://dblp.org/pid/35/3072>;
     dcat:keyword "disaster management"@en;
+    dct:source <https://doi.org/10.1556/1848.2020.00004>,
+               <https://doi.org/10.1007/s13740-019-00110-6>;
     mod:designedForTask ocmv:DataPublication;
     ocmv:context ocmv:Research;
-    dct:source <https://doi.org/10.1556/1848.2020.00004>, <https://doi.org/10.1007/s13740-019-00110-6>;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/khantong2020ontology"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/khantong2020ontology"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:56:03.092028774Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:56:03.092028774Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/5a426516-e211-4e7b-abc5-dca6b11d2d6a> dcat:distribution <https://w3id.org/ontouml-models/distribution/48407f93-c4e4-4925-ba5c-3518169e223e/>, <https://w3id.org/ontouml-models/distribution/094cc3c7-c53a-489a-bf84-207d0283c31a/>, <https://w3id.org/ontouml-models/distribution/a5bd29f0-70c8-4b5a-87d4-c6b4146244ad/>, <https://w3id.org/ontouml-models/distribution/d74f43fe-4a2c-4529-a21d-fe49399f5af5>, <https://w3id.org/ontouml-models/distribution/3a516b68-9ecb-442e-82e9-a830e54fb1fd>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/5a426516-e211-4e7b-abc5-dca6b11d2d6a> dcat:distribution <https://w3id.org/ontouml-models/distribution/48407f93-c4e4-4925-ba5c-3518169e223e/>,
+                      <https://w3id.org/ontouml-models/distribution/094cc3c7-c53a-489a-bf84-207d0283c31a/>,
+                      <https://w3id.org/ontouml-models/distribution/a5bd29f0-70c8-4b5a-87d4-c6b4146244ad/>,
+                      <https://w3id.org/ontouml-models/distribution/d74f43fe-4a2c-4529-a21d-fe49399f5af5>,
+                      <https://w3id.org/ontouml-models/distribution/3a516b68-9ecb-442e-82e9-a830e54fb1fd> .

--- a/models/kostov2017towards/metadata.ttl
+++ b/models/kostov2017towards/metadata.ttl
@@ -1,32 +1,51 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/b8d64beb-327f-4e7c-96a7-a10ab1a9da3e/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:title "Aviation Safety Ontology";
     dct:issued "2016"^^xsd:gYear;
     dct:modified "2017"^^xsd:gYear;
     dcat:theme lcc:T;
     skos:editorialNote "The main paper (kostov2017towards) presents just part of the Aviation Ontology (diagram 1). Other part of the same model can be found in ahmad2016ontological, which was reproduced in diagram 2. The Safety Ontology is represented in diagram3. When a class' stereotype is not present in one diagram but can be found in another we represent it in both diagrams. Associations originally represented as bound were represented separated.";
     dct:language "en";
-    dct:contributor <https://dblp.org/pid/185/3559>, <https://dblp.org/pid/77/5702>, <https://dblp.org/pid/129/7052>, <https://dblp.org/pid/50/8371>, <https://dblp.org/pid/185/3585>, <https://dblp.org/pid/185/3630>, <https://dblp.org/pid/185/3575>, <https://dblp.org/pid/185/3579>, <https://dblp.org/pid/129/7052>;
-    dcat:keyword "aviation"@en, "safety"@en;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    dct:contributor <https://dblp.org/pid/185/3559>,
+                    <https://dblp.org/pid/77/5702>,
+                    <https://dblp.org/pid/129/7052>,
+                    <https://dblp.org/pid/50/8371>,
+                    <https://dblp.org/pid/185/3585>,
+                    <https://dblp.org/pid/185/3630>,
+                    <https://dblp.org/pid/185/3575>,
+                    <https://dblp.org/pid/185/3579>,
+                    <https://dblp.org/pid/129/7052>;
+    dcat:keyword "aviation"@en,
+                 "safety"@en;
+    dct:source <https://doi.org/10.1007/978-3-319-45880-9_2>,
+               <https://doi.org/10.2514/1.I010441>,
+               <https://doi.org/10.1007/978-3-319-55961-2_25>;
     mod:designedForTask ocmv:ConceptualClarification;
     ocmv:context ocmv:Research;
-    dct:source <https://doi.org/10.1007/978-3-319-45880-9_2>, <https://doi.org/10.2514/1.I010441>, <https://doi.org/10.1007/978-3-319-55961-2_25>;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/kostov2017towards"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/kostov2017towards"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:56:12.577469842Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:56:12.577469842Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/b8d64beb-327f-4e7c-96a7-a10ab1a9da3e> dcat:distribution <https://w3id.org/ontouml-models/distribution/8c8d9f3e-c061-4804-8cc2-f51099c85074/>, <https://w3id.org/ontouml-models/distribution/f13f2b9e-ebc9-4694-9618-a67defc9ecca/>, <https://w3id.org/ontouml-models/distribution/82a399ae-59e0-428e-aebe-7d4c7b282ce4/>, <https://w3id.org/ontouml-models/distribution/29af279a-50ca-406f-85f5-a82fff0bfb5b>, <https://w3id.org/ontouml-models/distribution/5da6873a-0c03-44dc-a6ee-da43a7ca3ee6>, <https://w3id.org/ontouml-models/distribution/7f429482-a2db-4b2d-b9fe-a1eb5f797377>, <https://w3id.org/ontouml-models/distribution/a8be78da-af8a-4308-a267-25e1b54cc14d>, <https://w3id.org/ontouml-models/distribution/976ab279-112b-4e38-9d04-06ec400ba2fd>, <https://w3id.org/ontouml-models/distribution/7cc30b6b-249e-47da-9780-cc62014a4e2b>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/b8d64beb-327f-4e7c-96a7-a10ab1a9da3e> dcat:distribution <https://w3id.org/ontouml-models/distribution/8c8d9f3e-c061-4804-8cc2-f51099c85074/>,
+                      <https://w3id.org/ontouml-models/distribution/f13f2b9e-ebc9-4694-9618-a67defc9ecca/>,
+                      <https://w3id.org/ontouml-models/distribution/82a399ae-59e0-428e-aebe-7d4c7b282ce4/>,
+                      <https://w3id.org/ontouml-models/distribution/29af279a-50ca-406f-85f5-a82fff0bfb5b>,
+                      <https://w3id.org/ontouml-models/distribution/5da6873a-0c03-44dc-a6ee-da43a7ca3ee6>,
+                      <https://w3id.org/ontouml-models/distribution/7f429482-a2db-4b2d-b9fe-a1eb5f797377>,
+                      <https://w3id.org/ontouml-models/distribution/a8be78da-af8a-4308-a267-25e1b54cc14d>,
+                      <https://w3id.org/ontouml-models/distribution/976ab279-112b-4e38-9d04-06ec400ba2fd>,
+                      <https://w3id.org/ontouml-models/distribution/7cc30b6b-249e-47da-9780-cc62014a4e2b> .

--- a/models/kritz2020ontobg/metadata.ttl
+++ b/models/kritz2020ontobg/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/47cee156-e106-40c9-ae22-f2933d56abc6/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -21,12 +20,24 @@
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:contributor <https://dblp.org/pid/315/5366>;
     dcat:keyword "board games"@en;
+    dct:source <https://www.cos.ufrj.br/index.php/pt-BR/publicacoes-pesquisa/details/15/2955>;
     mod:designedForTask ocmv:ConceptualClarification;
     ocmv:context ocmv:Research;
-    dct:source <https://www.cos.ufrj.br/index.php/pt-BR/publicacoes-pesquisa/details/15/2955>;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/kritz2020ontobg"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/kritz2020ontobg"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:56:29.201500323Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:56:29.201500323Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/47cee156-e106-40c9-ae22-f2933d56abc6> dcat:distribution <https://w3id.org/ontouml-models/distribution/23712593-71f1-46e8-9dc2-d467cb0429c7/>, <https://w3id.org/ontouml-models/distribution/85c1bcc2-d1fb-4d7c-a654-ec595ff8b0c8/>, <https://w3id.org/ontouml-models/distribution/e1fb7c36-0da0-4894-853f-5a933ae43d8d/>, <https://w3id.org/ontouml-models/distribution/69b0040c-064f-406e-bb15-d3dddad301b4>, <https://w3id.org/ontouml-models/distribution/c2526baf-f308-4b28-9538-6748f1983147>, <https://w3id.org/ontouml-models/distribution/568a4638-c08d-4fa6-b70a-93e08c90a010>, <https://w3id.org/ontouml-models/distribution/20b2b409-c5de-43f4-bac7-d437d38d2d1d>, <https://w3id.org/ontouml-models/distribution/19b02888-7729-4676-9b07-fefbc0fad3c6>, <https://w3id.org/ontouml-models/distribution/a998e363-13ab-44fb-a252-be8d13d5ac79>, <https://w3id.org/ontouml-models/distribution/50719ee0-77dc-4f7a-b999-6834511419f5>, <https://w3id.org/ontouml-models/distribution/4f896116-84d4-40ee-a982-9e719437e3cf>, <https://w3id.org/ontouml-models/distribution/8cbb8e10-b85f-4ac1-b8f1-c139cf6339b9>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/47cee156-e106-40c9-ae22-f2933d56abc6> dcat:distribution <https://w3id.org/ontouml-models/distribution/23712593-71f1-46e8-9dc2-d467cb0429c7/>,
+                      <https://w3id.org/ontouml-models/distribution/85c1bcc2-d1fb-4d7c-a654-ec595ff8b0c8/>,
+                      <https://w3id.org/ontouml-models/distribution/e1fb7c36-0da0-4894-853f-5a933ae43d8d/>,
+                      <https://w3id.org/ontouml-models/distribution/69b0040c-064f-406e-bb15-d3dddad301b4>,
+                      <https://w3id.org/ontouml-models/distribution/c2526baf-f308-4b28-9538-6748f1983147>,
+                      <https://w3id.org/ontouml-models/distribution/568a4638-c08d-4fa6-b70a-93e08c90a010>,
+                      <https://w3id.org/ontouml-models/distribution/20b2b409-c5de-43f4-bac7-d437d38d2d1d>,
+                      <https://w3id.org/ontouml-models/distribution/19b02888-7729-4676-9b07-fefbc0fad3c6>,
+                      <https://w3id.org/ontouml-models/distribution/a998e363-13ab-44fb-a252-be8d13d5ac79>,
+                      <https://w3id.org/ontouml-models/distribution/50719ee0-77dc-4f7a-b999-6834511419f5>,
+                      <https://w3id.org/ontouml-models/distribution/4f896116-84d4-40ee-a982-9e719437e3cf>,
+                      <https://w3id.org/ontouml-models/distribution/8cbb8e10-b85f-4ac1-b8f1-c139cf6339b9> .

--- a/models/laurier2018rea/metadata.ttl
+++ b/models/laurier2018rea/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/c71c375d-a9b6-4a3c-b10b-376357286b51/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -18,14 +17,27 @@
     dcat:theme lcc:H;
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:contributor <https://dblp.org/pid/33/7322>, <https://dblp.org/pid/223/7406>, <https://dblp.org/pid/57/2960>;
-    dcat:keyword "business"@en, "finance"@en;
-    mod:designedForTask ocmv:OntologicalAnalysis, ocmv:Interoperability;
-    ocmv:context ocmv:Research;
+    dct:contributor <https://dblp.org/pid/33/7322>,
+                    <https://dblp.org/pid/223/7406>,
+                    <https://dblp.org/pid/57/2960>;
+    dcat:keyword "business"@en,
+                 "finance"@en;
     dct:source <https://doi.org/10.3233/AO-180198>;
+    mod:designedForTask ocmv:OntologicalAnalysis,
+                        ocmv:Interoperability;
+    ocmv:context ocmv:Research;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/laurier2018rea"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/laurier2018rea"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:56:50.049232045Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:56:50.049232045Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/c71c375d-a9b6-4a3c-b10b-376357286b51> dcat:distribution <https://w3id.org/ontouml-models/distribution/d9996b63-d792-4fa3-aa34-722c1eeecb89/>, <https://w3id.org/ontouml-models/distribution/a5c06e94-d77f-4967-8cae-a742a4c90f88/>, <https://w3id.org/ontouml-models/distribution/e99e1c86-6af5-4e56-9edb-1f6c1f1e81b5/>, <https://w3id.org/ontouml-models/distribution/6cc27304-e120-4b71-9074-b92ba55a6980>, <https://w3id.org/ontouml-models/distribution/c6543d12-20f0-4ff0-91d9-fbe9dd1f4971>, <https://w3id.org/ontouml-models/distribution/4e06461a-15d3-404f-88ce-61c0315999ed>, <https://w3id.org/ontouml-models/distribution/795afd06-0f7b-46d3-beb4-7930f3ac8c74>, <https://w3id.org/ontouml-models/distribution/2618147c-6e1b-4764-b7c0-8bee07dda1d5>, <https://w3id.org/ontouml-models/distribution/010542ad-4d36-441c-95ab-e532ed6e1b76>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/c71c375d-a9b6-4a3c-b10b-376357286b51> dcat:distribution <https://w3id.org/ontouml-models/distribution/d9996b63-d792-4fa3-aa34-722c1eeecb89/>,
+                      <https://w3id.org/ontouml-models/distribution/a5c06e94-d77f-4967-8cae-a742a4c90f88/>,
+                      <https://w3id.org/ontouml-models/distribution/e99e1c86-6af5-4e56-9edb-1f6c1f1e81b5/>,
+                      <https://w3id.org/ontouml-models/distribution/6cc27304-e120-4b71-9074-b92ba55a6980>,
+                      <https://w3id.org/ontouml-models/distribution/c6543d12-20f0-4ff0-91d9-fbe9dd1f4971>,
+                      <https://w3id.org/ontouml-models/distribution/4e06461a-15d3-404f-88ce-61c0315999ed>,
+                      <https://w3id.org/ontouml-models/distribution/795afd06-0f7b-46d3-beb4-7930f3ac8c74>,
+                      <https://w3id.org/ontouml-models/distribution/2618147c-6e1b-4764-b7c0-8bee07dda1d5>,
+                      <https://w3id.org/ontouml-models/distribution/010542ad-4d36-441c-95ab-e532ed6e1b76> .

--- a/models/leao2024ontomed/metadata.ttl
+++ b/models/leao2024ontomed/metadata.ttl
@@ -1,15 +1,16 @@
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/model/leao2024ontomed/> a dcat:Dataset, mod:SemanticArtefact;
+<https://w3id.org/ontouml-models/model/leao2024ontomed/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
+    dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
     dct:title "Ontology for Medication Interaction Decision Support";
     mod:acronym "OntoMed";
     dct:issued "2024"^^xsd:gYear;
@@ -17,22 +18,31 @@
     skos:editorialNote "This work is the result of a scientific initiation project and represents the initial version of the ontology in Portuguese. The ontology remains under development, with plans for further refinements and the creation of versions in English in the future.";
     dct:language "pt-br";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:contributor <https://www.linkedin.com/in/renzo-henrique-guzzo-le%C3%A3o-193aa4234/>, <https://dblp.org/pid/36/6967>, <https://dblp.org/pid/91/3408>;
-    mod:designedForTask ocmv:DecisionSupportSystem, ocmv:ConceptualClarification, ocmv:OntologicalAnalysis;
+    dct:contributor <https://www.linkedin.com/in/renzo-henrique-guzzo-le%C3%A3o-193aa4234/>,
+                    <https://dblp.org/pid/36/6967>,
+                    <https://dblp.org/pid/91/3408>;
+    dcat:keyword "drug interaction"@en,
+                 "pharmaceutical ingredients"@en,
+                 "medication interaction"@en,
+                 "substance classification"@en;
+    dct:source <https://doi.org/10.5753/eries.2024.244714>;
+    mod:designedForTask ocmv:DecisionSupportSystem,
+                        ocmv:ConceptualClarification,
+                        ocmv:OntologicalAnalysis;
     ocmv:context ocmv:Research;
-    dct:source <https://doi.org/10.5753/eries.2024.244714>.
-<https://w3id.org/ontouml-models/model/leao2024ontomed/> dcat:distribution <https://w3id.org/ontouml-models/model/leao2024ontomed/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/leao2024ontomed/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Ontology for Medication Interaction Decision Support\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/leao2024ontomed/ontology.ttl>.
-<https://w3id.org/ontouml-models/model/leao2024ontomed/> dcat:distribution <https://w3id.org/ontouml-models/model/leao2024ontomed/distribution/json>.
-<https://w3id.org/ontouml-models/model/leao2024ontomed/distribution/json> a dcat:Distribution;
-    dct:title "JSON distribution of \"Ontology for Medication Interaction Decision Support\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/leao2024ontomed/ontology.json>.
-<https://w3id.org/ontouml-models/model/leao2024ontomed/> dcat:distribution <https://w3id.org/ontouml-models/model/leao2024ontomed/distribution/vpp>.
-<https://w3id.org/ontouml-models/model/leao2024ontomed/distribution/vpp> a dcat:Distribution;
-    dct:title "Visual Paradigm distribution of \"Ontology for Medication Interaction Decision Support\""@en;
-    dcat:mediaType <https://www.visual-paradigm.com/vpp>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/leao2024ontomed/ontology.vpp>.
+    ocmv:representationStyle ocmv:OntoumlStyle;
+    ocmv:ontologyType ocmv:Domain;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/leao2024ontomed"^^xsd:anyURI;
+    fdpo:metadataIssued "2026-06-23T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/leao2024ontomed/> dcat:distribution <https://w3id.org/ontouml-models/model/leao2024ontomed/distribution/ttl>,
+                      <https://www.iana.org/assignments/media-types/text/turtle>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/leao2024ontomed/ontology.ttl>,
+                      <https://w3id.org/ontouml-models/model/leao2024ontomed/>,
+                      <https://w3id.org/ontouml-models/model/leao2024ontomed/distribution/json>,
+                      <https://www.iana.org/assignments/media-types/application/json>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/leao2024ontomed/ontology.json>,
+                      <https://w3id.org/ontouml-models/model/leao2024ontomed/distribution/vpp>,
+                      <https://www.visual-paradigm.com/vpp>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/leao2024ontomed/ontology.vpp> .

--- a/models/library/metadata.ttl
+++ b/models/library/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/c26c4ec3-c554-4988-9b19-581855aa4646/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -23,7 +22,12 @@
     ocmv:context ocmv:Classroom;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/library"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/library"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:57:06.085708644Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:57:06.085708644Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/c26c4ec3-c554-4988-9b19-581855aa4646> dcat:distribution <https://w3id.org/ontouml-models/distribution/4777506b-c2c4-4996-a100-cbe75575804f/>, <https://w3id.org/ontouml-models/distribution/74d94cee-b9f6-4f92-948c-e95ba4001530/>, <https://w3id.org/ontouml-models/distribution/33263686-b82a-45dd-b808-f9f649d3c035/>, <https://w3id.org/ontouml-models/distribution/f1df092a-7e5f-4c35-b1b1-f274d839aec3>, <https://w3id.org/ontouml-models/distribution/fb315658-327e-493b-8dfc-cd9083f18cb7>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/c26c4ec3-c554-4988-9b19-581855aa4646> dcat:distribution <https://w3id.org/ontouml-models/distribution/4777506b-c2c4-4996-a100-cbe75575804f/>,
+                      <https://w3id.org/ontouml-models/distribution/74d94cee-b9f6-4f92-948c-e95ba4001530/>,
+                      <https://w3id.org/ontouml-models/distribution/33263686-b82a-45dd-b808-f9f649d3c035/>,
+                      <https://w3id.org/ontouml-models/distribution/f1df092a-7e5f-4c35-b1b1-f274d839aec3>,
+                      <https://w3id.org/ontouml-models/distribution/fb315658-327e-493b-8dfc-cd9083f18cb7> .

--- a/models/lindeberg2022full-ontorights/metadata.ttl
+++ b/models/lindeberg2022full-ontorights/metadata.ttl
@@ -1,16 +1,16 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/model/lindeberg2022full-ontorights/> a dcat:Dataset, mod:SemanticArtefact;
+<https://w3id.org/ontouml-models/model/lindeberg2022full-ontorights/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
+    dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
     dct:title "Full OntoRights";
     dct:issued "2022"^^xsd:gYear;
     dct:modified "2023"^^xsd:gYear;
@@ -20,21 +20,24 @@
     dcat:landingPage <https://joranl.github.io/human-rights-ontology/>;
     dct:license <https://unlicense.org/>;
     dct:contributor <https://orcid.org/0000-0001-7806-749X>;
+    dcat:keyword "human rights"@en,
+                 "human rights violations"@en;
+    dct:source <https://github.com/JoranL/human-rights-ontology/blob/gh-pages/files/Lindeberg%202022%20Ontology%20Design%20Master%20Thesis.pdf>,
+               <https://doi.org/10.1093/jhuman/huae019>,
+               <https://doi.org/10.1007/978-3-031-21488-2_15>;
     mod:designedForTask ocmv:ConceptualClarification;
     ocmv:context ocmv:Research;
-    dct:source <https://github.com/JoranL/human-rights-ontology/blob/gh-pages/files/Lindeberg%202022%20Ontology%20Design%20Master%20Thesis.pdf>,<https://doi.org/10.1093/jhuman/huae019>,<https://doi.org/10.1007/978-3-031-21488-2_15>.
-<https://w3id.org/ontouml-models/model/lindeberg2022full-ontorights/> dcat:distribution <https://w3id.org/ontouml-models/model/lindeberg2022full-ontorights/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/lindeberg2022full-ontorights/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Full OntoRights\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/lindeberg2022full-ontorights/ontology.ttl>.
-<https://w3id.org/ontouml-models/model/lindeberg2022full-ontorights/> dcat:distribution <https://w3id.org/ontouml-models/model/lindeberg2022full-ontorights/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/lindeberg2022full-ontorights/distribution/ttl> a dcat:Distribution;
-    dct:title "JSON distribution of \"Full OntoRights\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/lindeberg2022full-ontorights/ontology.json>.
-<https://w3id.org/ontouml-models/model/lindeberg2022full-ontorights/> dcat:distribution <https://w3id.org/ontouml-models/model/lindeberg2022full-ontorights/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/lindeberg2022full-ontorights/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Full OntoRights\""@en;
-    dcat:mediaType <https://www.visual-paradigm.com/vpp>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/lindeberg2022full-ontorights/ontology.vpp>.
+    ocmv:representationStyle ocmv:OntoumlStyle;
+    ocmv:ontologyType ocmv:Domain;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/lindeberg2022full-ontorights"^^xsd:anyURI;
+    fdpo:metadataIssued "2026-06-23T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/lindeberg2022full-ontorights/> dcat:distribution <https://w3id.org/ontouml-models/model/lindeberg2022full-ontorights/distribution/ttl>,
+                      <https://www.iana.org/assignments/media-types/text/turtle>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/lindeberg2022full-ontorights/ontology.ttl>,
+                      <https://w3id.org/ontouml-models/model/lindeberg2022full-ontorights/>,
+                      <https://www.iana.org/assignments/media-types/application/json>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/lindeberg2022full-ontorights/ontology.json>,
+                      <https://www.visual-paradigm.com/vpp>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/lindeberg2022full-ontorights/ontology.vpp> .

--- a/models/lindeberg2022simple-ontorights/metadata.ttl
+++ b/models/lindeberg2022simple-ontorights/metadata.ttl
@@ -1,16 +1,16 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/model/lindeberg2022simple-ontorights/> a dcat:Dataset, mod:SemanticArtefact;
+<https://w3id.org/ontouml-models/model/lindeberg2022simple-ontorights/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
+    dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
     dct:title "Easy OntoRights";
     dct:issued "2022"^^xsd:gYear;
     dct:modified "2023"^^xsd:gYear;
@@ -20,13 +20,28 @@
     dcat:landingPage <https://joranl.github.io/human-rights-ontology/>;
     dct:license <https://unlicense.org/>;
     dct:contributor <https://orcid.org/0000-0001-7806-749X>;
-    dcat:keyword "human rights violations"@en;
+    dcat:keyword "human rights"@en,
+                 "human rights violations"@en;
+    dct:source <https://raw.githubusercontent.com/JoranL/human-rights-ontology/gh-pages/files/Lindeberg_2022_Ontology_Design_Master_Thesis.pdf>;
     mod:designedForTask ocmv:SoftwareEngineering;
     ocmv:context ocmv:Research;
-    dct:source <https://raw.githubusercontent.com/JoranL/human-rights-ontology/gh-pages/files/Lindeberg_2022_Ontology_Design_Master_Thesis.pdf>;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/lindeberg2022simple-ontorights"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/lindeberg2022simple-ontorights"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:57:48.477389719Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:57:48.477389719Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/0747ca35-c0b1-4464-bd1d-27b9098b3beb> dcat:distribution <https://w3id.org/ontouml-models/distribution/e373a49d-1e65-4fb5-a6cb-b32549b25642/>, <https://w3id.org/ontouml-models/distribution/242d4c0b-b23c-4783-b384-c5db6a9aec11/>, <https://w3id.org/ontouml-models/distribution/556ac585-13b6-4a50-b2e1-2f8caec18d2b/>, <https://w3id.org/ontouml-models/distribution/9c3112ee-1552-4c4e-925b-1f6b83291762>, <https://w3id.org/ontouml-models/distribution/74c24250-079d-48a7-9c01-6190be67d4e5>, <https://w3id.org/ontouml-models/distribution/87f79721-b58b-45d2-b1f8-6e1ab047c13f>, <https://w3id.org/ontouml-models/distribution/b1174c05-fb7a-410d-a46f-ad32e7d9b80e>, <https://w3id.org/ontouml-models/distribution/6b1ad188-a12e-4421-bbf3-fced0fd4315b>, <https://w3id.org/ontouml-models/distribution/e5e1f563-ee0d-46b2-bd1e-2f820d2dfe9d>, <https://w3id.org/ontouml-models/distribution/cbc0f466-ed21-4b23-b8b1-8c7dc099e04d>, <https://w3id.org/ontouml-models/distribution/ade0e6fa-46f2-4427-935f-02f0c0f0865a>, <https://w3id.org/ontouml-models/distribution/14e5dbf7-6d31-40ca-955e-65796ab3b080>, <https://w3id.org/ontouml-models/distribution/7135e6de-a834-4486-8c21-c984e4133d3b>, <https://w3id.org/ontouml-models/distribution/5162cf20-65d4-4bc0-98f2-7433c6fe1cbe>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/0747ca35-c0b1-4464-bd1d-27b9098b3beb> dcat:distribution <https://w3id.org/ontouml-models/distribution/e373a49d-1e65-4fb5-a6cb-b32549b25642/>,
+                      <https://w3id.org/ontouml-models/distribution/242d4c0b-b23c-4783-b384-c5db6a9aec11/>,
+                      <https://w3id.org/ontouml-models/distribution/556ac585-13b6-4a50-b2e1-2f8caec18d2b/>,
+                      <https://w3id.org/ontouml-models/distribution/9c3112ee-1552-4c4e-925b-1f6b83291762>,
+                      <https://w3id.org/ontouml-models/distribution/74c24250-079d-48a7-9c01-6190be67d4e5>,
+                      <https://w3id.org/ontouml-models/distribution/87f79721-b58b-45d2-b1f8-6e1ab047c13f>,
+                      <https://w3id.org/ontouml-models/distribution/b1174c05-fb7a-410d-a46f-ad32e7d9b80e>,
+                      <https://w3id.org/ontouml-models/distribution/6b1ad188-a12e-4421-bbf3-fced0fd4315b>,
+                      <https://w3id.org/ontouml-models/distribution/e5e1f563-ee0d-46b2-bd1e-2f820d2dfe9d>,
+                      <https://w3id.org/ontouml-models/distribution/cbc0f466-ed21-4b23-b8b1-8c7dc099e04d>,
+                      <https://w3id.org/ontouml-models/distribution/ade0e6fa-46f2-4427-935f-02f0c0f0865a>,
+                      <https://w3id.org/ontouml-models/distribution/14e5dbf7-6d31-40ca-955e-65796ab3b080>,
+                      <https://w3id.org/ontouml-models/distribution/7135e6de-a834-4486-8c21-c984e4133d3b>,
+                      <https://w3id.org/ontouml-models/distribution/5162cf20-65d4-4bc0-98f2-7433c6fe1cbe> .

--- a/models/lindeberg2024legal-enforcement/metadata.ttl
+++ b/models/lindeberg2024legal-enforcement/metadata.ttl
@@ -1,37 +1,46 @@
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/model/lindeberg2024legal-enforcement/> a dcat:Dataset, mod:SemanticArtefact;
+<https://w3id.org/ontouml-models/model/lindeberg2024legal-enforcement/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
+    dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
     dct:title "Legal Enforcement Meta-Model";
     dct:issued "2024"^^xsd:gYear;
     dcat:theme lcc:K;
     skos:editorialNote "This meta-model is originally composed of three distinct project files. To be included into the catalog, these projects were merged into a single one. The authors state that the projects include both slight adaptations of previous modelling efforts by other authors, and their own contributions representing how supervisory authorities and the court system enforces legislation.";
     dct:language "en-gb";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:contributor <https://orcid.org/0000-0001-7194-9617>, <https://orcid.org/0000-0001-7806-749X>, <https://orcid.org/0000-0001-9044-5836>, <https://orcid.org/0000-0002-7416-8725>, <https://orcid.org/0000-0003-3290-2597>;
+    dct:contributor <https://orcid.org/0000-0001-7194-9617>,
+                    <https://orcid.org/0000-0001-7806-749X>,
+                    <https://orcid.org/0000-0001-9044-5836>,
+                    <https://orcid.org/0000-0002-7416-8725>,
+                    <https://orcid.org/0000-0003-3290-2597>;
+    dcat:keyword "organisational rules"@en,
+                 "legislation"@en,
+                 "law"@en,
+                 "legal enforcement"@en;
+    dct:source <https://doi.org/10.1007/978-3-031-75599-6_20>;
     mod:designedForTask ocmv:ConceptualClarification;
     ocmv:context ocmv:Research;
-    dct:source <https://doi.org/10.1007/978-3-031-75599-6_20>.
-<https://w3id.org/ontouml-models/model/lindeberg2024legal-enforcement/> dcat:distribution <https://w3id.org/ontouml-models/model/lindeberg2024legal-enforcement/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/lindeberg2024legal-enforcement/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Legal Enforcement Meta-Model\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/lindeberg2024legal-enforcement/ontology.ttl>.
-<https://w3id.org/ontouml-models/model/lindeberg2024legal-enforcement/> dcat:distribution <https://w3id.org/ontouml-models/model/lindeberg2024legal-enforcement/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/lindeberg2024legal-enforcement/distribution/ttl> a dcat:Distribution;
-    dct:title "JSON distribution of \"Legal Enforcement Meta-Model\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/lindeberg2024legal-enforcement/ontology.json>.
-<https://w3id.org/ontouml-models/model/lindeberg2024legal-enforcement/> dcat:distribution <https://w3id.org/ontouml-models/model/lindeberg2024legal-enforcement/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/lindeberg2024legal-enforcement/distribution/vpp> a dcat:Distribution;
-    dct:title "Visual Paradigm distribution of \"Legal Enforcement Meta-Model\""@en;
-    dcat:mediaType <https://www.visual-paradigm.com/vpp>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/lindeberg2024legal-enforcement/ontology.vpp>.
+    ocmv:representationStyle ocmv:OntoumlStyle;
+    ocmv:ontologyType ocmv:Application;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/lindeberg2024legal-enforcement"^^xsd:anyURI;
+    fdpo:metadataIssued "2026-06-23T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/lindeberg2024legal-enforcement/> dcat:distribution <https://w3id.org/ontouml-models/model/lindeberg2024legal-enforcement/distribution/ttl>,
+                      <https://www.iana.org/assignments/media-types/text/turtle>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/lindeberg2024legal-enforcement/ontology.ttl>,
+                      <https://w3id.org/ontouml-models/model/lindeberg2024legal-enforcement/>,
+                      <https://www.iana.org/assignments/media-types/application/json>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/lindeberg2024legal-enforcement/ontology.json>,
+                      <https://w3id.org/ontouml-models/model/lindeberg2024legal-enforcement/distribution/vpp>,
+                      <https://www.visual-paradigm.com/vpp>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/lindeberg2024legal-enforcement/ontology.vpp> .

--- a/models/machacova2023gym/metadata.ttl
+++ b/models/machacova2023gym/metadata.ttl
@@ -1,36 +1,40 @@
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/model/machacova2023gym/> a dcat:Dataset, mod:SemanticArtefact;
+<https://w3id.org/ontouml-models/model/machacova2023gym/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
+    dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
     dct:title "Example Ontology for Gym Products";
     dct:issued "2023"^^xsd:gYear;
     dcat:theme lcc:H;
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:contributor <https://dblp.org/pid/358/4857>, <https://dblp.org/pid/253/7051>;
+    dct:contributor <https://dblp.org/pid/358/4857>,
+                    <https://dblp.org/pid/253/7051>;
+    dcat:keyword "product"@en,
+                 "gym"@en,
+                 "sale"@en;
+    dct:source <https://dspace.cvut.cz/handle/10467/107233>;
     mod:designedForTask ocmv:Example;
     ocmv:context ocmv:Research;
-    dct:source <https://dspace.cvut.cz/handle/10467/107233>.
-<https://w3id.org/ontouml-models/model/machacova2023gym/> dcat:distribution <https://w3id.org/ontouml-models/model/machacova2023gym/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/machacova2023gym/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Example Ontology for Gym Products\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/machacova2023gym/ontology.ttl>.
-<https://w3id.org/ontouml-models/model/machacova2023gym/> dcat:distribution <https://w3id.org/ontouml-models/model/machacova2023gym/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/machacova2023gym/distribution/ttl> a dcat:Distribution;
-    dct:title "JSON distribution of \"Example Ontology for Gym Products\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/machacova2023gym/ontology.json>.
-<https://w3id.org/ontouml-models/model/machacova2023gym/> dcat:distribution <https://w3id.org/ontouml-models/model/machacova2023gym/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/machacova2023gym/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Example Ontology for Gym Products\""@en;
-    dcat:mediaType <https://www.visual-paradigm.com/vpp>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/machacova2023gym/ontology.vpp>.
+    ocmv:representationStyle ocmv:OntoumlStyle;
+    ocmv:ontologyType ocmv:Domain;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/machacova2023gym"^^xsd:anyURI;
+    fdpo:metadataIssued "2026-06-23T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/machacova2023gym/> dcat:distribution <https://w3id.org/ontouml-models/model/machacova2023gym/distribution/ttl>,
+                      <https://www.iana.org/assignments/media-types/text/turtle>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/machacova2023gym/ontology.ttl>,
+                      <https://w3id.org/ontouml-models/model/machacova2023gym/>,
+                      <https://www.iana.org/assignments/media-types/application/json>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/machacova2023gym/ontology.json>,
+                      <https://www.visual-paradigm.com/vpp>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/machacova2023gym/ontology.vpp> .

--- a/models/maddalena2021ontocovid/metadata.ttl
+++ b/models/maddalena2021ontocovid/metadata.ttl
@@ -1,31 +1,37 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/731a9856-9d6f-4a07-859c-48ec758fe5ce/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:title "OntoCovid";
     dct:issued "2021"^^xsd:gYear;
     dct:modified "2021"^^xsd:gYear;
     dcat:theme lcc:R;
     dct:language "pt-br";
-    dct:contributor <https://dblp.org/pid/309/4924>, <https://dblp.org/pid/b/FAraujoBaiao>;
-    dcat:keyword "health"@en, "covid"@en;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    dct:contributor <https://dblp.org/pid/309/4924>,
+                    <https://dblp.org/pid/b/FAraujoBaiao>;
+    dcat:keyword "health"@en,
+                 "covid"@en;
+    dct:source <https://dblp.org/rec/conf/ontobras/MaddalenaB21>;
     mod:designedForTask ocmv:ConceptualClarification;
     ocmv:context ocmv:Research;
-    dct:source <https://dblp.org/rec/conf/ontobras/MaddalenaB21>;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/maddalena2021ontocovid"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/maddalena2021ontocovid"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:58:12.467273247Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:58:12.467273247Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/731a9856-9d6f-4a07-859c-48ec758fe5ce> dcat:distribution <https://w3id.org/ontouml-models/distribution/8ba63420-bbe8-4151-9918-14aab50751b7/>, <https://w3id.org/ontouml-models/distribution/1a3c1d2b-679c-47d2-a2b4-59e81e1583e7/>, <https://w3id.org/ontouml-models/distribution/8e0087e7-8ee0-4619-8f79-a0b49917b1cf/>, <https://w3id.org/ontouml-models/distribution/9a59e63f-4edb-4aab-ba35-52d79a772916>, <https://w3id.org/ontouml-models/distribution/c1e13f91-fc02-4d28-b0d3-6f0751248fb9>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/731a9856-9d6f-4a07-859c-48ec758fe5ce> dcat:distribution <https://w3id.org/ontouml-models/distribution/8ba63420-bbe8-4151-9918-14aab50751b7/>,
+                      <https://w3id.org/ontouml-models/distribution/1a3c1d2b-679c-47d2-a2b4-59e81e1583e7/>,
+                      <https://w3id.org/ontouml-models/distribution/8e0087e7-8ee0-4619-8f79-a0b49917b1cf/>,
+                      <https://w3id.org/ontouml-models/distribution/9a59e63f-4edb-4aab-ba35-52d79a772916>,
+                      <https://w3id.org/ontouml-models/distribution/c1e13f91-fc02-4d28-b0d3-6f0751248fb9> .

--- a/models/martinez2013human-genome/metadata.ttl
+++ b/models/martinez2013human-genome/metadata.ttl
@@ -1,32 +1,41 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/7509f026-5e24-48e7-a995-ab2f419ce4d7/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:title "Conceptual Schema of Human Genome";
     mod:acronym "CSHG";
     dct:issued "2013"^^xsd:gYear;
     dct:modified "2013"^^xsd:gYear;
     dcat:theme lcc:R;
     dct:language "en";
-    dct:contributor <https://dblp.org/pid/137/2813>, <https://dblp.org/pid/p/OscarPastor>, <https://dblp.org/pid/11/78>;
-    dcat:keyword "healthcare"@en, "bioinformatics"@en;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    dct:contributor <https://dblp.org/pid/137/2813>,
+                    <https://dblp.org/pid/p/OscarPastor>,
+                    <https://dblp.org/pid/11/78>;
+    dcat:keyword "healthcare"@en,
+                 "bioinformatics"@en;
+    dct:source <https://doi.org/10.1007/978-3-642-41924-9_40>;
     mod:designedForTask ocmv:ConceptualClarification;
     ocmv:context ocmv:Research;
-    dct:source <https://doi.org/10.1007/978-3-642-41924-9_40>;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/martinez2013human-genome"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/martinez2013human-genome"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:58:23.166457014Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:58:23.166457014Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/7509f026-5e24-48e7-a995-ab2f419ce4d7> dcat:distribution <https://w3id.org/ontouml-models/distribution/5239badd-3f17-4eaf-9ef4-bab107211d70/>, <https://w3id.org/ontouml-models/distribution/0a7b8bb6-a311-4806-9ff2-b8c87c5d8e61/>, <https://w3id.org/ontouml-models/distribution/11544bb3-d60f-40d3-b20a-3adaf1b8142a/>, <https://w3id.org/ontouml-models/distribution/d53fdb12-3175-4151-b39e-31ed4e249f9a>, <https://w3id.org/ontouml-models/distribution/6a4cb048-3228-452d-aff0-0c4bb6a4489a>, <https://w3id.org/ontouml-models/distribution/5f288612-560c-4eb8-a166-538401b255bb>, <https://w3id.org/ontouml-models/distribution/1bc297ac-1a61-474d-833e-ad055fb2fc25>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/7509f026-5e24-48e7-a995-ab2f419ce4d7> dcat:distribution <https://w3id.org/ontouml-models/distribution/5239badd-3f17-4eaf-9ef4-bab107211d70/>,
+                      <https://w3id.org/ontouml-models/distribution/0a7b8bb6-a311-4806-9ff2-b8c87c5d8e61/>,
+                      <https://w3id.org/ontouml-models/distribution/11544bb3-d60f-40d3-b20a-3adaf1b8142a/>,
+                      <https://w3id.org/ontouml-models/distribution/d53fdb12-3175-4151-b39e-31ed4e249f9a>,
+                      <https://w3id.org/ontouml-models/distribution/6a4cb048-3228-452d-aff0-0c4bb6a4489a>,
+                      <https://w3id.org/ontouml-models/distribution/5f288612-560c-4eb8-a166-538401b255bb>,
+                      <https://w3id.org/ontouml-models/distribution/1bc297ac-1a61-474d-833e-ad055fb2fc25> .

--- a/models/meirelles2024credit-operations/metadata.ttl
+++ b/models/meirelles2024credit-operations/metadata.ttl
@@ -1,36 +1,41 @@
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/model/meirelles2024credit-operations/> a dcat:Dataset, mod:SemanticArtefact;
+<https://w3id.org/ontouml-models/model/meirelles2024credit-operations/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
+    dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
     dct:title "Ontologia de Referência para o Domínio de Operações de Crédito";
     dct:issued "2024"^^xsd:gYear;
     dcat:theme lcc:H;
     dct:language "pt-br";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:contributor <https://orcid.org/0009-0003-8838-3367>;
-    mod:designedForTask ocmv:ConceptualClarification, ocmv:Interoperability, ocmv:OntologicalAnalysis;
+    dcat:keyword "credit operations"@en,
+                 "finance"@en;
+    dct:source <http://repositorio.ufes.br/handle/10/18082>;
+    mod:designedForTask ocmv:ConceptualClarification,
+                        ocmv:Interoperability,
+                        ocmv:OntologicalAnalysis;
     ocmv:context ocmv:Research;
-    dct:source <http://repositorio.ufes.br/handle/10/18082>.
-<https://w3id.org/ontouml-models/model/meirelles2024credit-operations/> dcat:distribution <https://w3id.org/ontouml-models/model/meirelles2024credit-operations/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/meirelles2024credit-operations/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Ontologia de Referência para o Domínio de Operações de Crédito\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/meirelles2024credit-operations/ontology.ttl>.
-<https://w3id.org/ontouml-models/model/meirelles2024credit-operations/> dcat:distribution <https://w3id.org/ontouml-models/model/meirelles2024credit-operations/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/meirelles2024credit-operations/distribution/ttl> a dcat:Distribution;
-    dct:title "JSON distribution of \"Ontologia de Referência para o Domínio de Operações de Crédito\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/meirelles2024credit-operations/ontology.json>.
-<https://w3id.org/ontouml-models/model/meirelles2024credit-operations/> dcat:distribution <https://w3id.org/ontouml-models/model/meirelles2024credit-operations/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/meirelles2024credit-operations/distribution/vpp> a dcat:Distribution;
-    dct:title "Visual Paradigm distribution of \"Ontologia de Referência para o Domínio de Operações de Crédito\""@en;
-    dcat:mediaType <https://www.visual-paradigm.com/vpp>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/meirelles2024credit-operations/ontology.vpp>.
+    ocmv:representationStyle ocmv:OntoumlStyle;
+    ocmv:ontologyType ocmv:Domain;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/meirelles2024credit-operations"^^xsd:anyURI;
+    fdpo:metadataIssued "2026-06-23T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/meirelles2024credit-operations/> dcat:distribution <https://w3id.org/ontouml-models/model/meirelles2024credit-operations/distribution/ttl>,
+                      <https://www.iana.org/assignments/media-types/text/turtle>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/meirelles2024credit-operations/ontology.ttl>,
+                      <https://w3id.org/ontouml-models/model/meirelles2024credit-operations/>,
+                      <https://www.iana.org/assignments/media-types/application/json>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/meirelles2024credit-operations/ontology.json>,
+                      <https://w3id.org/ontouml-models/model/meirelles2024credit-operations/distribution/vpp>,
+                      <https://www.visual-paradigm.com/vpp>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/meirelles2024credit-operations/ontology.vpp> .

--- a/models/mello2022monotheism/metadata.ttl
+++ b/models/mello2022monotheism/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/01b11d4e-3eb1-4aae-ab31-5daa5220fffc/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -20,12 +19,17 @@
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:contributor <https://dblp.org/pid/230/6787>;
     dcat:keyword "religion"@en;
+    dct:source <https://repositorio.ufsc.br/handle/123456789/230921>;
     mod:designedForTask ocmv:ConceptualClarification;
     ocmv:context ocmv:Research;
-    dct:source <https://repositorio.ufsc.br/handle/123456789/230921>;
     ocmv:representationStyle ocmv:UfoStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/mello2022monotheism"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/mello2022monotheism"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:58:35.678649277Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:58:35.678649277Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/01b11d4e-3eb1-4aae-ab31-5daa5220fffc> dcat:distribution <https://w3id.org/ontouml-models/distribution/feb7c004-899f-4d76-a93f-9ba0ecb4f07c/>, <https://w3id.org/ontouml-models/distribution/1183b185-8ef8-4fb5-99cb-9d456d3a8f5c/>, <https://w3id.org/ontouml-models/distribution/fcd2bc30-4b0e-48a1-80f8-943af9e93887/>, <https://w3id.org/ontouml-models/distribution/cdbf61bf-ad17-404a-87e1-488446a11fff>, <https://w3id.org/ontouml-models/distribution/6fcfe50a-d29f-4f06-b3c1-cb84c94e4f43>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/01b11d4e-3eb1-4aae-ab31-5daa5220fffc> dcat:distribution <https://w3id.org/ontouml-models/distribution/feb7c004-899f-4d76-a93f-9ba0ecb4f07c/>,
+                      <https://w3id.org/ontouml-models/distribution/1183b185-8ef8-4fb5-99cb-9d456d3a8f5c/>,
+                      <https://w3id.org/ontouml-models/distribution/fcd2bc30-4b0e-48a1-80f8-943af9e93887/>,
+                      <https://w3id.org/ontouml-models/distribution/cdbf61bf-ad17-404a-87e1-488446a11fff>,
+                      <https://w3id.org/ontouml-models/distribution/6fcfe50a-d29f-4f06-b3c1-cb84c94e4f43> .

--- a/models/melo2024onto-educational/metadata.ttl
+++ b/models/melo2024onto-educational/metadata.ttl
@@ -1,37 +1,44 @@
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/model/melo2024onto-educational/> a dcat:Dataset, mod:SemanticArtefact;
+<https://w3id.org/ontouml-models/model/melo2024onto-educational/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
+    dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
     dct:title "Ontologia para Integração de Dados de Evasão Escolar, Desempenho Acadêmico e Concessão de Auxílios Socioeconômicos";
     mod:acronym "Onto-Educacional";
     dct:issued "2024"^^xsd:gYear;
     dcat:theme lcc:H;
     dct:language "pt-br";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:contributor <https://dblp.org/pid/368/9900>, <https://dblp.org/pid/121/5314>;
-    mod:designedForTask ocmv:ConceptualClarification, ocmv:InformationRetrieval, ocmv:Interoperability;
+    dct:contributor <https://dblp.org/pid/368/9900>,
+                    <https://dblp.org/pid/121/5314>;
+    dcat:keyword "academic performance"@en,
+                 "socioeconomic aid"@en,
+                 "education"@en;
+    dct:source <https://www.inf.ufrgs.br/ontobras/wp-content/uploads/2024/10/ontobras_2024_paper_4.pdf>;
+    mod:designedForTask ocmv:ConceptualClarification,
+                        ocmv:InformationRetrieval,
+                        ocmv:Interoperability;
     ocmv:context ocmv:Research;
-    dct:source <https://www.inf.ufrgs.br/ontobras/wp-content/uploads/2024/10/ontobras_2024_paper_4.pdf>.
-<https://w3id.org/ontouml-models/model/melo2024onto-educational/> dcat:distribution <https://w3id.org/ontouml-models/model/melo2024onto-educational/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/melo2024onto-educational/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Ontologia para Integração de Dados de Evasão Escolar, Desempenho Acadêmico e Concessão de Auxílios Socioeconômicos\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/melo2024onto-educational/ontology.ttl>.
-<https://w3id.org/ontouml-models/model/melo2024onto-educational/> dcat:distribution <https://w3id.org/ontouml-models/model/melo2024onto-educational/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/melo2024onto-educational/distribution/ttl> a dcat:Distribution;
-    dct:title "JSON distribution of \"Ontologia para Integração de Dados de Evasão Escolar, Desempenho Acadêmico e Concessão de Auxílios Socioeconômicos\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/melo2024onto-educational/ontology.json>.
-<https://w3id.org/ontouml-models/model/melo2024onto-educational/> dcat:distribution <https://w3id.org/ontouml-models/model/melo2024onto-educational/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/melo2024onto-educational/distribution/vpp> a dcat:Distribution;
-    dct:title "Visual Paradigm distribution of \"Ontologia para Integração de Dados de Evasão Escolar, Desempenho Acadêmico e Concessão de Auxílios Socioeconômicos\""@en;
-    dcat:mediaType <https://www.visual-paradigm.com/vpp>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/melo2024onto-educational/ontology.vpp>.
+    ocmv:representationStyle ocmv:OntoumlStyle;
+    ocmv:ontologyType ocmv:Domain;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/melo2024onto-educational"^^xsd:anyURI;
+    fdpo:metadataIssued "2026-06-23T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/melo2024onto-educational/> dcat:distribution <https://w3id.org/ontouml-models/model/melo2024onto-educational/distribution/ttl>,
+                      <https://www.iana.org/assignments/media-types/text/turtle>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/melo2024onto-educational/ontology.ttl>,
+                      <https://w3id.org/ontouml-models/model/melo2024onto-educational/>,
+                      <https://www.iana.org/assignments/media-types/application/json>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/melo2024onto-educational/ontology.json>,
+                      <https://w3id.org/ontouml-models/model/melo2024onto-educational/distribution/vpp>,
+                      <https://www.visual-paradigm.com/vpp>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/melo2024onto-educational/ontology.vpp> .

--- a/models/mgic-antt2011/metadata.ttl
+++ b/models/mgic-antt2011/metadata.ttl
@@ -1,37 +1,44 @@
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/model/mgic-antt2011/> a dcat:Dataset, mod:SemanticArtefact;
+<https://w3id.org/ontouml-models/model/mgic-antt2011/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
+    dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
     dct:title "National Agency of Terrestrial Transportation (ANTT) Ontology";
     dct:issued "2011"^^xsd:gYear;
     dct:modified "2015"^^xsd:gYear;
     dcat:theme lcc:H;
-    skos:editorialNote "The models were imported to Visual Paradigm from a file generated from the last known version of the complete ontology, which was originally build on Enterprise Architect. After the importation, unused elements were removed and stereotypes fixed using the OntoUML plugin for Visual Paradigm. The diagrams were kept as they were, only with organization of relationships. Some notes for internal use were removed, but domain notes were kept. Essential and inseparable constraints were kept in the visualization, but the meta-properties were added to their corresponding compositions. Class Fiscal da ANTT 2 was merged to class Fiscal da ANTT, however Fiscal 2 was not merged to Fiscal because of their different stereotypes. The original diagrams were also generated from the same eap file, however, for these, nothing was done in order to correct the layout of the diagrams and importation problems may have happened. The main-source for this work does not describe the ontology itself, but the project in which the ontology was built. The original file also contained goal models, which were removed.";
+    skos:editorialNote "The models were imported to Visual Paradigm from a file generated from the last known version of the complete ontology, which was originally build on Enterprise Architect. After the importation, unused elements were removed and stereotypes fixed using the OntoUML plugin for Visual Paradigm. The diagrams were kept as they were, only with organization of relationships. Some notes for internal use were removed, but domain notes were kept. Essential and inseparable constraints were kept in the visualization, but the meta-properties were added to their corresponding compositions. Class Fiscal da ANTT 2 was merged to class Fiscal da ANTT, however Fiscal 2 was not merged to Fiscal because of their different stereotypes. The original diagrams were also generated from the same eap file, however, for these, nothing was done in order to correct the layout of the diagrams and importation problems may have happened. The main-source for this work does not describe the ontology itself, but the project in which the ontology was built.";
     dct:language "pt-br";
-    dct:contributor <https://dblp.org/pid/96/8280>, <https://dblp.org/pid/134/4947>, <https://dblp.org/pid/54/10278>;
+    dct:contributor <https://dblp.org/pid/96/8280>,
+                    <https://dblp.org/pid/134/4947>,
+                    <https://dblp.org/pid/54/10278>;
+    dcat:keyword "terrestrial transportation"@en,
+                 "normative acts"@en,
+                 "inspection"@en,
+                 "people"@en,
+                 "financing"@en;
+    dct:source <https://www.scitepress.org/Link.aspx?doi=10.5220/0003695200030011>;
     mod:designedForTask ocmv:ConceptualClarification;
     ocmv:context ocmv:Industry;
-    dct:source <https://www.scitepress.org/Link.aspx?doi=10.5220/0003695200030011>.
-<https://w3id.org/ontouml-models/model/mgic-antt2011/> dcat:distribution <https://w3id.org/ontouml-models/model/mgic-antt2011/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/mgic-antt2011/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"National Agency of Terrestrial Transportation (ANTT) Ontology\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/mgic-antt2011/ontology.ttl>.
-<https://w3id.org/ontouml-models/model/mgic-antt2011/> dcat:distribution <https://w3id.org/ontouml-models/model/mgic-antt2011/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/mgic-antt2011/distribution/ttl> a dcat:Distribution;
-    dct:title "JSON distribution of \"National Agency of Terrestrial Transportation (ANTT) Ontology\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/mgic-antt2011/ontology.json>.
-<https://w3id.org/ontouml-models/model/mgic-antt2011/> dcat:distribution <https://w3id.org/ontouml-models/model/mgic-antt2011/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/mgic-antt2011/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"National Agency of Terrestrial Transportation (ANTT) Ontology\""@en;
-    dcat:mediaType <https://www.visual-paradigm.com/vpp>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/mgic-antt2011/ontology.vpp>.
+    ocmv:representationStyle ocmv:OntoumlStyle;
+    ocmv:ontologyType ocmv:Domain;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/mgic-antt2011"^^xsd:anyURI;
+    fdpo:metadataIssued "2026-06-23T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/mgic-antt2011/> dcat:distribution <https://w3id.org/ontouml-models/model/mgic-antt2011/distribution/ttl>,
+                      <https://www.iana.org/assignments/media-types/text/turtle>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/mgic-antt2011/ontology.ttl>,
+                      <https://w3id.org/ontouml-models/model/mgic-antt2011/>,
+                      <https://www.iana.org/assignments/media-types/application/json>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/mgic-antt2011/ontology.json>,
+                      <https://www.visual-paradigm.com/vpp>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/mgic-antt2011/ontology.vpp> .

--- a/models/moreira2018saref4health/metadata.ttl
+++ b/models/moreira2018saref4health/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/0ed90b91-3f0c-46e2-9710-7e14cc846b34/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -19,14 +18,25 @@
     skos:editorialNote "The OntoUML representation of the SAREF ontology contains OWL constraints that cannot be fully represented here.";
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:contributor <https://dblp.org/pid/74/7740>, <https://dblp.org/pid/p/LuisFerreiraPires>, <https://dblp.org/pid/s/MartenvanSinderen>, <https://dblp.org/pid/65/1704>;
+    dct:contributor <https://dblp.org/pid/74/7740>,
+                    <https://dblp.org/pid/p/LuisFerreiraPires>,
+                    <https://dblp.org/pid/s/MartenvanSinderen>,
+                    <https://dblp.org/pid/65/1704>;
     dcat:keyword "e-health subsystems"@en;
-    mod:designedForTask ocmv:ConceptualClarification, ocmv:DataPublication;
-    ocmv:context ocmv:Research;
     dct:source <https://doi.org/10.3233/978-1-61499-910-2-239>;
+    mod:designedForTask ocmv:ConceptualClarification,
+                        ocmv:DataPublication;
+    ocmv:context ocmv:Research;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/moreira2018saref4health"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/moreira2018saref4health"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T18:06:14.085933922Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:06:14.085933922Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/0ed90b91-3f0c-46e2-9710-7e14cc846b34> dcat:distribution <https://w3id.org/ontouml-models/distribution/e1758a7a-de62-4633-9eba-906a1937b43a/>, <https://w3id.org/ontouml-models/distribution/201c9f10-7f12-471e-ab50-e062d8d29769/>, <https://w3id.org/ontouml-models/distribution/9220464d-d577-4cc1-b080-b67e6cbef8eb/>, <https://w3id.org/ontouml-models/distribution/089289ba-974c-487f-816c-5f82df03c6ee>, <https://w3id.org/ontouml-models/distribution/090b1aa5-5f72-4156-a432-88538c4e9fc1>, <https://w3id.org/ontouml-models/distribution/2b7d45f2-85ae-417a-969f-51ba664d61e4>, <https://w3id.org/ontouml-models/distribution/73b8a96a-e7a7-452d-a0a4-013ab8e19957>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/0ed90b91-3f0c-46e2-9710-7e14cc846b34> dcat:distribution <https://w3id.org/ontouml-models/distribution/e1758a7a-de62-4633-9eba-906a1937b43a/>,
+                      <https://w3id.org/ontouml-models/distribution/201c9f10-7f12-471e-ab50-e062d8d29769/>,
+                      <https://w3id.org/ontouml-models/distribution/9220464d-d577-4cc1-b080-b67e6cbef8eb/>,
+                      <https://w3id.org/ontouml-models/distribution/089289ba-974c-487f-816c-5f82df03c6ee>,
+                      <https://w3id.org/ontouml-models/distribution/090b1aa5-5f72-4156-a432-88538c4e9fc1>,
+                      <https://w3id.org/ontouml-models/distribution/2b7d45f2-85ae-417a-969f-51ba664d61e4>,
+                      <https://w3id.org/ontouml-models/distribution/73b8a96a-e7a7-452d-a0a4-013ab8e19957> .

--- a/models/music-ontology/metadata.ttl
+++ b/models/music-ontology/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/daca2352-8735-4a4b-a1c2-952862fb594f/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -23,7 +22,12 @@
     ocmv:context ocmv:Classroom;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/music-ontology"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/music-ontology"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T18:06:26.607761114Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:06:26.607761114Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/daca2352-8735-4a4b-a1c2-952862fb594f> dcat:distribution <https://w3id.org/ontouml-models/distribution/4dbee2f8-a170-4836-89fd-9877152a1a76/>, <https://w3id.org/ontouml-models/distribution/aabc4dad-2beb-477b-b8a7-4aed656cf520/>, <https://w3id.org/ontouml-models/distribution/66b6d2ce-fb44-47cb-ac54-1502a7cac6d9/>, <https://w3id.org/ontouml-models/distribution/6315eee1-0888-4e10-8894-a7f30a2c4464>, <https://w3id.org/ontouml-models/distribution/8d90a6b8-4b97-4ea9-9eb1-1da07c88dbde>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/daca2352-8735-4a4b-a1c2-952862fb594f> dcat:distribution <https://w3id.org/ontouml-models/distribution/4dbee2f8-a170-4836-89fd-9877152a1a76/>,
+                      <https://w3id.org/ontouml-models/distribution/aabc4dad-2beb-477b-b8a7-4aed656cf520/>,
+                      <https://w3id.org/ontouml-models/distribution/66b6d2ce-fb44-47cb-ac54-1502a7cac6d9/>,
+                      <https://w3id.org/ontouml-models/distribution/6315eee1-0888-4e10-8894-a7f30a2c4464>,
+                      <https://w3id.org/ontouml-models/distribution/8d90a6b8-4b97-4ea9-9eb1-1da07c88dbde> .

--- a/models/nardi2015ufo-s/metadata.ttl
+++ b/models/nardi2015ufo-s/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/05b32152-3907-4a0a-915e-c5ff81117ded/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -17,18 +16,49 @@
     dct:issued "2013"^^xsd:gYear;
     dct:modified "2016"^^xsd:gYear;
     dcat:theme lcc:H;
-    skos:editorialNote "The project contains constraints that cannot be serialized into ontouml-schema at the moment of writing.\nAt times, there is no hint in the diagram about a relation's direction, so other diagrams are considered in the decision.\n";
+    skos:editorialNote """The project contains constraints that cannot be serialized into ontouml-schema at the moment of writing.
+At times, there is no hint in the diagram about a relation's direction, so other diagrams are considered in the decision.
+""";
     dct:language "en";
     dcat:landingPage <https://github.com/unibz-core/UFO-S>;
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:contributor <https://dblp.org/pid/65/4688>, <https://dblp.org/pid/229/4259>, <https://dblp.org/pid/11/78>, <https://dblp.org/pid/91/3408>, <https://dblp.org/pid/65/6778>, <https://dblp.org/pid/s/MartenvanSinderen>, <https://dblp.org/pid/p/LuisFerreiraPires>, <https://dblp.org/pid/169/2246>;
+    dct:contributor <https://dblp.org/pid/65/4688>,
+                    <https://dblp.org/pid/229/4259>,
+                    <https://dblp.org/pid/11/78>,
+                    <https://dblp.org/pid/91/3408>,
+                    <https://dblp.org/pid/65/6778>,
+                    <https://dblp.org/pid/s/MartenvanSinderen>,
+                    <https://dblp.org/pid/p/LuisFerreiraPires>,
+                    <https://dblp.org/pid/169/2246>;
     dcat:keyword "services"@en;
+    dct:source <https://doi.org/10.1016/j.is.2015.01.012>,
+               <https://doi.org/10.1109/EDOC.2013.28>,
+               <https://doi.org/10.1016/j.is.2015.09.008>,
+               <https://nemo.inf.ufes.br/files/ufo_s_techreport.pdf>;
     mod:designedForTask ocmv:ConceptualClarification;
     ocmv:context ocmv:Research;
-    dct:source <https://doi.org/10.1016/j.is.2015.01.012>, <https://doi.org/10.1109/EDOC.2013.28>, <https://doi.org/10.1016/j.is.2015.09.008>, <https://nemo.inf.ufes.br/files/ufo_s_techreport.pdf>;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Core;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/nardi2015ufo-s"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/nardi2015ufo-s"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T18:06:35.922283926Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:06:35.922283926Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/05b32152-3907-4a0a-915e-c5ff81117ded> dcat:distribution <https://w3id.org/ontouml-models/distribution/9c05d925-4fcc-4802-afa6-003e56c7b8c2/>, <https://w3id.org/ontouml-models/distribution/c4206f2d-e99d-4daa-8ea5-ce3f080ff4ec/>, <https://w3id.org/ontouml-models/distribution/affd4a46-6d47-452d-87f4-c85889b8dc85/>, <https://w3id.org/ontouml-models/distribution/1f1c53e1-c3a5-4528-9165-e36e2881a7c8>, <https://w3id.org/ontouml-models/distribution/fb1a73ab-5d3c-48db-a6ad-67a3b2afad32>, <https://w3id.org/ontouml-models/distribution/ac005b2b-4a0d-4b89-bb84-f4e5a3fabc30>, <https://w3id.org/ontouml-models/distribution/a51eb2ee-151d-4870-8e47-eeda2872f8cd>, <https://w3id.org/ontouml-models/distribution/8c29e784-ad2b-4cad-8b60-197f231f88f2>, <https://w3id.org/ontouml-models/distribution/225dade6-2550-42c5-8656-2530ad06c2ab>, <https://w3id.org/ontouml-models/distribution/bcf24258-7efd-46dc-ab97-cf7681e82a9b>, <https://w3id.org/ontouml-models/distribution/57c0b833-00c9-4f55-864c-b50b188ee2dc>, <https://w3id.org/ontouml-models/distribution/0ea19bdc-db4c-4753-be93-dd3bea011e6b>, <https://w3id.org/ontouml-models/distribution/ad254988-7bfd-4d4c-b804-f73aaef8815d>, <https://w3id.org/ontouml-models/distribution/ec6cee07-9025-4281-ada9-1a0d18138ca4>, <https://w3id.org/ontouml-models/distribution/c4eb2756-c3af-4f2f-981e-d3da4c3911f2>, <https://w3id.org/ontouml-models/distribution/fef3caeb-4bf3-496a-8a7d-038237cae024>, <https://w3id.org/ontouml-models/distribution/70ff5349-5dc7-4531-bb6f-8db423c52eb6>, <https://w3id.org/ontouml-models/distribution/4778a7bd-64f0-47ad-bc84-6976c4047aba>, <https://w3id.org/ontouml-models/distribution/5dd37385-2026-4bce-a42f-6e91940f0079>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/05b32152-3907-4a0a-915e-c5ff81117ded> dcat:distribution <https://w3id.org/ontouml-models/distribution/9c05d925-4fcc-4802-afa6-003e56c7b8c2/>,
+                      <https://w3id.org/ontouml-models/distribution/c4206f2d-e99d-4daa-8ea5-ce3f080ff4ec/>,
+                      <https://w3id.org/ontouml-models/distribution/affd4a46-6d47-452d-87f4-c85889b8dc85/>,
+                      <https://w3id.org/ontouml-models/distribution/1f1c53e1-c3a5-4528-9165-e36e2881a7c8>,
+                      <https://w3id.org/ontouml-models/distribution/fb1a73ab-5d3c-48db-a6ad-67a3b2afad32>,
+                      <https://w3id.org/ontouml-models/distribution/ac005b2b-4a0d-4b89-bb84-f4e5a3fabc30>,
+                      <https://w3id.org/ontouml-models/distribution/a51eb2ee-151d-4870-8e47-eeda2872f8cd>,
+                      <https://w3id.org/ontouml-models/distribution/8c29e784-ad2b-4cad-8b60-197f231f88f2>,
+                      <https://w3id.org/ontouml-models/distribution/225dade6-2550-42c5-8656-2530ad06c2ab>,
+                      <https://w3id.org/ontouml-models/distribution/bcf24258-7efd-46dc-ab97-cf7681e82a9b>,
+                      <https://w3id.org/ontouml-models/distribution/57c0b833-00c9-4f55-864c-b50b188ee2dc>,
+                      <https://w3id.org/ontouml-models/distribution/0ea19bdc-db4c-4753-be93-dd3bea011e6b>,
+                      <https://w3id.org/ontouml-models/distribution/ad254988-7bfd-4d4c-b804-f73aaef8815d>,
+                      <https://w3id.org/ontouml-models/distribution/ec6cee07-9025-4281-ada9-1a0d18138ca4>,
+                      <https://w3id.org/ontouml-models/distribution/c4eb2756-c3af-4f2f-981e-d3da4c3911f2>,
+                      <https://w3id.org/ontouml-models/distribution/fef3caeb-4bf3-496a-8a7d-038237cae024>,
+                      <https://w3id.org/ontouml-models/distribution/70ff5349-5dc7-4531-bb6f-8db423c52eb6>,
+                      <https://w3id.org/ontouml-models/distribution/4778a7bd-64f0-47ad-bc84-6976c4047aba>,
+                      <https://w3id.org/ontouml-models/distribution/5dd37385-2026-4bce-a42f-6e91940f0079> .

--- a/models/nascimento2023spacecon/metadata.ttl
+++ b/models/nascimento2023spacecon/metadata.ttl
@@ -1,15 +1,16 @@
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/model/nascimento2023spacecon/> a dcat:Dataset, mod:SemanticArtefact;
+<https://w3id.org/ontouml-models/model/nascimento2023spacecon/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
+    dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
     dct:title "Smart Spaces Context Ontology";
     mod:acronym "SpaceCOn";
     dct:issued "2023"^^xsd:gYear;
@@ -17,22 +18,26 @@
     dct:language "en";
     dcat:landingPage <https://github.com/lvnascimento/spacecon>;
     dct:license <https://opensource.org/license/mit>;
-    dct:contributor <https://dblp.org/pid/45/3567>, <https://dblp.org/pid/o/JosePalazzoMoreiradeOliveira>;
-    mod:designedForTask ocmv:ConceptualClarification, ocmv:Interoperability;
+    dct:contributor <https://dblp.org/pid/45/3567>,
+                    <https://dblp.org/pid/o/JosePalazzoMoreiradeOliveira>;
+    dcat:keyword "context"@en,
+                 "context-aware computing"@en,
+                 "quality of context"@en;
+    dct:source <https://doi.org/10.1007/978-3-031-47262-6_19>;
+    mod:designedForTask ocmv:ConceptualClarification,
+                        ocmv:Interoperability;
     ocmv:context ocmv:Research;
-    dct:source <https://doi.org/10.1007/978-3-031-47262-6_19>.
-<https://w3id.org/ontouml-models/model/nascimento2023spacecon/> dcat:distribution <https://w3id.org/ontouml-models/model/nascimento2023spacecon/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/nascimento2023spacecon/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Smart Spaces Context Ontology\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/nascimento2023spacecon/ontology.ttl>.
-<https://w3id.org/ontouml-models/model/nascimento2023spacecon/> dcat:distribution <https://w3id.org/ontouml-models/model/nascimento2023spacecon/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/nascimento2023spacecon/distribution/ttl> a dcat:Distribution;
-    dct:title "JSON distribution of \"Smart Spaces Context Ontology\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/nascimento2023spacecon/ontology.json>.
-<https://w3id.org/ontouml-models/model/nascimento2023spacecon/> dcat:distribution <https://w3id.org/ontouml-models/model/nascimento2023spacecon/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/nascimento2023spacecon/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Smart Spaces Context Ontology\""@en;
-    dcat:mediaType <https://www.visual-paradigm.com/vpp>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/nascimento2023spacecon/ontology.vpp>.
+    ocmv:representationStyle ocmv:OntoumlStyle;
+    ocmv:ontologyType ocmv:Core;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/nascimento2023spacecon"^^xsd:anyURI;
+    fdpo:metadataIssued "2026-06-23T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/nascimento2023spacecon/> dcat:distribution <https://w3id.org/ontouml-models/model/nascimento2023spacecon/distribution/ttl>,
+                      <https://www.iana.org/assignments/media-types/text/turtle>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/nascimento2023spacecon/ontology.ttl>,
+                      <https://w3id.org/ontouml-models/model/nascimento2023spacecon/>,
+                      <https://www.iana.org/assignments/media-types/application/json>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/nascimento2023spacecon/ontology.json>,
+                      <https://www.visual-paradigm.com/vpp>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/nascimento2023spacecon/ontology.vpp> .

--- a/models/nazar2024marchine-learning/metadata.ttl
+++ b/models/nazar2024marchine-learning/metadata.ttl
@@ -1,36 +1,40 @@
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/model/nazar2024marchine-learning/> a dcat:Dataset, mod:SemanticArtefact;
+<https://w3id.org/ontouml-models/model/nazar2024marchine-learning/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
+    dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
     dct:title "Machine Learning Ontology";
     dct:issued "2024"^^xsd:gYear;
     dcat:theme lcc:T;
     skos:editorialNote "This model was developed as part of the Ontologies course at Federal University of Rio de Janeiro.";
     dct:language "pt-br";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:contributor <https://www.linkedin.com/in/antonio-nazar/>, <https://www.linkedin.com/in/gabriel-trindade-corr%C3%AAa-15526b342/>;
+    dct:contributor <https://www.linkedin.com/in/antonio-nazar/>,
+                    <https://www.linkedin.com/in/gabriel-trindade-corr%C3%AAa-15526b342/>;
+    dcat:keyword "machine learning"@en;
     mod:designedForTask ocmv:Learning;
-    ocmv:context ocmv:Classroom.
-<https://w3id.org/ontouml-models/model/nazar2024marchine-learning/> dcat:distribution <https://w3id.org/ontouml-models/model/nazar2024marchine-learning/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/nazar2024marchine-learning/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Machine Learning Ontology\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/nazar2024marchine-learning/ontology.ttl>.
-<https://w3id.org/ontouml-models/model/nazar2024marchine-learning/> dcat:distribution <https://w3id.org/ontouml-models/model/nazar2024marchine-learning/distribution/json>.
-<https://w3id.org/ontouml-models/model/nazar2024marchine-learning/distribution/json> a dcat:Distribution;
-    dct:title "JSON distribution of \"Machine Learning Ontology\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/nazar2024marchine-learning/ontology.json>.
-<https://w3id.org/ontouml-models/model/nazar2024marchine-learning/> dcat:distribution <https://w3id.org/ontouml-models/model/nazar2024marchine-learning/distribution/vpp>.
-<https://w3id.org/ontouml-models/model/nazar2024marchine-learning/distribution/vpp> a dcat:Distribution;
-    dct:title "Visual Paradigm distribution of \"Machine Learning Ontology\""@en;
-    dcat:mediaType <https://www.visual-paradigm.com/vpp>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/nazar2024marchine-learning/ontology.vpp>.
+    ocmv:context ocmv:Classroom;
+    ocmv:representationStyle ocmv:OntoumlStyle;
+    ocmv:ontologyType ocmv:Domain;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/nazar2024marchine-learning"^^xsd:anyURI;
+    fdpo:metadataIssued "2026-06-23T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/nazar2024marchine-learning/> dcat:distribution <https://w3id.org/ontouml-models/model/nazar2024marchine-learning/distribution/ttl>,
+                      <https://www.iana.org/assignments/media-types/text/turtle>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/nazar2024marchine-learning/ontology.ttl>,
+                      <https://w3id.org/ontouml-models/model/nazar2024marchine-learning/>,
+                      <https://w3id.org/ontouml-models/model/nazar2024marchine-learning/distribution/json>,
+                      <https://www.iana.org/assignments/media-types/application/json>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/nazar2024marchine-learning/ontology.json>,
+                      <https://w3id.org/ontouml-models/model/nazar2024marchine-learning/distribution/vpp>,
+                      <https://www.visual-paradigm.com/vpp>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/nazar2024marchine-learning/ontology.vpp> .

--- a/models/neves2020nwpontology/metadata.ttl
+++ b/models/neves2020nwpontology/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/7f3cddbe-6810-45a9-9a7d-08b996705c77/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -16,17 +15,24 @@
     dct:issued "2020"^^xsd:gYear;
     dct:modified "2020"^^xsd:gYear;
     dcat:theme lcc:Q;
-    skos:editorialNote "";
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:contributor <https://dblp.org/pid/278/1718>, <https://dblp.org/pid/117/6100>, <https://dblp.org/pid/43/7740>;
+    dct:contributor <https://dblp.org/pid/278/1718>,
+                    <https://dblp.org/pid/117/6100>,
+                    <https://dblp.org/pid/43/7740>;
     dcat:keyword "weather prediction"@en;
-    mod:designedForTask ocmv:ConceptualClarification, ocmv:Interoperability;
-    ocmv:context ocmv:Research;
     dct:source <https://dblp.org/rec/conf/ontobras/NevesBC20>;
+    mod:designedForTask ocmv:ConceptualClarification,
+                        ocmv:Interoperability;
+    ocmv:context ocmv:Research;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/neves2020nwpontology"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/neves2020nwpontology"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T18:07:07.247861482Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:07:07.247861482Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/7f3cddbe-6810-45a9-9a7d-08b996705c77> dcat:distribution <https://w3id.org/ontouml-models/distribution/3196e4b2-9bf3-4c27-b5fe-72951bfb0d3f/>, <https://w3id.org/ontouml-models/distribution/7540d5b3-3712-4606-ae9d-8aa0bd2d6b82/>, <https://w3id.org/ontouml-models/distribution/3e955514-56df-457e-94b3-3da2f0517b97/>, <https://w3id.org/ontouml-models/distribution/2b8f8376-3147-407d-a1e4-98cde1592438>, <https://w3id.org/ontouml-models/distribution/8c9c8bd2-3388-4731-a7f3-618f05579c0d>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/7f3cddbe-6810-45a9-9a7d-08b996705c77> dcat:distribution <https://w3id.org/ontouml-models/distribution/3196e4b2-9bf3-4c27-b5fe-72951bfb0d3f/>,
+                      <https://w3id.org/ontouml-models/distribution/7540d5b3-3712-4606-ae9d-8aa0bd2d6b82/>,
+                      <https://w3id.org/ontouml-models/distribution/3e955514-56df-457e-94b3-3da2f0517b97/>,
+                      <https://w3id.org/ontouml-models/distribution/2b8f8376-3147-407d-a1e4-98cde1592438>,
+                      <https://w3id.org/ontouml-models/distribution/8c9c8bd2-3388-4731-a7f3-618f05579c0d> .

--- a/models/neves2021grain-production/metadata.ttl
+++ b/models/neves2021grain-production/metadata.ttl
@@ -1,32 +1,39 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/1d378243-6061-4e3a-b32e-05436601d9d9/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:title "Grain Production Ontology";
     dct:issued "2021"^^xsd:gYear;
     dct:modified "2021"^^xsd:gYear;
     dcat:theme lcc:S;
     skos:editorialNote "I inferred the association direction from their names. For instance, I assumed that the association named 'Crop-Digital_Images' had 'Crop' as its source and 'Digital_Images' as its target.";
     dct:language "en";
-    dct:contributor <https://dblp.org/pid/261/1068>, <https://dblp.org/pid/92/1196>;
-    dcat:keyword "agriculture"@en, "grain production"@en;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    dct:contributor <https://dblp.org/pid/261/1068>,
+                    <https://dblp.org/pid/92/1196>;
+    dcat:keyword "agriculture"@en,
+                 "grain production"@en;
+    dct:source <https://doi.org/10.1109/ICSC50631.2021.00071>;
     mod:designedForTask ocmv:DecisionSupportSystem;
     ocmv:context ocmv:Research;
-    dct:source <https://doi.org/10.1109/ICSC50631.2021.00071>;
     ocmv:representationStyle ocmv:OntoumlStyle;
-    ocmv:ontologyType ocmv:Domain, ocmv:Application;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/neves2021grain-production"^^xsd:anyURI ;
+    ocmv:ontologyType ocmv:Domain,
+                      ocmv:Application;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/neves2021grain-production"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T18:07:16.678198598Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:07:16.678198598Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/1d378243-6061-4e3a-b32e-05436601d9d9> dcat:distribution <https://w3id.org/ontouml-models/distribution/1e79d4ec-d6c5-4f71-8696-900f0458dfe7/>, <https://w3id.org/ontouml-models/distribution/38a5d0e0-26f8-4daa-8df1-b9bdd147db31/>, <https://w3id.org/ontouml-models/distribution/1a05466b-d6ad-4948-a5fc-0dfec77596e3/>, <https://w3id.org/ontouml-models/distribution/c43ad639-7df9-4fb8-a923-894bd5166e45>, <https://w3id.org/ontouml-models/distribution/93ab29e4-4762-41c9-9687-0eaac5564e87>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/1d378243-6061-4e3a-b32e-05436601d9d9> dcat:distribution <https://w3id.org/ontouml-models/distribution/1e79d4ec-d6c5-4f71-8696-900f0458dfe7/>,
+                      <https://w3id.org/ontouml-models/distribution/38a5d0e0-26f8-4daa-8df1-b9bdd147db31/>,
+                      <https://w3id.org/ontouml-models/distribution/1a05466b-d6ad-4948-a5fc-0dfec77596e3/>,
+                      <https://w3id.org/ontouml-models/distribution/c43ad639-7df9-4fb8-a923-894bd5166e45>,
+                      <https://w3id.org/ontouml-models/distribution/93ab29e4-4762-41c9-9687-0eaac5564e87> .

--- a/models/niederkofler2019dssapple/metadata.ttl
+++ b/models/niederkofler2019dssapple/metadata.ttl
@@ -1,32 +1,52 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/5f97c733-db8a-44cc-b94d-a28b7d3e85cc/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:title "DSSApple Ontology";
     dct:issued "2019"^^xsd:gYear;
     dct:modified "2019"^^xsd:gYear;
     dcat:theme lcc:S;
     skos:editorialNote "diagrams visualization not easy to replicate via vpp. By using \"Styles and Formatting\" > \"Curve\" the layout was partially replicated.";
     dct:language "en";
-    dct:contributor <https://dblp.org/pid/255/6389>, <https://dblp.org/pid/227/0572>, <https://dblp.org/pid/11/78>, <https://dblp.org/pid/204/3801>, <https://dblp.org/pid/90/3147>;
-    dcat:keyword "apple"@en, "apple harvest"@en, "apple diseases"@en, "agriculture"@en;
-    mod:designedForTask ocmv:OntologicalAnalysis, ocmv:ConceptualClarification;
-    ocmv:context ocmv:Research;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    dct:contributor <https://dblp.org/pid/255/6389>,
+                    <https://dblp.org/pid/227/0572>,
+                    <https://dblp.org/pid/11/78>,
+                    <https://dblp.org/pid/204/3801>,
+                    <https://dblp.org/pid/90/3147>;
+    dcat:keyword "apple"@en,
+                 "apple harvest"@en,
+                 "apple diseases"@en,
+                 "agriculture"@en;
     dct:source <https://dblp.org/rec/conf/jowo/NiederkoflerBGS19>;
+    mod:designedForTask ocmv:OntologicalAnalysis,
+                        ocmv:ConceptualClarification;
+    ocmv:context ocmv:Research;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/niederkofler2019dssapple"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/niederkofler2019dssapple"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T18:07:26.392881968Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:07:26.392881968Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/5f97c733-db8a-44cc-b94d-a28b7d3e85cc> dcat:distribution <https://w3id.org/ontouml-models/distribution/cb560e3e-8fad-4d7c-9168-35be47fc94fc/>, <https://w3id.org/ontouml-models/distribution/36860b97-38e6-472a-9c2b-341eef7e90b0/>, <https://w3id.org/ontouml-models/distribution/492d606a-a498-4ebc-91d5-4a06d6066561/>, <https://w3id.org/ontouml-models/distribution/29e15945-6397-47e0-a698-8294c6d0d5db>, <https://w3id.org/ontouml-models/distribution/d99669c8-e78a-4359-bb23-6befe93bea0e>, <https://w3id.org/ontouml-models/distribution/afd3ef2e-09d3-4680-82ff-f4e849433f28>, <https://w3id.org/ontouml-models/distribution/59ae34ad-f83a-4b9b-b0aa-37f92a45ae86>, <https://w3id.org/ontouml-models/distribution/9773c084-5df1-42d7-9844-fcd8e43e9b0b>, <https://w3id.org/ontouml-models/distribution/684997b1-4606-4be4-a9c2-db36a5a996d5>, <https://w3id.org/ontouml-models/distribution/99aa0a36-37e0-45e4-8c24-54e5c262653c>, <https://w3id.org/ontouml-models/distribution/deedff70-f964-454f-8327-d63ad9e7fb8a>, <https://w3id.org/ontouml-models/distribution/6611ee0b-4cd1-4875-97e2-222326151354>, <https://w3id.org/ontouml-models/distribution/f58981c1-7752-4ffe-a8e2-5e2e342ad0fd>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/5f97c733-db8a-44cc-b94d-a28b7d3e85cc> dcat:distribution <https://w3id.org/ontouml-models/distribution/cb560e3e-8fad-4d7c-9168-35be47fc94fc/>,
+                      <https://w3id.org/ontouml-models/distribution/36860b97-38e6-472a-9c2b-341eef7e90b0/>,
+                      <https://w3id.org/ontouml-models/distribution/492d606a-a498-4ebc-91d5-4a06d6066561/>,
+                      <https://w3id.org/ontouml-models/distribution/29e15945-6397-47e0-a698-8294c6d0d5db>,
+                      <https://w3id.org/ontouml-models/distribution/d99669c8-e78a-4359-bb23-6befe93bea0e>,
+                      <https://w3id.org/ontouml-models/distribution/afd3ef2e-09d3-4680-82ff-f4e849433f28>,
+                      <https://w3id.org/ontouml-models/distribution/59ae34ad-f83a-4b9b-b0aa-37f92a45ae86>,
+                      <https://w3id.org/ontouml-models/distribution/9773c084-5df1-42d7-9844-fcd8e43e9b0b>,
+                      <https://w3id.org/ontouml-models/distribution/684997b1-4606-4be4-a9c2-db36a5a996d5>,
+                      <https://w3id.org/ontouml-models/distribution/99aa0a36-37e0-45e4-8c24-54e5c262653c>,
+                      <https://w3id.org/ontouml-models/distribution/deedff70-f964-454f-8327-d63ad9e7fb8a>,
+                      <https://w3id.org/ontouml-models/distribution/6611ee0b-4cd1-4875-97e2-222326151354>,
+                      <https://w3id.org/ontouml-models/distribution/f58981c1-7752-4ffe-a8e2-5e2e342ad0fd> .

--- a/models/o3ontology2015/metadata.ttl
+++ b/models/o3ontology2015/metadata.ttl
@@ -1,35 +1,40 @@
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/model/o3ontology2015/> a dcat:Dataset, mod:SemanticArtefact;
+<https://w3id.org/ontouml-models/model/o3ontology2015/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
+    dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
     dct:title "O3 Ontology";
     dct:issued "2015"^^xsd:gYear;
     dcat:theme lcc:H;
     skos:editorialNote "Author wanted to remain anonymous. The ontology was build in a different editor tool and imported to Visual Paradigm, the current diagrammation may not exactly match the original one.";
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    mod:designedForTask ocmv:ConceptualClarification, ocmv:SoftwareEngineering;
-    ocmv:context ocmv:Research.
-<https://w3id.org/ontouml-models/model/o3ontology2015/> dcat:distribution <https://w3id.org/ontouml-models/model/o3ontology2015/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/o3ontology2015/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"O3 Ontology\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/o3ontology2015/ontology.ttl>.
-<https://w3id.org/ontouml-models/model/o3ontology2015/> dcat:distribution <https://w3id.org/ontouml-models/model/o3ontology2015/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/o3ontology2015/distribution/ttl> a dcat:Distribution;
-    dct:title "JSON distribution of \"O3 Ontology\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/o3ontology2015/ontology.json>.
-<https://w3id.org/ontouml-models/model/o3ontology2015/> dcat:distribution <https://w3id.org/ontouml-models/model/o3ontology2015/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/o3ontology2015/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"O3 Ontology\""@en;
-    dcat:mediaType <https://www.visual-paradigm.com/vpp>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/o3ontology2015/ontology.vpp>.
+    dcat:keyword "organization"@en,
+                 "business"@en,
+                 "enterprise"@en;
+    mod:designedForTask ocmv:ConceptualClarification,
+                        ocmv:SoftwareEngineering;
+    ocmv:context ocmv:Research;
+    ocmv:representationStyle ocmv:UfoStyle,
+                             ocmv:OntoumlStyle;
+    ocmv:ontologyType ocmv:Domain;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/o3ontology2015"^^xsd:anyURI;
+    fdpo:metadataIssued "2026-06-23T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/o3ontology2015/> dcat:distribution <https://w3id.org/ontouml-models/model/o3ontology2015/distribution/ttl>,
+                      <https://www.iana.org/assignments/media-types/text/turtle>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/o3ontology2015/ontology.ttl>,
+                      <https://w3id.org/ontouml-models/model/o3ontology2015/>,
+                      <https://www.iana.org/assignments/media-types/application/json>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/o3ontology2015/ontology.json>,
+                      <https://www.visual-paradigm.com/vpp>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/o3ontology2015/ontology.vpp> .

--- a/models/oliveira2007collaboration/metadata.ttl
+++ b/models/oliveira2007collaboration/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/1823a511-3915-42e1-978b-0dcee8d5bd97/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -19,14 +18,25 @@
     skos:editorialNote "This ontology has an interest example of datatype that may have as instances values that are enumarated or not. Maybe this sort of \"categories\" of qualities mapped into continuous or discrete spaces should be captured through qualities.";
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:contributor <https://dblp.org/pid/75/5043>, <https://www.linkedin.com/in/felipefo>, <https://dblp.org/pid/00/7501>;
-    dcat:keyword "collaboration"@en, "cooperation"@en, "communication"@en;
+    dct:contributor <https://dblp.org/pid/75/5043>,
+                    <https://www.linkedin.com/in/felipefo>,
+                    <https://dblp.org/pid/00/7501>;
+    dcat:keyword "collaboration"@en,
+                 "cooperation"@en,
+                 "communication"@en;
+    dct:source <https://nemo.inf.ufes.br/wp-content/papercite-data/pdf/towards_a_collaboration_ontology_2007.pdf>;
     mod:designedForTask ocmv:Interoperability;
     ocmv:context ocmv:Research;
-    dct:source <https://nemo.inf.ufes.br/wp-content/papercite-data/pdf/towards_a_collaboration_ontology_2007.pdf>;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/oliveira2007collaboration"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/oliveira2007collaboration"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T18:07:48.613048205Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:07:48.613048205Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/1823a511-3915-42e1-978b-0dcee8d5bd97> dcat:distribution <https://w3id.org/ontouml-models/distribution/ebf17084-aa6e-49bf-a39f-5680cd3bd611/>, <https://w3id.org/ontouml-models/distribution/a2e589e3-b883-4d89-aacf-a8fbf9af2691/>, <https://w3id.org/ontouml-models/distribution/2c2b0c3e-e9f8-445f-9985-98bb49d69767/>, <https://w3id.org/ontouml-models/distribution/29dbecd6-bc92-4bc2-827c-f2be4d46d96e>, <https://w3id.org/ontouml-models/distribution/99a30d15-b09f-4faa-8a36-f59d323237ea>, <https://w3id.org/ontouml-models/distribution/8139a9a0-4f6b-486a-a648-1385827f4563>, <https://w3id.org/ontouml-models/distribution/a837ef91-b0ab-4b53-b4af-f85154ab35b2>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/1823a511-3915-42e1-978b-0dcee8d5bd97> dcat:distribution <https://w3id.org/ontouml-models/distribution/ebf17084-aa6e-49bf-a39f-5680cd3bd611/>,
+                      <https://w3id.org/ontouml-models/distribution/a2e589e3-b883-4d89-aacf-a8fbf9af2691/>,
+                      <https://w3id.org/ontouml-models/distribution/2c2b0c3e-e9f8-445f-9985-98bb49d69767/>,
+                      <https://w3id.org/ontouml-models/distribution/29dbecd6-bc92-4bc2-827c-f2be4d46d96e>,
+                      <https://w3id.org/ontouml-models/distribution/99a30d15-b09f-4faa-8a36-f59d323237ea>,
+                      <https://w3id.org/ontouml-models/distribution/8139a9a0-4f6b-486a-a648-1385827f4563>,
+                      <https://w3id.org/ontouml-models/distribution/a837ef91-b0ab-4b53-b4af-f85154ab35b2> .

--- a/models/oliveira2022rose/metadata.ttl
+++ b/models/oliveira2022rose/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/cdd96c73-7f49-4f22-8748-1bd39eec9ceb/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -20,14 +19,32 @@
     dct:language "en";
     dcat:landingPage <https://github.com/unibz-core/security-ontology>;
     dct:license <https://opensource.org/license/mit>;
-    dct:contributor <https://dblp.org/pid/212/6684>, <https://dblp.org/pid/134/4947>, <https://dblp.org/pid/255/6391>, <https://dblp.org/pid/161/4517>, <https://dblp.org/pid/11/78>;
-    dcat:keyword "risk"@en, "value"@en, "security"@en, "safety"@en;
-    mod:designedForTask ocmv:ConceptualClarification, ocmv:OntologicalAnalysis;
-    ocmv:context ocmv:Research;
+    dct:contributor <https://dblp.org/pid/212/6684>,
+                    <https://dblp.org/pid/134/4947>,
+                    <https://dblp.org/pid/255/6391>,
+                    <https://dblp.org/pid/161/4517>,
+                    <https://dblp.org/pid/11/78>;
+    dcat:keyword "risk"@en,
+                 "value"@en,
+                 "security"@en,
+                 "safety"@en;
     dct:source <https://doi.org/10.1007/978-3-031-17995-2_26>;
+    mod:designedForTask ocmv:ConceptualClarification,
+                        ocmv:OntologicalAnalysis;
+    ocmv:context ocmv:Research;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Core;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/oliveira2022rose"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/oliveira2022rose"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T18:08:01.407519553Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:08:01.407519553Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/cdd96c73-7f49-4f22-8748-1bd39eec9ceb> dcat:distribution <https://w3id.org/ontouml-models/distribution/6865a8b2-d930-4316-9309-9beca149a9ab/>, <https://w3id.org/ontouml-models/distribution/03d70308-94fa-425d-975c-56f7d25d544d/>, <https://w3id.org/ontouml-models/distribution/acf43795-f64d-44c1-b9ad-d71b3ebf7068/>, <https://w3id.org/ontouml-models/distribution/cffc9d3d-0616-4417-8a68-3b0ebd4f9276>, <https://w3id.org/ontouml-models/distribution/3d72e78d-3fc8-402d-87bf-ae989d944da9>, <https://w3id.org/ontouml-models/distribution/d7be48c6-19f7-4550-8cfd-57f1cc8d361e>, <https://w3id.org/ontouml-models/distribution/f2f321e1-6360-43f4-92d1-199a325aba56>, <https://w3id.org/ontouml-models/distribution/82992107-7ab0-4593-91a9-abf768485261>, <https://w3id.org/ontouml-models/distribution/2227cf7d-f77d-494f-a9cb-5af658b43ef2>, <https://w3id.org/ontouml-models/distribution/c23e6e96-3f93-476d-be7d-95647b6a329c>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/cdd96c73-7f49-4f22-8748-1bd39eec9ceb> dcat:distribution <https://w3id.org/ontouml-models/distribution/6865a8b2-d930-4316-9309-9beca149a9ab/>,
+                      <https://w3id.org/ontouml-models/distribution/03d70308-94fa-425d-975c-56f7d25d544d/>,
+                      <https://w3id.org/ontouml-models/distribution/acf43795-f64d-44c1-b9ad-d71b3ebf7068/>,
+                      <https://w3id.org/ontouml-models/distribution/cffc9d3d-0616-4417-8a68-3b0ebd4f9276>,
+                      <https://w3id.org/ontouml-models/distribution/3d72e78d-3fc8-402d-87bf-ae989d944da9>,
+                      <https://w3id.org/ontouml-models/distribution/d7be48c6-19f7-4550-8cfd-57f1cc8d361e>,
+                      <https://w3id.org/ontouml-models/distribution/f2f321e1-6360-43f4-92d1-199a325aba56>,
+                      <https://w3id.org/ontouml-models/distribution/82992107-7ab0-4593-91a9-abf768485261>,
+                      <https://w3id.org/ontouml-models/distribution/2227cf7d-f77d-494f-a9cb-5af658b43ef2>,
+                      <https://w3id.org/ontouml-models/distribution/c23e6e96-3f93-476d-be7d-95647b6a329c> .

--- a/models/oliveira2024phishing/metadata.ttl
+++ b/models/oliveira2024phishing/metadata.ttl
@@ -1,15 +1,16 @@
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/model/oliveira2024phishing/> a dcat:Dataset, mod:SemanticArtefact;
+<https://w3id.org/ontouml-models/model/oliveira2024phishing/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
+    dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
     dct:title "Phishing Attack Process Ontology";
     mod:acronym "PAPO";
     dct:issued "2024"^^xsd:gYear;
@@ -19,22 +20,39 @@
     dct:language "en";
     dcat:landingPage <http://w3id.org/phishing-process-ontology/git>;
     dct:license <https://www.apache.org/licenses/LICENSE-2.0>;
-    dct:contributor <https://dblp.org/pid/212/6684>, <https://dblp.org/pid/w/GerdWagner>, <https://dblp.org/pid/81/4277>, <https://dblp.org/pid/134/4947>, <https://dblp.org/pid/150/9376>, <https://dblp.org/pid/136/9942>, <https://dblp.org/pid/97/8574>, <https://dblp.org/pid/17/3761>, <https://dblp.org/pid/11/78>;
-    mod:designedForTask ocmv:ConceptualClarification, ocmv:OntologicalAnalysis, ocmv:Interoperability;
+    dct:contributor <https://dblp.org/pid/212/6684>,
+                    <https://dblp.org/pid/w/GerdWagner>,
+                    <https://dblp.org/pid/81/4277>,
+                    <https://dblp.org/pid/134/4947>,
+                    <https://dblp.org/pid/150/9376>,
+                    <https://dblp.org/pid/136/9942>,
+                    <https://dblp.org/pid/97/8574>,
+                    <https://dblp.org/pid/17/3761>,
+                    <https://dblp.org/pid/11/78>;
+    dcat:keyword "phishing"@en,
+                 "social engineering"@en,
+                 "trust"@en,
+                 "vulnerability"@en,
+                 "cybersecurity"@en,
+                 "protection"@en;
+    dct:source <https://www.researchgate.net/profile/Italo-Oliveira-11/publication/391590969_An_Ontological_Model_of_the_Phishing_Attack_Process/links/681dbae0d1054b0207ece94b/An-Ontological-Model-of-the-Phishing-Attack-Process.pdf>;
+    mod:designedForTask ocmv:ConceptualClarification,
+                        ocmv:OntologicalAnalysis,
+                        ocmv:Interoperability;
     ocmv:context ocmv:Research;
-    dct:source <https://www.researchgate.net/profile/Italo-Oliveira-11/publication/391590969_An_Ontological_Model_of_the_Phishing_Attack_Process/links/681dbae0d1054b0207ece94b/An-Ontological-Model-of-the-Phishing-Attack-Process.pdf>.
-<https://w3id.org/ontouml-models/model/oliveira2024phishing/> dcat:distribution <https://w3id.org/ontouml-models/model/oliveira2024phishing/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/oliveira2024phishing/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Phishing Attack Process Ontology\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/oliveira2024phishing/ontology.ttl>.
-<https://w3id.org/ontouml-models/model/oliveira2024phishing/> dcat:distribution <https://w3id.org/ontouml-models/model/oliveira2024phishing/distribution/json>.
-<https://w3id.org/ontouml-models/model/oliveira2024phishing/distribution/json> a dcat:Distribution;
-    dct:title "JSON distribution of \"Phishing Attack Process Ontology\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/oliveira2024phishing/ontology.json>.
-<https://w3id.org/ontouml-models/model/oliveira2024phishing/> dcat:distribution <https://w3id.org/ontouml-models/model/oliveira2024phishing/distribution/vpp>.
-<https://w3id.org/ontouml-models/model/oliveira2024phishing/distribution/vpp> a dcat:Distribution;
-    dct:title "Visual Paradigm distribution of \"Phishing Attack Process Ontology\""@en;
-    dcat:mediaType <https://www.visual-paradigm.com/vpp>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/oliveira2024phishing/ontology.vpp>.
+    ocmv:representationStyle ocmv:OntoumlStyle;
+    ocmv:ontologyType ocmv:Core;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/oliveira2024phishing"^^xsd:anyURI;
+    fdpo:metadataIssued "2026-06-23T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/oliveira2024phishing/> dcat:distribution <https://w3id.org/ontouml-models/model/oliveira2024phishing/distribution/ttl>,
+                      <https://www.iana.org/assignments/media-types/text/turtle>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/oliveira2024phishing/ontology.ttl>,
+                      <https://w3id.org/ontouml-models/model/oliveira2024phishing/>,
+                      <https://w3id.org/ontouml-models/model/oliveira2024phishing/distribution/json>,
+                      <https://www.iana.org/assignments/media-types/application/json>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/oliveira2024phishing/ontology.json>,
+                      <https://w3id.org/ontouml-models/model/oliveira2024phishing/distribution/vpp>,
+                      <https://www.visual-paradigm.com/vpp>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/oliveira2024phishing/ontology.vpp> .

--- a/models/online-mentoring/metadata.ttl
+++ b/models/online-mentoring/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/68e2c350-96a5-495f-b573-b2b14bfde3e2/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -18,12 +17,18 @@
     skos:editorialNote "The ontology was developed as a course assignment.";
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0>;
-    dcat:keyword "online mentoring"@en, "education"@en;
+    dcat:keyword "online mentoring"@en,
+                 "education"@en;
     mod:designedForTask ocmv:ConceptualClarification;
     ocmv:context ocmv:Classroom;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/online-mentoring"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/online-mentoring"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T18:08:18.555620709Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:08:18.555620709Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/68e2c350-96a5-495f-b573-b2b14bfde3e2> dcat:distribution <https://w3id.org/ontouml-models/distribution/0edd8dd8-5606-43d8-b525-033a487323f7/>, <https://w3id.org/ontouml-models/distribution/8cdffeeb-6c5a-4eaa-bdc9-791a36e15f02/>, <https://w3id.org/ontouml-models/distribution/96bac99f-b93f-42bd-9d4b-6a106dfa4f18/>, <https://w3id.org/ontouml-models/distribution/1efc856e-13d1-4ef6-8100-524f26f20698>, <https://w3id.org/ontouml-models/distribution/41c931c6-70f7-4917-9b45-8f5ed7ed99f3>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/68e2c350-96a5-495f-b573-b2b14bfde3e2> dcat:distribution <https://w3id.org/ontouml-models/distribution/0edd8dd8-5606-43d8-b525-033a487323f7/>,
+                      <https://w3id.org/ontouml-models/distribution/8cdffeeb-6c5a-4eaa-bdc9-791a36e15f02/>,
+                      <https://w3id.org/ontouml-models/distribution/96bac99f-b93f-42bd-9d4b-6a106dfa4f18/>,
+                      <https://w3id.org/ontouml-models/distribution/1efc856e-13d1-4ef6-8100-524f26f20698>,
+                      <https://w3id.org/ontouml-models/distribution/41c931c6-70f7-4917-9b45-8f5ed7ed99f3> .

--- a/models/parking-business2013/metadata.ttl
+++ b/models/parking-business2013/metadata.ttl
@@ -1,35 +1,39 @@
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/model/parking-business2013/> a dcat:Dataset, mod:SemanticArtefact;
+<https://w3id.org/ontouml-models/model/parking-business2013/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
+    dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
     dct:title "Parking Business Ontology";
     dct:issued "2013"^^xsd:gYear;
     dcat:theme lcc:H;
     skos:editorialNote "Ontology created during a lecture by students who wanted to remain anonymous. The ontology was build in a different editor tool and imported to Visual Paradigm, the current diagrammation may not exactly match the original one.";
     dct:language "pt-br";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    mod:designedForTask ocmv:ConceptualClarification, ocmv:Learning;
-    ocmv:context ocmv:Classroom.
-<https://w3id.org/ontouml-models/model/parking-business2013/> dcat:distribution <https://w3id.org/ontouml-models/model/parking-business2013/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/parking-business2013/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Parking Business Ontology\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/parking-business2013/ontology.ttl>.
-<https://w3id.org/ontouml-models/model/parking-business2013/> dcat:distribution <https://w3id.org/ontouml-models/model/parking-business2013/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/parking-business2013/distribution/ttl> a dcat:Distribution;
-    dct:title "JSON distribution of \"Parking Business Ontology\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/parking-business2013/ontology.json>.
-<https://w3id.org/ontouml-models/model/parking-business2013/> dcat:distribution <https://w3id.org/ontouml-models/model/parking-business2013/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/parking-business2013/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Parking Business Ontology\""@en;
-    dcat:mediaType <https://www.visual-paradigm.com/vpp>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/parking-business2013/ontology.vpp>.
+    dcat:keyword "parking lot"@en,
+                 "vehicle"@en,
+                 "business"@en;
+    mod:designedForTask ocmv:ConceptualClarification,
+                        ocmv:Learning;
+    ocmv:context ocmv:Classroom;
+    ocmv:representationStyle ocmv:OntoumlStyle;
+    ocmv:ontologyType ocmv:Domain;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/parking-business2013"^^xsd:anyURI;
+    fdpo:metadataIssued "2026-06-23T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/parking-business2013/> dcat:distribution <https://w3id.org/ontouml-models/model/parking-business2013/distribution/ttl>,
+                      <https://www.iana.org/assignments/media-types/text/turtle>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/parking-business2013/ontology.ttl>,
+                      <https://w3id.org/ontouml-models/model/parking-business2013/>,
+                      <https://www.iana.org/assignments/media-types/application/json>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/parking-business2013/ontology.json>,
+                      <https://www.visual-paradigm.com/vpp>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/parking-business2013/ontology.vpp> .

--- a/models/peixoto2025anchorlogy/metadata.ttl
+++ b/models/peixoto2025anchorlogy/metadata.ttl
@@ -1,15 +1,16 @@
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/model/peixoto2025anchorlogy/> a dcat:Dataset, mod:SemanticArtefact;
+<https://w3id.org/ontouml-models/model/peixoto2025anchorlogy/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
+    dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
     dct:title "Anchorlogy Ontology for Anchoring Bias in Forecasting";
     mod:acronym "Anchorlogy";
     dct:issued "2025"^^xsd:gYear;
@@ -17,22 +18,31 @@
     skos:editorialNote "This ontology aims to represent the context-dependent nature of anchoring bias in human and artificial forecasting decisions.";
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:contributor <https://dblp.org/pid/0009-0005-4081-6615>, <https://dblp.org/pid/0000-0001-7932-7134>, <https://dblp.org/pid/0000-0002-5804-5741>, <https://dblp.org/pid/0000-0002-3452-553X>;
-    mod:designedForTask ocmv:ConceptualClarification, ocmv:OntologicalAnalysis;
+    dct:contributor <https://dblp.org/pid/0009-0005-4081-6615>,
+                    <https://dblp.org/pid/0000-0001-7932-7134>,
+                    <https://dblp.org/pid/0000-0002-5804-5741>,
+                    <https://dblp.org/pid/0000-0002-3452-553X>;
+    dcat:keyword "anchoring bias"@en,
+                 "belief formation"@en,
+                 "decision-making process"@en,
+                 "human judgment"@en;
+    dct:source <https://www.researchgate.net/profile/Giancarlo-Guizzardi-2/publication/390767962_Anchorlogy_An_ontology_for_anchoring_bias_detection_in_forecasting/links/67fd51bd60241d51400c4b0c/Anchorlogy-An-ontology-for-anchoring-bias-detection-in-forecasting.pdf>;
+    mod:designedForTask ocmv:ConceptualClarification,
+                        ocmv:OntologicalAnalysis;
     ocmv:context ocmv:Research;
-    dct:source <https://www.researchgate.net/profile/Giancarlo-Guizzardi-2/publication/390767962_Anchorlogy_An_ontology_for_anchoring_bias_detection_in_forecasting/links/67fd51bd60241d51400c4b0c/Anchorlogy-An-ontology-for-anchoring-bias-detection-in-forecasting.pdf>.
-<https://w3id.org/ontouml-models/model/peixoto2025anchorlogy/> dcat:distribution <https://w3id.org/ontouml-models/model/peixoto2025anchorlogy/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/peixoto2025anchorlogy/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Anchorlogy Ontology for Anchoring Bias in Forecasting\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/peixoto2025anchorlogy/ontology.ttl>.
-<https://w3id.org/ontouml-models/model/peixoto2025anchorlogy/> dcat:distribution <https://w3id.org/ontouml-models/model/peixoto2025anchorlogy/distribution/json>.
-<https://w3id.org/ontouml-models/model/peixoto2025anchorlogy/distribution/json> a dcat:Distribution;
-    dct:title "JSON distribution of \"Anchorlogy Ontology for Anchoring Bias in Forecasting\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/peixoto2025anchorlogy/ontology.json>.
-<https://w3id.org/ontouml-models/model/peixoto2025anchorlogy/> dcat:distribution <https://w3id.org/ontouml-models/model/peixoto2025anchorlogy/distribution/vpp>.
-<https://w3id.org/ontouml-models/model/peixoto2025anchorlogy/distribution/vpp> a dcat:Distribution;
-    dct:title "Visual Paradigm distribution of \"Anchorlogy Ontology for Anchoring Bias in Forecasting\""@en;
-    dcat:mediaType <https://www.visual-paradigm.com/vpp>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/peixoto2025anchorlogy/ontology.vpp>.
+    ocmv:representationStyle ocmv:OntoumlStyle;
+    ocmv:ontologyType ocmv:Domain;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/peixoto2025anchorlogy"^^xsd:anyURI;
+    fdpo:metadataIssued "2026-06-23T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/peixoto2025anchorlogy/> dcat:distribution <https://w3id.org/ontouml-models/model/peixoto2025anchorlogy/distribution/ttl>,
+                      <https://www.iana.org/assignments/media-types/text/turtle>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/peixoto2025anchorlogy/ontology.ttl>,
+                      <https://w3id.org/ontouml-models/model/peixoto2025anchorlogy/>,
+                      <https://w3id.org/ontouml-models/model/peixoto2025anchorlogy/distribution/json>,
+                      <https://www.iana.org/assignments/media-types/application/json>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/peixoto2025anchorlogy/ontology.json>,
+                      <https://w3id.org/ontouml-models/model/peixoto2025anchorlogy/distribution/vpp>,
+                      <https://www.visual-paradigm.com/vpp>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/peixoto2025anchorlogy/ontology.vpp> .

--- a/models/pereira2015doacao-orgaos/metadata.ttl
+++ b/models/pereira2015doacao-orgaos/metadata.ttl
@@ -1,31 +1,40 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/ff633ccf-80c1-4276-b9e2-7bf969b0d05b/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:title "Ontologia de Doação de Órgão e Tecidos";
     dct:issued "2015"^^xsd:gYear;
     dct:modified "2015"^^xsd:gYear;
     dcat:theme lcc:R;
     dct:language "pt-br";
-    dct:contributor <https://dblp.org/pid/74/4999>, <https://dblp.org/pid/63/9777>, <https://dblp.org/pid/234/2383>, <https://dblp.org/pid/232/9234>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    dct:contributor <https://dblp.org/pid/74/4999>,
+                    <https://dblp.org/pid/63/9777>,
+                    <https://dblp.org/pid/234/2383>,
+                    <https://dblp.org/pid/232/9234>;
     dcat:keyword "organ and tissue donation"@en;
+    dct:source <https://dblp.org/rec/conf/cibse/PereiraCJC15>;
     mod:designedForTask ocmv:ConceptualClarification;
     ocmv:context ocmv:Research;
-    dct:source <https://dblp.org/rec/conf/cibse/PereiraCJC15>;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/pereira2015doacao-orgaos"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/pereira2015doacao-orgaos"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T18:08:27.754080944Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:08:27.754080944Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/ff633ccf-80c1-4276-b9e2-7bf969b0d05b> dcat:distribution <https://w3id.org/ontouml-models/distribution/a26bccc2-0f0f-4e02-9044-7c84c52a0dc0/>, <https://w3id.org/ontouml-models/distribution/5a69dd6a-ba39-4a5a-b64e-0647e21862b7/>, <https://w3id.org/ontouml-models/distribution/954b09bd-0586-430b-9cd2-7c4365eaa613/>, <https://w3id.org/ontouml-models/distribution/a032b424-2c43-4cd8-bbcf-469fea40ef0d>, <https://w3id.org/ontouml-models/distribution/bb237183-27c2-472f-a8d3-d99fceff5bbc>, <https://w3id.org/ontouml-models/distribution/68835e65-28c7-4651-b8ff-7b22add04ee4>, <https://w3id.org/ontouml-models/distribution/bd1913a7-6cd5-4d59-a505-a0268675d043>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/ff633ccf-80c1-4276-b9e2-7bf969b0d05b> dcat:distribution <https://w3id.org/ontouml-models/distribution/a26bccc2-0f0f-4e02-9044-7c84c52a0dc0/>,
+                      <https://w3id.org/ontouml-models/distribution/5a69dd6a-ba39-4a5a-b64e-0647e21862b7/>,
+                      <https://w3id.org/ontouml-models/distribution/954b09bd-0586-430b-9cd2-7c4365eaa613/>,
+                      <https://w3id.org/ontouml-models/distribution/a032b424-2c43-4cd8-bbcf-469fea40ef0d>,
+                      <https://w3id.org/ontouml-models/distribution/bb237183-27c2-472f-a8d3-d99fceff5bbc>,
+                      <https://w3id.org/ontouml-models/distribution/68835e65-28c7-4651-b8ff-7b22add04ee4>,
+                      <https://w3id.org/ontouml-models/distribution/bd1913a7-6cd5-4d59-a505-a0268675d043> .

--- a/models/pereira2020ontotrans/metadata.ttl
+++ b/models/pereira2020ontotrans/metadata.ttl
@@ -1,31 +1,39 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/0a01a029-1863-498e-aba5-6e9580f94dc5/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:title "OntoTrans";
     dct:issued "2020"^^xsd:gYear;
     dct:modified "2020"^^xsd:gYear;
     dcat:theme lcc:J;
     dct:language "en";
-    dct:contributor <https://dblp.org/pid/247/3238>, <https://dblp.org/pid/20/5813>, <https://dblp.org/pid/b/FAraujoBaiao>, <https://dblp.org/pid/98/2600>, <https://dblp.org/pid/57/10010>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    dct:contributor <https://dblp.org/pid/247/3238>,
+                    <https://dblp.org/pid/20/5813>,
+                    <https://dblp.org/pid/b/FAraujoBaiao>,
+                    <https://dblp.org/pid/98/2600>,
+                    <https://dblp.org/pid/57/10010>;
     dcat:keyword "government transparency"@en;
+    dct:source <https://dblp.org/rec/conf/amcis/PereiraCBN19>;
     mod:designedForTask ocmv:ConceptualClarification;
     ocmv:context ocmv:Research;
-    dct:source <https://dblp.org/rec/conf/amcis/PereiraCBN19>;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/pereira2020ontotrans"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/pereira2020ontotrans"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T18:08:40.480778512Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:08:40.480778512Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/0a01a029-1863-498e-aba5-6e9580f94dc5> dcat:distribution <https://w3id.org/ontouml-models/distribution/d5a06614-857b-474b-b32b-5336aa4338bf/>, <https://w3id.org/ontouml-models/distribution/e4eb323d-5ebe-4ef5-a32a-06f6324d447e/>, <https://w3id.org/ontouml-models/distribution/9a202f11-e289-4069-938e-fdd72d40f5b7/>, <https://w3id.org/ontouml-models/distribution/27d53ec1-fd5b-45b1-afc8-5689d662d2a9>, <https://w3id.org/ontouml-models/distribution/b0681911-8fbc-469e-8285-752cca933862>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/0a01a029-1863-498e-aba5-6e9580f94dc5> dcat:distribution <https://w3id.org/ontouml-models/distribution/d5a06614-857b-474b-b32b-5336aa4338bf/>,
+                      <https://w3id.org/ontouml-models/distribution/e4eb323d-5ebe-4ef5-a32a-06f6324d447e/>,
+                      <https://w3id.org/ontouml-models/distribution/9a202f11-e289-4069-938e-fdd72d40f5b7/>,
+                      <https://w3id.org/ontouml-models/distribution/27d53ec1-fd5b-45b1-afc8-5689d662d2a9>,
+                      <https://w3id.org/ontouml-models/distribution/b0681911-8fbc-469e-8285-752cca933862> .

--- a/models/photography/metadata.ttl
+++ b/models/photography/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/62dac1a5-a19d-4520-a68b-2bc94844128f/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -22,7 +21,12 @@
     ocmv:context ocmv:Classroom;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/photography"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/photography"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T18:08:49.7686163Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:08:49.7686163Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/62dac1a5-a19d-4520-a68b-2bc94844128f> dcat:distribution <https://w3id.org/ontouml-models/distribution/0fb16505-8029-49c6-8d89-1933658ea08d/>, <https://w3id.org/ontouml-models/distribution/37148a7b-cf18-48d4-ae5c-40c9ce51ac06/>, <https://w3id.org/ontouml-models/distribution/1c2e49e6-a12f-4d6c-ad4b-47e8b450f86e/>, <https://w3id.org/ontouml-models/distribution/28946ba1-feb4-497a-825f-82b8e7e29a40>, <https://w3id.org/ontouml-models/distribution/d6f4ffba-2e7f-4eae-983a-acb462b552ab>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/62dac1a5-a19d-4520-a68b-2bc94844128f> dcat:distribution <https://w3id.org/ontouml-models/distribution/0fb16505-8029-49c6-8d89-1933658ea08d/>,
+                      <https://w3id.org/ontouml-models/distribution/37148a7b-cf18-48d4-ae5c-40c9ce51ac06/>,
+                      <https://w3id.org/ontouml-models/distribution/1c2e49e6-a12f-4d6c-ad4b-47e8b450f86e/>,
+                      <https://w3id.org/ontouml-models/distribution/28946ba1-feb4-497a-825f-82b8e7e29a40>,
+                      <https://w3id.org/ontouml-models/distribution/d6f4ffba-2e7f-4eae-983a-acb462b552ab> .

--- a/models/piest2024dsr-kb/metadata.ttl
+++ b/models/piest2024dsr-kb/metadata.ttl
@@ -1,15 +1,16 @@
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/model/piest2024dsr-kb/> a dcat:Dataset, mod:SemanticArtefact;
+<https://w3id.org/ontouml-models/model/piest2024dsr-kb/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
+    dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
     dct:title "Domain Reference Ontology for Design Science Research Knowledge Bases";
     mod:acronym "DSR-KB";
     dct:issued "2024"^^xsd:gYear;
@@ -17,22 +18,27 @@
     dct:language "en";
     dcat:landingPage <https://github.com/SebastianPiest/dsr-kb>;
     dct:license <https://opensource.org/licenses/MIT>;
-    dct:contributor <https://dblp.org/pid/187/6481>, <https://dblp.org/pid/377/0420>, <https://dblp.org/pid/63/5160>, <https://www.linkedin.com/in/ricardo-junior-cunha/>;
-    mod:designedForTask ocmv:ConceptualClarification, ocmv:OntologicalAnalysis;
+    dct:contributor <https://dblp.org/pid/187/6481>,
+                    <https://dblp.org/pid/377/0420>,
+                    <https://dblp.org/pid/63/5160>,
+                    <https://www.linkedin.com/in/ricardo-junior-cunha/>;
+    dcat:keyword "design science research"@en,
+                 "knowledge base"@en;
+    dct:source <https://www.utwente.nl/en/eemcs/fois2024/resources/papers/piest-et-al-a-domain-reference-ontology-for-design-science-research-knowledge-bases.pdf>;
+    mod:designedForTask ocmv:ConceptualClarification,
+                        ocmv:OntologicalAnalysis;
     ocmv:context ocmv:Research;
-    dct:source <https://www.utwente.nl/en/eemcs/fois2024/resources/papers/piest-et-al-a-domain-reference-ontology-for-design-science-research-knowledge-bases.pdf>.
-<https://w3id.org/ontouml-models/model/piest2024dsr-kb/> dcat:distribution <https://w3id.org/ontouml-models/model/piest2024dsr-kb/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/piest2024dsr-kb/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Domain Reference Ontology for Design Science Research Knowledge Bases\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/piest2024dsr-kb/ontology.ttl>.
-<https://w3id.org/ontouml-models/model/piest2024dsr-kb/> dcat:distribution <https://w3id.org/ontouml-models/model/piest2024dsr-kb/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/piest2024dsr-kb/distribution/ttl> a dcat:Distribution;
-    dct:title "JSON distribution of \"Domain Reference Ontology for Design Science Research Knowledge Bases\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/piest2024dsr-kb/ontology.json>.
-<https://w3id.org/ontouml-models/model/piest2024dsr-kb/> dcat:distribution <https://w3id.org/ontouml-models/model/piest2024dsr-kb/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/piest2024dsr-kb/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Domain Reference Ontology for Design Science Research Knowledge Bases\""@en;
-    dcat:mediaType <https://www.visual-paradigm.com/vpp>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/piest2024dsr-kb/ontology.vpp>.
+    ocmv:representationStyle ocmv:OntoumlStyle;
+    ocmv:ontologyType ocmv:Domain;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/piest2024dsr-kb"^^xsd:anyURI;
+    fdpo:metadataIssued "2026-06-23T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/piest2024dsr-kb/> dcat:distribution <https://w3id.org/ontouml-models/model/piest2024dsr-kb/distribution/ttl>,
+                      <https://www.iana.org/assignments/media-types/text/turtle>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/piest2024dsr-kb/ontology.ttl>,
+                      <https://w3id.org/ontouml-models/model/piest2024dsr-kb/>,
+                      <https://www.iana.org/assignments/media-types/application/json>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/piest2024dsr-kb/ontology.json>,
+                      <https://www.visual-paradigm.com/vpp>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/piest2024dsr-kb/ontology.vpp> .

--- a/models/pinheiro2024api/metadata.ttl
+++ b/models/pinheiro2024api/metadata.ttl
@@ -1,36 +1,43 @@
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/model/pinheiro2024api/> a dcat:Dataset, mod:SemanticArtefact;
+<https://w3id.org/ontouml-models/model/pinheiro2024api/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
+    dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
     dct:title "Reference Ontology for Enterprise Architecture Mining from APIs";
     dct:issued "2024"^^xsd:gYear;
     dcat:theme lcc:T;
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:contributor <https://dblp.org/pid/306/9640>, <https://dblp.org/pid/38/10199>, <https://dblp.org/pid/217/4594>;
+    dct:contributor <https://dblp.org/pid/306/9640>,
+                    <https://dblp.org/pid/38/10199>,
+                    <https://dblp.org/pid/217/4594>;
+    dcat:keyword "api"@en,
+                 "automatic architecture modelling"@en,
+                 "enterprise architecture"@en,
+                 "enterprise architecture management"@en,
+                 "mining"@en;
+    dct:source <https://doi.org/10.1007/978-3-031-64755-0_13>;
     mod:designedForTask ocmv:ConceptualClarification;
     ocmv:context ocmv:Research;
-    dct:source <https://doi.org/10.1007/978-3-031-64755-0_13>.
-<https://w3id.org/ontouml-models/model/pinheiro2024api/> dcat:distribution <https://w3id.org/ontouml-models/model/pinheiro2024api/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/pinheiro2024api/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Reference Ontology for Enterprise Architecture Mining from APIs\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/pinheiro2024api/ontology.ttl>.
-<https://w3id.org/ontouml-models/model/pinheiro2024api/> dcat:distribution <https://w3id.org/ontouml-models/model/pinheiro2024api/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/pinheiro2024api/distribution/ttl> a dcat:Distribution;
-    dct:title "JSON distribution of \"Reference Ontology for Enterprise Architecture Mining from APIs\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/pinheiro2024api/ontology.json>.
-<https://w3id.org/ontouml-models/model/pinheiro2024api/> dcat:distribution <https://w3id.org/ontouml-models/model/pinheiro2024api/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/pinheiro2024api/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Reference Ontology for Enterprise Architecture Mining from APIs\""@en;
-    dcat:mediaType <https://www.visual-paradigm.com/vpp>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/pinheiro2024api/ontology.vpp>.
+    ocmv:representationStyle ocmv:OntoumlStyle;
+    ocmv:ontologyType ocmv:Domain;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/pinheiro2024api"^^xsd:anyURI;
+    fdpo:metadataIssued "2026-06-23T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/pinheiro2024api/> dcat:distribution <https://w3id.org/ontouml-models/model/pinheiro2024api/distribution/ttl>,
+                      <https://www.iana.org/assignments/media-types/text/turtle>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/pinheiro2024api/ontology.ttl>,
+                      <https://w3id.org/ontouml-models/model/pinheiro2024api/>,
+                      <https://www.iana.org/assignments/media-types/application/json>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/pinheiro2024api/ontology.json>,
+                      <https://www.visual-paradigm.com/vpp>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/pinheiro2024api/ontology.vpp> .

--- a/models/plato-ontology2019/metadata.ttl
+++ b/models/plato-ontology2019/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/db8cf905-98d1-4ba5-acff-587d4fc91890/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -21,12 +20,23 @@
     dct:license <https://creativecommons.org/licenses/by/4.0>;
     dct:contributor <https://a-komaromi.medium.com>;
     dcat:keyword "philosophy"@en;
+    dct:source <https://philosophy-models.blog/2019/01/19/some-aspects-of-platos-philosophy-presented-in-owl-bfo-model/>;
     mod:designedForTask ocmv:ConceptualClarification;
     ocmv:context ocmv:Research;
-    dct:source <https://philosophy-models.blog/2019/01/19/some-aspects-of-platos-philosophy-presented-in-owl-bfo-model/>;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/plato-ontology2019"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/plato-ontology2019"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T18:08:59.193512262Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:08:59.193512262Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/db8cf905-98d1-4ba5-acff-587d4fc91890> dcat:distribution <https://w3id.org/ontouml-models/distribution/9918a840-5572-4a1e-b8fb-d6ca7a1bf784/>, <https://w3id.org/ontouml-models/distribution/cf902cc0-a64f-4ce4-af25-2d8ff263e1ff/>, <https://w3id.org/ontouml-models/distribution/07f5324b-adb1-48a9-9e5d-b8c20305b260/>, <https://w3id.org/ontouml-models/distribution/7d918b35-ee77-4f32-be17-4cc6bd7716d2>, <https://w3id.org/ontouml-models/distribution/a7c607d1-541c-408c-a888-5b2ebec71303>, <https://w3id.org/ontouml-models/distribution/4a481f2b-88dd-47a1-a85f-b1f09aabfa8c>, <https://w3id.org/ontouml-models/distribution/1775e670-f2ca-4d72-a086-f8e7ffc40cc3>, <https://w3id.org/ontouml-models/distribution/2478ce4d-473c-484b-b391-f0a014fcec45>, <https://w3id.org/ontouml-models/distribution/5b7c71ec-1493-440f-b41e-65fed6a0aacd>, <https://w3id.org/ontouml-models/distribution/333214b2-910b-4aaa-89e1-c34d037292c6>, <https://w3id.org/ontouml-models/distribution/eef5b48e-3ef3-4b69-a468-917492b83fc5>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/db8cf905-98d1-4ba5-acff-587d4fc91890> dcat:distribution <https://w3id.org/ontouml-models/distribution/9918a840-5572-4a1e-b8fb-d6ca7a1bf784/>,
+                      <https://w3id.org/ontouml-models/distribution/cf902cc0-a64f-4ce4-af25-2d8ff263e1ff/>,
+                      <https://w3id.org/ontouml-models/distribution/07f5324b-adb1-48a9-9e5d-b8c20305b260/>,
+                      <https://w3id.org/ontouml-models/distribution/7d918b35-ee77-4f32-be17-4cc6bd7716d2>,
+                      <https://w3id.org/ontouml-models/distribution/a7c607d1-541c-408c-a888-5b2ebec71303>,
+                      <https://w3id.org/ontouml-models/distribution/4a481f2b-88dd-47a1-a85f-b1f09aabfa8c>,
+                      <https://w3id.org/ontouml-models/distribution/1775e670-f2ca-4d72-a086-f8e7ffc40cc3>,
+                      <https://w3id.org/ontouml-models/distribution/2478ce4d-473c-484b-b391-f0a014fcec45>,
+                      <https://w3id.org/ontouml-models/distribution/5b7c71ec-1493-440f-b41e-65fed6a0aacd>,
+                      <https://w3id.org/ontouml-models/distribution/333214b2-910b-4aaa-89e1-c34d037292c6>,
+                      <https://w3id.org/ontouml-models/distribution/eef5b48e-3ef3-4b69-a468-917492b83fc5> .

--- a/models/porello2020coex/metadata.ttl
+++ b/models/porello2020coex/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/da6748bf-3355-478a-b22f-d197518c6e54/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -19,14 +18,28 @@
     skos:editorialNote "The ontology was documented based on the author's paper.";
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:contributor <https://dblp.org/pid/33/8219>, <https://dblp.org/pid/11/78>, <https://dblp.org/pid/134/4947>, <https://dblp.org/pid/81/4277>, <https://dblp.org/pid/65/6778>, <https://dblp.org/pid/44/9683>, <https://www.researchgate.net/profile/Emma-Tieffenbach>;
+    dct:contributor <https://dblp.org/pid/33/8219>,
+                    <https://dblp.org/pid/11/78>,
+                    <https://dblp.org/pid/134/4947>,
+                    <https://dblp.org/pid/81/4277>,
+                    <https://dblp.org/pid/65/6778>,
+                    <https://dblp.org/pid/44/9683>,
+                    <https://www.researchgate.net/profile/Emma-Tieffenbach>;
     dcat:keyword "economic exchange"@en;
+    dct:source <https://doi.org/10.1007/978-3-030-62522-1_27>,
+               <https://dblp.org/rec/conf/vmbo/PorelloGSAG20>;
     mod:designedForTask ocmv:ConceptualClarification;
     ocmv:context ocmv:Research;
-    dct:source <https://doi.org/10.1007/978-3-030-62522-1_27>, <https://dblp.org/rec/conf/vmbo/PorelloGSAG20>;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/porello2020coex"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/porello2020coex"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T18:09:18.882401468Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:09:18.882401468Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/da6748bf-3355-478a-b22f-d197518c6e54> dcat:distribution <https://w3id.org/ontouml-models/distribution/4b71ed7d-4527-4503-bd36-33705dfae0bd/>, <https://w3id.org/ontouml-models/distribution/e4492dd5-be1f-4e0a-b047-15a55ae1a885/>, <https://w3id.org/ontouml-models/distribution/7c939058-c9e5-43ad-9d16-6fdc46f02775/>, <https://w3id.org/ontouml-models/distribution/76825349-ac5b-4a89-b779-a48e38e1a1e7>, <https://w3id.org/ontouml-models/distribution/d6a1c885-ff51-41b6-9701-1b6e61a627dc>, <https://w3id.org/ontouml-models/distribution/c045c7fd-b032-4b61-8ffa-43aa4e545618>, <https://w3id.org/ontouml-models/distribution/ab82d331-3b84-4f0d-85c5-9e629bec373d>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/da6748bf-3355-478a-b22f-d197518c6e54> dcat:distribution <https://w3id.org/ontouml-models/distribution/4b71ed7d-4527-4503-bd36-33705dfae0bd/>,
+                      <https://w3id.org/ontouml-models/distribution/e4492dd5-be1f-4e0a-b047-15a55ae1a885/>,
+                      <https://w3id.org/ontouml-models/distribution/7c939058-c9e5-43ad-9d16-6fdc46f02775/>,
+                      <https://w3id.org/ontouml-models/distribution/76825349-ac5b-4a89-b779-a48e38e1a1e7>,
+                      <https://w3id.org/ontouml-models/distribution/d6a1c885-ff51-41b6-9701-1b6e61a627dc>,
+                      <https://w3id.org/ontouml-models/distribution/c045c7fd-b032-4b61-8ffa-43aa4e545618>,
+                      <https://w3id.org/ontouml-models/distribution/ab82d331-3b84-4f0d-85c5-9e629bec373d> .

--- a/models/ppo-o2021/metadata.ttl
+++ b/models/ppo-o2021/metadata.ttl
@@ -1,18 +1,16 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/6c200266-ceb5-4cc6-8c8a-b01038687b72/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:title "PreProcessing Operators Ontology";
     mod:acronym "PPO-O";
     dct:issued "2021"^^xsd:gYear;
@@ -20,14 +18,30 @@
     dcat:theme lcc:T;
     skos:editorialNote "According to the authors, \"the purpose of [PPO-O] is to identify and represent the concepts related to the preparation of \"cured\" raw data, that is, data significantly selected, more organized, easier to analyze and understand. The idea is to facilitate the generation of training and test data to be consumed by ML algorithms.\"";
     dct:language "en";
-    dct:contributor <https://dblp.org/pid/293/7222>, <https://dblp.org/pid/151/7984>, <https://dblp.org/pid/43/7740>, <https://dblp.org/pid/c/MariaClaudiaReisCavalcanti>;
-    dcat:keyword "data preprocessing"@en, "data mining"@en;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    dct:contributor <https://dblp.org/pid/293/7222>,
+                    <https://dblp.org/pid/151/7984>,
+                    <https://dblp.org/pid/43/7740>,
+                    <https://dblp.org/pid/c/MariaClaudiaReisCavalcanti>;
+    dcat:keyword "data preprocessing"@en,
+                 "data mining"@en;
+    dct:source <https://doi.org/10.5220/0010460000990110>;
     mod:designedForTask ocmv:ConceptualClarification;
     ocmv:context ocmv:Research;
-    dct:source <https://doi.org/10.5220/0010460000990110>;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/ppo-o2021"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/ppo-o2021"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T18:09:31.704568786Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:09:31.704568786Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/6c200266-ceb5-4cc6-8c8a-b01038687b72> dcat:distribution <https://w3id.org/ontouml-models/distribution/df59c12e-bc63-4ed4-8e65-c71c923382da/>, <https://w3id.org/ontouml-models/distribution/207a8ad9-0897-471d-b95a-9924fb8e9664/>, <https://w3id.org/ontouml-models/distribution/64cba689-6d73-4187-998d-4d19c6f1db86/>, <https://w3id.org/ontouml-models/distribution/de410ae2-2ef9-4cdf-b5cb-a5771e1e71b3>, <https://w3id.org/ontouml-models/distribution/07882504-43e2-47e4-bf93-1f6db8f614a9>, <https://w3id.org/ontouml-models/distribution/50be4548-0060-4cab-a72f-518fd6fdb0e3>, <https://w3id.org/ontouml-models/distribution/9b3d638c-a2ba-4103-8359-394b07b55018>, <https://w3id.org/ontouml-models/distribution/8077ce1a-4700-4785-b1a2-7603915b15e5>, <https://w3id.org/ontouml-models/distribution/c03f14b4-7836-43bf-923c-d19cc61f4e28>, <https://w3id.org/ontouml-models/distribution/44ae6831-6fca-404e-adfb-059df1cc4d44>, <https://w3id.org/ontouml-models/distribution/c213468d-f58e-4b82-8e6f-3dc33722c12d>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/6c200266-ceb5-4cc6-8c8a-b01038687b72> dcat:distribution <https://w3id.org/ontouml-models/distribution/df59c12e-bc63-4ed4-8e65-c71c923382da/>,
+                      <https://w3id.org/ontouml-models/distribution/207a8ad9-0897-471d-b95a-9924fb8e9664/>,
+                      <https://w3id.org/ontouml-models/distribution/64cba689-6d73-4187-998d-4d19c6f1db86/>,
+                      <https://w3id.org/ontouml-models/distribution/de410ae2-2ef9-4cdf-b5cb-a5771e1e71b3>,
+                      <https://w3id.org/ontouml-models/distribution/07882504-43e2-47e4-bf93-1f6db8f614a9>,
+                      <https://w3id.org/ontouml-models/distribution/50be4548-0060-4cab-a72f-518fd6fdb0e3>,
+                      <https://w3id.org/ontouml-models/distribution/9b3d638c-a2ba-4103-8359-394b07b55018>,
+                      <https://w3id.org/ontouml-models/distribution/8077ce1a-4700-4785-b1a2-7603915b15e5>,
+                      <https://w3id.org/ontouml-models/distribution/c03f14b4-7836-43bf-923c-d19cc61f4e28>,
+                      <https://w3id.org/ontouml-models/distribution/44ae6831-6fca-404e-adfb-059df1cc4d44>,
+                      <https://w3id.org/ontouml-models/distribution/c213468d-f58e-4b82-8e6f-3dc33722c12d> .

--- a/models/project-assets2013/metadata.ttl
+++ b/models/project-assets2013/metadata.ttl
@@ -1,35 +1,38 @@
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/model/project-assets2013/> a dcat:Dataset, mod:SemanticArtefact;
+<https://w3id.org/ontouml-models/model/project-assets2013/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
+    dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
     dct:title "Project Assets";
     dct:issued "2013"^^xsd:gYear;
     dcat:theme lcc:H;
     skos:editorialNote "Ontology created during a lecture by students who wanted to remain anonymous. The ontology was build in a different editor tool and imported to Visual Paradigm, the current diagrammation may not exactly match the original one.";
     dct:language "pt-br";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    mod:designedForTask ocmv:ConceptualClarification, ocmv:Learning;
-    ocmv:context ocmv:Classroom.
-<https://w3id.org/ontouml-models/model/project-assets2013/> dcat:distribution <https://w3id.org/ontouml-models/model/project-assets2013/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/project-assets2013/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Project Assets\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/project-assets2013/ontology.ttl>.
-<https://w3id.org/ontouml-models/model/project-assets2013/> dcat:distribution <https://w3id.org/ontouml-models/model/project-assets2013/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/project-assets2013/distribution/ttl> a dcat:Distribution;
-    dct:title "JSON distribution of \"Project Assets\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/project-assets2013/ontology.json>.
-<https://w3id.org/ontouml-models/model/project-assets2013/> dcat:distribution <https://w3id.org/ontouml-models/model/project-assets2013/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/project-assets2013/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Project Assets\""@en;
-    dcat:mediaType <https://www.visual-paradigm.com/vpp>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/project-assets2013/ontology.vpp>.
+    dcat:keyword "project"@en,
+                 "asset"@en;
+    mod:designedForTask ocmv:ConceptualClarification,
+                        ocmv:Learning;
+    ocmv:context ocmv:Classroom;
+    ocmv:representationStyle ocmv:OntoumlStyle;
+    ocmv:ontologyType ocmv:Domain;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/project-assets2013"^^xsd:anyURI;
+    fdpo:metadataIssued "2026-06-23T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/project-assets2013/> dcat:distribution <https://w3id.org/ontouml-models/model/project-assets2013/distribution/ttl>,
+                      <https://www.iana.org/assignments/media-types/text/turtle>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/project-assets2013/ontology.ttl>,
+                      <https://w3id.org/ontouml-models/model/project-assets2013/>,
+                      <https://www.iana.org/assignments/media-types/application/json>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/project-assets2013/ontology.json>,
+                      <https://www.visual-paradigm.com/vpp>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/project-assets2013/ontology.vpp> .

--- a/models/project-management-ontology/metadata.ttl
+++ b/models/project-management-ontology/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/3788bfab-abc8-4765-80ec-7744f927c0e7/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -23,7 +22,12 @@
     ocmv:context ocmv:Classroom;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/project-management-ontology"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/project-management-ontology"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T18:09:51.446658398Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:09:51.446658398Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/3788bfab-abc8-4765-80ec-7744f927c0e7> dcat:distribution <https://w3id.org/ontouml-models/distribution/a7426d79-cecc-499d-86e1-91139978bf72/>, <https://w3id.org/ontouml-models/distribution/6b316f3c-3d71-4e66-9676-0fd089a118d3/>, <https://w3id.org/ontouml-models/distribution/a39f4b2c-5112-4781-8b24-b18deca25181/>, <https://w3id.org/ontouml-models/distribution/ea861cb5-7782-40cf-85d4-ab7443d6709c>, <https://w3id.org/ontouml-models/distribution/ad3c82f6-5cdf-4307-8b33-d433bbab89fb>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/3788bfab-abc8-4765-80ec-7744f927c0e7> dcat:distribution <https://w3id.org/ontouml-models/distribution/a7426d79-cecc-499d-86e1-91139978bf72/>,
+                      <https://w3id.org/ontouml-models/distribution/6b316f3c-3d71-4e66-9676-0fd089a118d3/>,
+                      <https://w3id.org/ontouml-models/distribution/a39f4b2c-5112-4781-8b24-b18deca25181/>,
+                      <https://w3id.org/ontouml-models/distribution/ea861cb5-7782-40cf-85d4-ab7443d6709c>,
+                      <https://w3id.org/ontouml-models/distribution/ad3c82f6-5cdf-4307-8b33-d433bbab89fb> .

--- a/models/public-expense-ontology2020/metadata.ttl
+++ b/models/public-expense-ontology2020/metadata.ttl
@@ -1,31 +1,42 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/0a044a49-bd7c-4429-8b83-68769b9037ee/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:title "Public Expense Ontology";
     dct:issued "2020"^^xsd:gYear;
     dcat:theme lcc:H;
     skos:editorialNote "The ontology was documented based on the author's publication.";
     dct:language "pt-br";
-    dct:contributor <https://dblp.org/pid/150/9241>, <https://dblp.org/pid/37/528>, <https://dblp.org/pid/54/10278>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    dct:contributor <https://dblp.org/pid/150/9241>,
+                    <https://dblp.org/pid/37/528>,
+                    <https://dblp.org/pid/54/10278>;
     dcat:keyword "public expense"@en;
-    mod:designedForTask ocmv:SoftwareEngineering, ocmv:ConceptualClarification;
-    ocmv:context ocmv:Research;
     dct:source <https://dblp.org/rec/conf/ontobras/BrittoRA20>;
+    mod:designedForTask ocmv:SoftwareEngineering,
+                        ocmv:ConceptualClarification;
+    ocmv:context ocmv:Research;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/public-expense-ontology2020"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/public-expense-ontology2020"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T18:10:00.840108165Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:10:00.840108165Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/0a044a49-bd7c-4429-8b83-68769b9037ee> dcat:distribution <https://w3id.org/ontouml-models/distribution/5eeec4ed-31ef-4b42-b206-9d13675eddb5/>, <https://w3id.org/ontouml-models/distribution/c57044ac-f96f-41d7-b01f-5cfc1409d18d/>, <https://w3id.org/ontouml-models/distribution/68fc458c-ae4b-46f9-94d4-0835e15aa5e3/>, <https://w3id.org/ontouml-models/distribution/fbab8498-3e03-4695-9e9a-078a73e22284>, <https://w3id.org/ontouml-models/distribution/64026512-94e6-47d6-a8e0-e10d18ab3da0>, <https://w3id.org/ontouml-models/distribution/e1d666ab-076d-48cf-96d0-e492d747e783>, <https://w3id.org/ontouml-models/distribution/ad898467-eef6-4e79-8855-13d7a62d3dd2>, <https://w3id.org/ontouml-models/distribution/fd6e9ce5-767a-495f-8c60-fa25d1a86020>, <https://w3id.org/ontouml-models/distribution/1962b854-8e69-485d-ab8d-098a65a4a939>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/0a044a49-bd7c-4429-8b83-68769b9037ee> dcat:distribution <https://w3id.org/ontouml-models/distribution/5eeec4ed-31ef-4b42-b206-9d13675eddb5/>,
+                      <https://w3id.org/ontouml-models/distribution/c57044ac-f96f-41d7-b01f-5cfc1409d18d/>,
+                      <https://w3id.org/ontouml-models/distribution/68fc458c-ae4b-46f9-94d4-0835e15aa5e3/>,
+                      <https://w3id.org/ontouml-models/distribution/fbab8498-3e03-4695-9e9a-078a73e22284>,
+                      <https://w3id.org/ontouml-models/distribution/64026512-94e6-47d6-a8e0-e10d18ab3da0>,
+                      <https://w3id.org/ontouml-models/distribution/e1d666ab-076d-48cf-96d0-e492d747e783>,
+                      <https://w3id.org/ontouml-models/distribution/ad898467-eef6-4e79-8855-13d7a62d3dd2>,
+                      <https://w3id.org/ontouml-models/distribution/fd6e9ce5-767a-495f-8c60-fa25d1a86020>,
+                      <https://w3id.org/ontouml-models/distribution/1962b854-8e69-485d-ab8d-098a65a4a939> .

--- a/models/public-organization2013/metadata.ttl
+++ b/models/public-organization2013/metadata.ttl
@@ -1,35 +1,38 @@
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/model/public-organization2013/> a dcat:Dataset, mod:SemanticArtefact;
+<https://w3id.org/ontouml-models/model/public-organization2013/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
+    dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
     dct:title "Ecology Public Organization";
     dct:issued "2013"^^xsd:gYear;
     dcat:theme lcc:H;
     skos:editorialNote "Ontology created during an Ontology Engineering lecture by students who wanted to remain anonymous. The ontology was build in a different editor tool and imported to Visual Paradigm, the current diagrammation may not exactly match the original one.";
     dct:language "pt-br";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    mod:designedForTask ocmv:ConceptualClarification, ocmv:Learning;
-    ocmv:context ocmv:Classroom.
-<https://w3id.org/ontouml-models/model/public-organization2013/> dcat:distribution <https://w3id.org/ontouml-models/model/public-organization2013/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/public-organization2013/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Ecology Public Organization\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/public-organization2013/ontology.ttl>.
-<https://w3id.org/ontouml-models/model/public-organization2013/> dcat:distribution <https://w3id.org/ontouml-models/model/public-organization2013/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/public-organization2013/distribution/ttl> a dcat:Distribution;
-    dct:title "JSON distribution of \"Ecology Public Organization\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/public-organization2013/ontology.json>.
-<https://w3id.org/ontouml-models/model/public-organization2013/> dcat:distribution <https://w3id.org/ontouml-models/model/public-organization2013/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/public-organization2013/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Ecology Public Organization\""@en;
-    dcat:mediaType <https://www.visual-paradigm.com/vpp>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/public-organization2013/ontology.vpp>.
+    dcat:keyword "organization"@en,
+                 "public organization"@en;
+    mod:designedForTask ocmv:ConceptualClarification,
+                        ocmv:Learning;
+    ocmv:context ocmv:Classroom;
+    ocmv:representationStyle ocmv:OntoumlStyle;
+    ocmv:ontologyType ocmv:Domain;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/public-organization2013"^^xsd:anyURI;
+    fdpo:metadataIssued "2026-06-23T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/public-organization2013/> dcat:distribution <https://w3id.org/ontouml-models/model/public-organization2013/distribution/ttl>,
+                      <https://www.iana.org/assignments/media-types/text/turtle>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/public-organization2013/ontology.ttl>,
+                      <https://w3id.org/ontouml-models/model/public-organization2013/>,
+                      <https://www.iana.org/assignments/media-types/application/json>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/public-organization2013/ontology.json>,
+                      <https://www.visual-paradigm.com/vpp>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/public-organization2013/ontology.vpp> .

--- a/models/public-tender/metadata.ttl
+++ b/models/public-tender/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/de0e84e8-9b55-4845-b8a5-17b495466d9f/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -18,11 +17,27 @@
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0>;
     dcat:keyword "public tender"@en;
-    mod:designedForTask ocmv:ConceptualClarification, ocmv:Learning;
+    mod:designedForTask ocmv:ConceptualClarification,
+                        ocmv:Learning;
     ocmv:context ocmv:Classroom;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/public-tender"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/public-tender"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T18:10:16.531836031Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:10:16.531836031Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/de0e84e8-9b55-4845-b8a5-17b495466d9f> dcat:distribution <https://w3id.org/ontouml-models/distribution/fde644b5-7d41-467e-a14c-7f3fdd6820b0/>, <https://w3id.org/ontouml-models/distribution/e1f6b191-d6cf-4198-bf25-6679f6bc7f0e/>, <https://w3id.org/ontouml-models/distribution/b574eea2-40f0-414a-bbc3-e86fad741fd7/>, <https://w3id.org/ontouml-models/distribution/0a9a1ed7-0c4c-4e4b-97f1-f9f14a215c3d>, <https://w3id.org/ontouml-models/distribution/8af69511-d098-4a31-b614-a5d226573929>, <https://w3id.org/ontouml-models/distribution/82ed33f0-f46e-4508-abff-22f2a141bd0a>, <https://w3id.org/ontouml-models/distribution/3f8663fa-7dd9-4c24-afa3-01fb625c69b9>, <https://w3id.org/ontouml-models/distribution/70ad06ac-a6b5-4b5b-8eef-0b75493f7768>, <https://w3id.org/ontouml-models/distribution/92ad8dcf-6e84-4595-a414-f718d64d4af7>, <https://w3id.org/ontouml-models/distribution/e9bb6f5f-d129-4666-8f26-eeda41e98417>, <https://w3id.org/ontouml-models/distribution/8d92255d-b31d-4e4f-b688-99825c48a110>, <https://w3id.org/ontouml-models/distribution/32257d63-1dd9-4aa7-b537-33977500c9a6>, <https://w3id.org/ontouml-models/distribution/ee40dfb4-c70c-443b-a713-425096c83293>, <https://w3id.org/ontouml-models/distribution/75bb45a5-b924-43c0-a1a8-1a7f1ab0161d>, <https://w3id.org/ontouml-models/distribution/614bcd69-4b3f-4498-8d81-bd8afe5d4651>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/de0e84e8-9b55-4845-b8a5-17b495466d9f> dcat:distribution <https://w3id.org/ontouml-models/distribution/fde644b5-7d41-467e-a14c-7f3fdd6820b0/>,
+                      <https://w3id.org/ontouml-models/distribution/e1f6b191-d6cf-4198-bf25-6679f6bc7f0e/>,
+                      <https://w3id.org/ontouml-models/distribution/b574eea2-40f0-414a-bbc3-e86fad741fd7/>,
+                      <https://w3id.org/ontouml-models/distribution/0a9a1ed7-0c4c-4e4b-97f1-f9f14a215c3d>,
+                      <https://w3id.org/ontouml-models/distribution/8af69511-d098-4a31-b614-a5d226573929>,
+                      <https://w3id.org/ontouml-models/distribution/82ed33f0-f46e-4508-abff-22f2a141bd0a>,
+                      <https://w3id.org/ontouml-models/distribution/3f8663fa-7dd9-4c24-afa3-01fb625c69b9>,
+                      <https://w3id.org/ontouml-models/distribution/70ad06ac-a6b5-4b5b-8eef-0b75493f7768>,
+                      <https://w3id.org/ontouml-models/distribution/92ad8dcf-6e84-4595-a414-f718d64d4af7>,
+                      <https://w3id.org/ontouml-models/distribution/e9bb6f5f-d129-4666-8f26-eeda41e98417>,
+                      <https://w3id.org/ontouml-models/distribution/8d92255d-b31d-4e4f-b688-99825c48a110>,
+                      <https://w3id.org/ontouml-models/distribution/32257d63-1dd9-4aa7-b537-33977500c9a6>,
+                      <https://w3id.org/ontouml-models/distribution/ee40dfb4-c70c-443b-a713-425096c83293>,
+                      <https://w3id.org/ontouml-models/distribution/75bb45a5-b924-43c0-a1a8-1a7f1ab0161d>,
+                      <https://w3id.org/ontouml-models/distribution/614bcd69-4b3f-4498-8d81-bd8afe5d4651> .

--- a/models/qam/metadata.ttl
+++ b/models/qam/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/0b6d6128-81e6-4985-8f0e-bd5af9a295f3/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -23,7 +22,12 @@
     ocmv:context ocmv:Classroom;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Application;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/qam"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/qam"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T18:10:41.704909005Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:10:41.704909005Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/0b6d6128-81e6-4985-8f0e-bd5af9a295f3> dcat:distribution <https://w3id.org/ontouml-models/distribution/f39081f9-416d-4d2f-832f-1b82d4a7d4cf/>, <https://w3id.org/ontouml-models/distribution/1e518491-06c2-410d-9869-96e3f778abec/>, <https://w3id.org/ontouml-models/distribution/160ad523-d919-4ec6-9614-e0ddc55304c1/>, <https://w3id.org/ontouml-models/distribution/882c2e30-eeea-4f93-9e39-bbf34c29d6b6>, <https://w3id.org/ontouml-models/distribution/bbeae61c-c1e6-4d74-b402-e1c57a8bddf9>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/0b6d6128-81e6-4985-8f0e-bd5af9a295f3> dcat:distribution <https://w3id.org/ontouml-models/distribution/f39081f9-416d-4d2f-832f-1b82d4a7d4cf/>,
+                      <https://w3id.org/ontouml-models/distribution/1e518491-06c2-410d-9869-96e3f778abec/>,
+                      <https://w3id.org/ontouml-models/distribution/160ad523-d919-4ec6-9614-e0ddc55304c1/>,
+                      <https://w3id.org/ontouml-models/distribution/882c2e30-eeea-4f93-9e39-bbf34c29d6b6>,
+                      <https://w3id.org/ontouml-models/distribution/bbeae61c-c1e6-4d74-b402-e1c57a8bddf9> .

--- a/models/quality-assurance-process-ontology2017/metadata.ttl
+++ b/models/quality-assurance-process-ontology2017/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/5b9a7ca3-3579-46aa-b24e-63f5b9011253/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -21,14 +20,25 @@
     dct:language "en";
     dcat:landingPage <https://dev.nemo.inf.ufes.br/seon/QAPO.html>;
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:contributor <https://dblp.org/pid/37/528>, <https://dblp.org/pid/229/4259>, <https://dblp.org/pid/97/7540>, <https://dblp.org/pid/189/5932>, <https://dblp.org/pid/11/78>;
+    dct:contributor <https://dblp.org/pid/37/528>,
+                    <https://dblp.org/pid/229/4259>,
+                    <https://dblp.org/pid/97/7540>,
+                    <https://dblp.org/pid/189/5932>,
+                    <https://dblp.org/pid/11/78>;
     dcat:keyword "quality assurance process"@en;
-    mod:designedForTask ocmv:ConceptualClarification, ocmv:Interoperability;
+    dct:source <https://nemo.inf.ufes.br/wp-content/papercite-data/pdf/software_engineering_standards_harmonization__an_ontology_based_approach_2017.pdf>,
+               <https://doi.org/10.1007/978-3-319-49004-5_34>;
+    mod:designedForTask ocmv:ConceptualClarification,
+                        ocmv:Interoperability;
     ocmv:context ocmv:Research;
-    dct:source <https://nemo.inf.ufes.br/wp-content/papercite-data/pdf/software_engineering_standards_harmonization__an_ontology_based_approach_2017.pdf>, <https://doi.org/10.1007/978-3-319-49004-5_34>;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/quality-assurance-process-ontology2017"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/quality-assurance-process-ontology2017"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T18:10:51.321399595Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:10:51.321399595Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/5b9a7ca3-3579-46aa-b24e-63f5b9011253> dcat:distribution <https://w3id.org/ontouml-models/distribution/b5652eaf-ea14-4989-a37f-786fa3688231/>, <https://w3id.org/ontouml-models/distribution/dbab55db-92a1-4b60-9011-a686ccbbed58/>, <https://w3id.org/ontouml-models/distribution/cf62546d-39d4-4a55-8de9-cd5ea9181347/>, <https://w3id.org/ontouml-models/distribution/41476e96-efbf-4153-98a5-3cb9ab53500e>, <https://w3id.org/ontouml-models/distribution/39710719-af8b-4d11-9745-5b1b57a7da97>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/5b9a7ca3-3579-46aa-b24e-63f5b9011253> dcat:distribution <https://w3id.org/ontouml-models/distribution/b5652eaf-ea14-4989-a37f-786fa3688231/>,
+                      <https://w3id.org/ontouml-models/distribution/dbab55db-92a1-4b60-9011-a686ccbbed58/>,
+                      <https://w3id.org/ontouml-models/distribution/cf62546d-39d4-4a55-8de9-cd5ea9181347/>,
+                      <https://w3id.org/ontouml-models/distribution/41476e96-efbf-4153-98a5-3cb9ab53500e>,
+                      <https://w3id.org/ontouml-models/distribution/39710719-af8b-4d11-9745-5b1b57a7da97> .

--- a/models/ramirez2015userfeedback/metadata.ttl
+++ b/models/ramirez2015userfeedback/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/d8502133-b2b2-4b8a-b96f-dd8285863b23/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -16,17 +15,36 @@
     dct:issued "2015"^^xsd:gYear;
     dct:modified "2015"^^xsd:gYear;
     dcat:theme lcc:T;
-    skos:editorialNote "The ontology contains OCL constraints represented in UML notes.\nAggregations with empty diamond were interpreted as «componentOf» relations, following OntoUML's original proposal.\nCertain classes, such as the «kind» Person, have been extracted from the text and included to diagrams.\n";
+    skos:editorialNote """The ontology contains OCL constraints represented in UML notes.
+Aggregations with empty diamond were interpreted as «componentOf» relations, following OntoUML's original proposal.
+Certain classes, such as the «kind» Person, have been extracted from the text and included to diagrams.
+""";
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:contributor <https://dblp.org/pid/04/8766>, <https://dblp.org/pid/16/4754>, <https://dblp.org/pid/75/5043>;
-    dcat:keyword "online user feedback"@en, "software engineering"@en, "requirements engineering"@en;
-    mod:designedForTask ocmv:ConceptualClarification, ocmv:InformationRetrieval;
-    ocmv:context ocmv:Research;
+    dct:contributor <https://dblp.org/pid/04/8766>,
+                    <https://dblp.org/pid/16/4754>,
+                    <https://dblp.org/pid/75/5043>;
+    dcat:keyword "online user feedback"@en,
+                 "software engineering"@en,
+                 "requirements engineering"@en;
     dct:source <https://doi.org/10.3233/AO-150150>;
+    mod:designedForTask ocmv:ConceptualClarification,
+                        ocmv:InformationRetrieval;
+    ocmv:context ocmv:Research;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/ramirez2015userfeedback"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/ramirez2015userfeedback"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T18:11:00.927415824Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:11:00.927415824Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/d8502133-b2b2-4b8a-b96f-dd8285863b23> dcat:distribution <https://w3id.org/ontouml-models/distribution/ef1031db-2b7e-4262-a46c-691c642110eb/>, <https://w3id.org/ontouml-models/distribution/1055e22a-4139-4fa3-b850-8a9c3f88e302/>, <https://w3id.org/ontouml-models/distribution/08ccba6f-a750-4c1a-afc4-a49233f5a56d/>, <https://w3id.org/ontouml-models/distribution/65b65a29-9d2e-4755-a340-d6d314e235b5>, <https://w3id.org/ontouml-models/distribution/7bb3feb9-c5fa-479f-888e-2aad79f66a2f>, <https://w3id.org/ontouml-models/distribution/291a2894-b9c1-4dfc-bd91-203e4747b379>, <https://w3id.org/ontouml-models/distribution/79901ad5-26a3-4c54-b9c6-b0e420b8ecc3>, <https://w3id.org/ontouml-models/distribution/586ce6ce-9ba6-4719-837e-f98c7b246210>, <https://w3id.org/ontouml-models/distribution/32357034-636e-4b74-b7e8-26a99fccdf44>, <https://w3id.org/ontouml-models/distribution/bc8fe631-b7c7-4362-8702-134284b90f98>, <https://w3id.org/ontouml-models/distribution/b4378f85-c054-4115-abe0-0895d468ced0>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/d8502133-b2b2-4b8a-b96f-dd8285863b23> dcat:distribution <https://w3id.org/ontouml-models/distribution/ef1031db-2b7e-4262-a46c-691c642110eb/>,
+                      <https://w3id.org/ontouml-models/distribution/1055e22a-4139-4fa3-b850-8a9c3f88e302/>,
+                      <https://w3id.org/ontouml-models/distribution/08ccba6f-a750-4c1a-afc4-a49233f5a56d/>,
+                      <https://w3id.org/ontouml-models/distribution/65b65a29-9d2e-4755-a340-d6d314e235b5>,
+                      <https://w3id.org/ontouml-models/distribution/7bb3feb9-c5fa-479f-888e-2aad79f66a2f>,
+                      <https://w3id.org/ontouml-models/distribution/291a2894-b9c1-4dfc-bd91-203e4747b379>,
+                      <https://w3id.org/ontouml-models/distribution/79901ad5-26a3-4c54-b9c6-b0e420b8ecc3>,
+                      <https://w3id.org/ontouml-models/distribution/586ce6ce-9ba6-4719-837e-f98c7b246210>,
+                      <https://w3id.org/ontouml-models/distribution/32357034-636e-4b74-b7e8-26a99fccdf44>,
+                      <https://w3id.org/ontouml-models/distribution/bc8fe631-b7c7-4362-8702-134284b90f98>,
+                      <https://w3id.org/ontouml-models/distribution/b4378f85-c054-4115-abe0-0895d468ced0> .

--- a/models/ramos2021bias/metadata.ttl
+++ b/models/ramos2021bias/metadata.ttl
@@ -1,32 +1,44 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/e3e0f697-53e8-45dc-8d32-bf282b5434cb/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:title "Decision Making Ontology Extended with Intuitive Decision Making";
     dct:issued "2021"^^xsd:gYear;
     dct:modified "2021"^^xsd:gYear;
     dcat:theme lcc:H;
-    skos:editorialNote "The Visual Paradigm file contains several notes in natural language but they do not represent actual constraints. Some of this information is in Portuguese.\nThe ontology contains ternary relations that are ignored by the current serialization.\n";
+    skos:editorialNote """The Visual Paradigm file contains several notes in natural language but they do not represent actual constraints. Some of this information is in Portuguese.
+The ontology contains ternary relations that are ignored by the current serialization.
+""";
     dct:language "en";
-    dct:contributor <https://dblp.org/pid/30/11293>, <https://dblp.org/pid/78/4279>, <https://dblp.org/pid/b/FAraujoBaiao>, <https://dblp.org/pid/75/5043>;
-    dcat:keyword "decision making"@en, "intuitive decision making"@en, "behavioral economics"@en, "bias"@en;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    dct:contributor <https://dblp.org/pid/30/11293>,
+                    <https://dblp.org/pid/78/4279>,
+                    <https://dblp.org/pid/b/FAraujoBaiao>,
+                    <https://dblp.org/pid/75/5043>;
+    dcat:keyword "decision making"@en,
+                 "intuitive decision making"@en,
+                 "behavioral economics"@en,
+                 "bias"@en;
+    dct:source <https://dblp.org/rec/conf/ontobras/RamosCBG21>;
     mod:designedForTask ocmv:ConceptualClarification;
     ocmv:context ocmv:Research;
-    dct:source <https://dblp.org/rec/conf/ontobras/RamosCBG21>;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Core;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/ramos2021bias"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/ramos2021bias"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T18:11:19.922357852Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:11:19.922357852Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/e3e0f697-53e8-45dc-8d32-bf282b5434cb> dcat:distribution <https://w3id.org/ontouml-models/distribution/d17cb65c-4e65-4f05-9f99-87e6bc2339c6/>, <https://w3id.org/ontouml-models/distribution/7e275e7a-0431-473f-8b67-ba5f2d2f3cc1/>, <https://w3id.org/ontouml-models/distribution/19bfdac0-b684-4932-bc30-c636dba1361d/>, <https://w3id.org/ontouml-models/distribution/f7f8aee3-3360-42d3-8498-24b1916bf761>, <https://w3id.org/ontouml-models/distribution/93d3202d-2430-4d7d-935f-636eee74d614>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/e3e0f697-53e8-45dc-8d32-bf282b5434cb> dcat:distribution <https://w3id.org/ontouml-models/distribution/d17cb65c-4e65-4f05-9f99-87e6bc2339c6/>,
+                      <https://w3id.org/ontouml-models/distribution/7e275e7a-0431-473f-8b67-ba5f2d2f3cc1/>,
+                      <https://w3id.org/ontouml-models/distribution/19bfdac0-b684-4932-bc30-c636dba1361d/>,
+                      <https://w3id.org/ontouml-models/distribution/f7f8aee3-3360-42d3-8498-24b1916bf761>,
+                      <https://w3id.org/ontouml-models/distribution/93d3202d-2430-4d7d-935f-636eee74d614> .

--- a/models/real-estate-ontology/metadata.ttl
+++ b/models/real-estate-ontology/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/4b53123f-83f0-493a-951e-5c9d70ae6bda/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -23,7 +22,12 @@
     ocmv:context ocmv:Classroom;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/real-estate-ontology"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/real-estate-ontology"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T18:11:29.34266465Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:11:29.34266465Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/4b53123f-83f0-493a-951e-5c9d70ae6bda> dcat:distribution <https://w3id.org/ontouml-models/distribution/0e7bd522-511e-4f27-859f-3cfc1f900302/>, <https://w3id.org/ontouml-models/distribution/033f38a4-bf80-4796-9692-99d4e8043633/>, <https://w3id.org/ontouml-models/distribution/673c3c56-0853-414f-a9fb-28c95ad6e694/>, <https://w3id.org/ontouml-models/distribution/1eb26eab-7adc-42fa-ac3b-c698eb2c8d89>, <https://w3id.org/ontouml-models/distribution/4901a3d3-c5ef-4f7d-8c6d-369a0f8d631a>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/4b53123f-83f0-493a-951e-5c9d70ae6bda> dcat:distribution <https://w3id.org/ontouml-models/distribution/0e7bd522-511e-4f27-859f-3cfc1f900302/>,
+                      <https://w3id.org/ontouml-models/distribution/033f38a4-bf80-4796-9692-99d4e8043633/>,
+                      <https://w3id.org/ontouml-models/distribution/673c3c56-0853-414f-a9fb-28c95ad6e694/>,
+                      <https://w3id.org/ontouml-models/distribution/1eb26eab-7adc-42fa-ac3b-c698eb2c8d89>,
+                      <https://w3id.org/ontouml-models/distribution/4901a3d3-c5ef-4f7d-8c6d-369a0f8d631a> .

--- a/models/recommendation-ontology/metadata.ttl
+++ b/models/recommendation-ontology/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/451e3138-fc99-40bf-81c7-430b3a321863/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -18,12 +17,18 @@
     skos:editorialNote "This model was done as an assignment for a course. The author required to remain anonymous. There is no information about the ontology's development year.";
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dcat:keyword "decision support systems"@en, "recommendation"@en;
+    dcat:keyword "decision support systems"@en,
+                 "recommendation"@en;
     mod:designedForTask ocmv:Learning;
     ocmv:context ocmv:Classroom;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/recommendation-ontology"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/recommendation-ontology"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T18:11:38.463517554Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:11:38.463517554Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/451e3138-fc99-40bf-81c7-430b3a321863> dcat:distribution <https://w3id.org/ontouml-models/distribution/050508f6-d536-4516-8529-029949230707/>, <https://w3id.org/ontouml-models/distribution/478c900b-d2f9-4436-b152-d6d4cdde92b1/>, <https://w3id.org/ontouml-models/distribution/663bbae6-5738-41a1-8513-0949564cb0e9/>, <https://w3id.org/ontouml-models/distribution/4bbc4898-deb9-4685-b5ea-91056e7171eb>, <https://w3id.org/ontouml-models/distribution/cc0c4096-fe24-41fc-89c8-0e9b8f5e382d>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/451e3138-fc99-40bf-81c7-430b3a321863> dcat:distribution <https://w3id.org/ontouml-models/distribution/050508f6-d536-4516-8529-029949230707/>,
+                      <https://w3id.org/ontouml-models/distribution/478c900b-d2f9-4436-b152-d6d4cdde92b1/>,
+                      <https://w3id.org/ontouml-models/distribution/663bbae6-5738-41a1-8513-0949564cb0e9/>,
+                      <https://w3id.org/ontouml-models/distribution/4bbc4898-deb9-4685-b5ea-91056e7171eb>,
+                      <https://w3id.org/ontouml-models/distribution/cc0c4096-fe24-41fc-89c8-0e9b8f5e382d> .

--- a/models/repa2021public-administration/metadata.ttl
+++ b/models/repa2021public-administration/metadata.ttl
@@ -1,32 +1,40 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/54af0ca8-e341-4457-b0dc-2594425a6489/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:title "Public Administration Ontology Model";
     dct:issued "2015"^^xsd:gYear;
     dct:modified "2021"^^xsd:gYear;
     dcat:theme lcc:J;
-    skos:editorialNote "A fragment of the PA ontology model.\nThe author makes use of a «viewpoint» stereotype, which an extension of OntoUML proposed in the following work: https://doi.org/10.1007/978-1-4614-7540-8_34\n";
+    skos:editorialNote """A fragment of the PA ontology model.
+The author makes use of a «viewpoint» stereotype, which an extension of OntoUML proposed in the following work: https://doi.org/10.1007/978-1-4614-7540-8_34
+""";
     dct:language "en";
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:contributor <https://dblp.org/pid/08/5518>;
-    dcat:keyword "e-government"@en, "public administration"@en;
+    dcat:keyword "e-government"@en,
+                 "public administration"@en;
+    dct:source <https://doi.org/10.1007/978-3-030-49640-1_6>,
+               <https://doi.org/10.1007/978-3-319-21915-8_3>;
     mod:designedForTask ocmv:ConceptualClarification;
     ocmv:context ocmv:Research;
-    dct:source <https://doi.org/10.1007/978-3-030-49640-1_6>, <https://doi.org/10.1007/978-3-319-21915-8_3>;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/repa2021public-administration"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/repa2021public-administration"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T18:11:48.05622345Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:11:48.05622345Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/54af0ca8-e341-4457-b0dc-2594425a6489> dcat:distribution <https://w3id.org/ontouml-models/distribution/44c92bf9-fa31-4f0d-ab28-a476b9c45e2a/>, <https://w3id.org/ontouml-models/distribution/e6ccc1da-6edf-43a9-9dc1-5353b40016cc/>, <https://w3id.org/ontouml-models/distribution/50f30200-a708-430f-b0d6-4910b513eb64/>, <https://w3id.org/ontouml-models/distribution/a964add5-9dec-4d83-b160-c6433f730292>, <https://w3id.org/ontouml-models/distribution/c3388ee5-20ac-450a-9487-e7f505bb991f>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/54af0ca8-e341-4457-b0dc-2594425a6489> dcat:distribution <https://w3id.org/ontouml-models/distribution/44c92bf9-fa31-4f0d-ab28-a476b9c45e2a/>,
+                      <https://w3id.org/ontouml-models/distribution/e6ccc1da-6edf-43a9-9dc1-5353b40016cc/>,
+                      <https://w3id.org/ontouml-models/distribution/50f30200-a708-430f-b0d6-4910b513eb64/>,
+                      <https://w3id.org/ontouml-models/distribution/a964add5-9dec-4d83-b160-c6433f730292>,
+                      <https://w3id.org/ontouml-models/distribution/c3388ee5-20ac-450a-9487-e7f505bb991f> .

--- a/models/richetti2019tdecision/metadata.ttl
+++ b/models/richetti2019tdecision/metadata.ttl
@@ -1,31 +1,39 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/a0ce75d5-54d0-4949-b9d0-444bad20573c/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:title "Decision Making in knowledge intensive process in Value Ascription and Goal processing";
     dct:issued "2019"^^xsd:gYear;
     dcat:theme lcc:H;
     skos:editorialNote "The ontology was documented based on the author's paper. Also, some special changes were needed to adapt to VP structure on Packages";
     dct:language "en";
-    dct:contributor <https://dblp.org/pid/150/5453>, <https://dblp.org/pid/b/FAraujoBaiao>, <https://dblp.org/pid/78/4279>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    dct:contributor <https://dblp.org/pid/150/5453>,
+                    <https://dblp.org/pid/b/FAraujoBaiao>,
+                    <https://dblp.org/pid/78/4279>;
     dcat:keyword "decision making"@en;
+    dct:source <https://doi.org/10.1007/978-3-030-33223-5_30>;
     mod:designedForTask ocmv:ConceptualClarification;
     ocmv:context ocmv:Research;
-    dct:source <https://doi.org/10.1007/978-3-030-33223-5_30>;
     ocmv:representationStyle ocmv:UfoStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/richetti2019tdecision"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/richetti2019tdecision"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T18:11:57.611992711Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:11:57.611992711Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/a0ce75d5-54d0-4949-b9d0-444bad20573c> dcat:distribution <https://w3id.org/ontouml-models/distribution/c1a8a442-85b5-4375-80c9-77e6cbf8ff18/>, <https://w3id.org/ontouml-models/distribution/60647cbd-4094-4d38-b893-a4a9719ff13a/>, <https://w3id.org/ontouml-models/distribution/4406cd90-86ba-45de-bdf2-5a9931e4bbff/>, <https://w3id.org/ontouml-models/distribution/ec125ce0-30d7-4434-a61a-b04504e6198b>, <https://w3id.org/ontouml-models/distribution/b087b1b9-536f-4fb6-99ce-78f5b04d6912>, <https://w3id.org/ontouml-models/distribution/43ff3ed7-640e-48ca-b01a-00148f0695ce>, <https://w3id.org/ontouml-models/distribution/e8958218-3286-4302-94aa-330025094e69>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/a0ce75d5-54d0-4949-b9d0-444bad20573c> dcat:distribution <https://w3id.org/ontouml-models/distribution/c1a8a442-85b5-4375-80c9-77e6cbf8ff18/>,
+                      <https://w3id.org/ontouml-models/distribution/60647cbd-4094-4d38-b893-a4a9719ff13a/>,
+                      <https://w3id.org/ontouml-models/distribution/4406cd90-86ba-45de-bdf2-5a9931e4bbff/>,
+                      <https://w3id.org/ontouml-models/distribution/ec125ce0-30d7-4434-a61a-b04504e6198b>,
+                      <https://w3id.org/ontouml-models/distribution/b087b1b9-536f-4fb6-99ce-78f5b04d6912>,
+                      <https://w3id.org/ontouml-models/distribution/43ff3ed7-640e-48ca-b01a-00148f0695ce>,
+                      <https://w3id.org/ontouml-models/distribution/e8958218-3286-4302-94aa-330025094e69> .

--- a/models/road-accident2013/metadata.ttl
+++ b/models/road-accident2013/metadata.ttl
@@ -1,35 +1,39 @@
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/model/road-accident2013/> a dcat:Dataset, mod:SemanticArtefact;
+<https://w3id.org/ontouml-models/model/road-accident2013/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
+    dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
     dct:title "Road Traffic Accident Ontology";
     dct:issued "2013"^^xsd:gYear;
     dcat:theme lcc:T;
     skos:editorialNote "Ontology created during an Ontology Engineering lecture by students who wanted to remain anonymous. The ontology was build in a different editor tool and imported to Visual Paradigm, the current diagrammation may not exactly match the original one.";
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    mod:designedForTask ocmv:ConceptualClarification, ocmv:Learning;
-    ocmv:context ocmv:Classroom.
-<https://w3id.org/ontouml-models/model/road-accident2013/> dcat:distribution <https://w3id.org/ontouml-models/model/road-accident2013/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/road-accident2013/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Road Traffic Accident Ontology\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/road-accident2013/ontology.ttl>.
-<https://w3id.org/ontouml-models/model/road-accident2013/> dcat:distribution <https://w3id.org/ontouml-models/model/road-accident2013/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/road-accident2013/distribution/ttl> a dcat:Distribution;
-    dct:title "JSON distribution of \"Road Traffic Accident Ontology\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/road-accident2013/ontology.json>.
-<https://w3id.org/ontouml-models/model/road-accident2013/> dcat:distribution <https://w3id.org/ontouml-models/model/road-accident2013/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/road-accident2013/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Road Traffic Accident Ontology\""@en;
-    dcat:mediaType <https://www.visual-paradigm.com/vpp>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/road-accident2013/ontology.vpp>.
+    dcat:keyword "road"@en,
+                 "traffic"@en,
+                 "accident"@en;
+    mod:designedForTask ocmv:ConceptualClarification,
+                        ocmv:Learning;
+    ocmv:context ocmv:Classroom;
+    ocmv:representationStyle ocmv:OntoumlStyle;
+    ocmv:ontologyType ocmv:Domain;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/road-accident2013"^^xsd:anyURI;
+    fdpo:metadataIssued "2026-06-23T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/road-accident2013/> dcat:distribution <https://w3id.org/ontouml-models/model/road-accident2013/distribution/ttl>,
+                      <https://www.iana.org/assignments/media-types/text/turtle>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/road-accident2013/ontology.ttl>,
+                      <https://w3id.org/ontouml-models/model/road-accident2013/>,
+                      <https://www.iana.org/assignments/media-types/application/json>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/road-accident2013/ontology.json>,
+                      <https://www.visual-paradigm.com/vpp>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/road-accident2013/ontology.vpp> .

--- a/models/rocha2023ciencia-aberta/metadata.ttl
+++ b/models/rocha2023ciencia-aberta/metadata.ttl
@@ -1,36 +1,40 @@
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/model/rocha2023ciencia-aberta/> a dcat:Dataset, mod:SemanticArtefact;
+<https://w3id.org/ontouml-models/model/rocha2023ciencia-aberta/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
+    dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
     dct:title "Ciência Aberta";
     dct:issued "2023"^^xsd:gYear;
     dcat:theme lcc:Q;
     dct:language "pt-br";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:contributor <https://dblp.org/pid/222/8384>, <https://orcid.org/0000-0003-0650-0121>;
-    mod:designedForTask ocmv:ConceptualClarification, ocmv:Interoperability;
+    dct:contributor <https://dblp.org/pid/222/8384>,
+                    <https://orcid.org/0000-0003-0650-0121>;
+    dcat:keyword "open science"@en,
+                 "science"@en;
+    dct:source <https://periodicos.ufmg.br/index.php/fronteiras-rc/article/view/42050>;
+    mod:designedForTask ocmv:ConceptualClarification,
+                        ocmv:Interoperability;
     ocmv:context ocmv:Research;
-    dct:source <https://periodicos.ufmg.br/index.php/fronteiras-rc/article/view/42050>.
-<https://w3id.org/ontouml-models/model/rocha2023ciencia-aberta/> dcat:distribution <https://w3id.org/ontouml-models/model/rocha2023ciencia-aberta/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/rocha2023ciencia-aberta/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Ciência Aberta\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/rocha2023ciencia-aberta/ontology.ttl>.
-<https://w3id.org/ontouml-models/model/rocha2023ciencia-aberta/> dcat:distribution <https://w3id.org/ontouml-models/model/rocha2023ciencia-aberta/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/rocha2023ciencia-aberta/distribution/ttl> a dcat:Distribution;
-    dct:title "JSON distribution of \"Ciência Aberta\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/rocha2023ciencia-aberta/ontology.json>.
-<https://w3id.org/ontouml-models/model/rocha2023ciencia-aberta/> dcat:distribution <https://w3id.org/ontouml-models/model/rocha2023ciencia-aberta/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/rocha2023ciencia-aberta/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Ciência Aberta\""@en;
-    dcat:mediaType <https://www.visual-paradigm.com/vpp>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/rocha2023ciencia-aberta/ontology.vpp>.
+    ocmv:representationStyle ocmv:OntoumlStyle;
+    ocmv:ontologyType ocmv:Domain;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/rocha2023ciencia-aberta"^^xsd:anyURI;
+    fdpo:metadataIssued "2026-06-23T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/rocha2023ciencia-aberta/> dcat:distribution <https://w3id.org/ontouml-models/model/rocha2023ciencia-aberta/distribution/ttl>,
+                      <https://www.iana.org/assignments/media-types/text/turtle>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/rocha2023ciencia-aberta/ontology.ttl>,
+                      <https://w3id.org/ontouml-models/model/rocha2023ciencia-aberta/>,
+                      <https://www.iana.org/assignments/media-types/application/json>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/rocha2023ciencia-aberta/ontology.json>,
+                      <https://www.visual-paradigm.com/vpp>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/rocha2023ciencia-aberta/ontology.vpp> .

--- a/models/rodrigues2017urinary-profiles/metadata.ttl
+++ b/models/rodrigues2017urinary-profiles/metadata.ttl
@@ -1,32 +1,55 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/ab12ac77-6476-4b22-9c2b-bb70a9c6f26d/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:title "Ontological Model for Urinary Profiles and Events";
     dct:issued "2015"^^xsd:gYear;
     dct:modified "2017"^^xsd:gYear;
     dcat:theme lcc:R;
     skos:editorialNote "Comparing the diagrams from the original 2015 paper and from the \"extended\" 2017 version, precisely \"Nephritic profile\", there is one missing \"is-a\" between \"Nephritic-Defining Albumin\" and \"Albumin\". I considered that it was just a lost, so I kept it as in the original paper (since they were supposed to change the layout only). It was not possible to identify what the \"Added\" keyword in \"Immune Response Event\" is.";
     dct:language "en";
-    dct:contributor <https://dblp.org/pid/151/1055>, <https://dblp.org/pid/151/1107>, <https://dblp.org/pid/a/MaraAbel>, <https://dblp.org/pid/f/CeciliaDiasFlores>, <https://dblp.org/pid/151/1095>;
-    dcat:keyword "medicine"@en, "urine analysis"@en;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    dct:contributor <https://dblp.org/pid/151/1055>,
+                    <https://dblp.org/pid/151/1107>,
+                    <https://dblp.org/pid/a/MaraAbel>,
+                    <https://dblp.org/pid/f/CeciliaDiasFlores>,
+                    <https://dblp.org/pid/151/1095>;
+    dcat:keyword "medicine"@en,
+                 "urine analysis"@en;
+    dct:source <https://doi.org/10.1109/ICTAI.2015.148>,
+               <http://ceur-ws.org/Vol-1908/paper3.pdf>,
+               <https://doi.org/10.1109/ICTAI.2017.00101>;
     mod:designedForTask ocmv:ConceptualClarification;
     ocmv:context ocmv:Research;
-    dct:source <https://doi.org/10.1109/ICTAI.2015.148>, <http://ceur-ws.org/Vol-1908/paper3.pdf>, <https://doi.org/10.1109/ICTAI.2017.00101>;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/rodrigues2017urinary-profiles"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/rodrigues2017urinary-profiles"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T18:12:10.290196298Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:12:10.290196298Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/ab12ac77-6476-4b22-9c2b-bb70a9c6f26d> dcat:distribution <https://w3id.org/ontouml-models/distribution/62fd42c9-77be-4991-809f-e91e6864bf22/>, <https://w3id.org/ontouml-models/distribution/fea6bb77-64c0-4d1c-9c6e-ded255d01916/>, <https://w3id.org/ontouml-models/distribution/78c22b1b-5af5-4780-be81-d35b544a83f3/>, <https://w3id.org/ontouml-models/distribution/d87d83c7-ed5f-439c-b14d-c5d752dbe627>, <https://w3id.org/ontouml-models/distribution/3e82a0e8-bdf2-4bc7-a701-a8509680fd49>, <https://w3id.org/ontouml-models/distribution/1b05a71a-d7fe-483e-a8b1-24d7148fc55a>, <https://w3id.org/ontouml-models/distribution/d3fe2608-3dac-40cb-8e92-aef349b38a59>, <https://w3id.org/ontouml-models/distribution/94a2ac5f-00de-4178-bf60-fa86d1bf75e3>, <https://w3id.org/ontouml-models/distribution/c3c704f8-2a32-4ccb-a642-10789926e4e6>, <https://w3id.org/ontouml-models/distribution/4c14360c-0319-4852-9ace-fc625f408268>, <https://w3id.org/ontouml-models/distribution/baab9559-f4bd-4079-b1f9-562a900ead30>, <https://w3id.org/ontouml-models/distribution/f590d05f-2d4b-462a-a0c1-bacb137ab6b5>, <https://w3id.org/ontouml-models/distribution/61b28ee5-cd61-46cf-916c-5e3ad48b7860>, <https://w3id.org/ontouml-models/distribution/cf93ad2d-64e6-43d0-87ee-8c38b58dca6b>, <https://w3id.org/ontouml-models/distribution/b196c56f-90da-4bd1-ab5d-014913b620b9>, <https://w3id.org/ontouml-models/distribution/c860803f-b094-41a1-b0c4-5d70a5baa964>, <https://w3id.org/ontouml-models/distribution/0b40f3e3-e4fa-46c8-a18d-acc711e607f2>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/ab12ac77-6476-4b22-9c2b-bb70a9c6f26d> dcat:distribution <https://w3id.org/ontouml-models/distribution/62fd42c9-77be-4991-809f-e91e6864bf22/>,
+                      <https://w3id.org/ontouml-models/distribution/fea6bb77-64c0-4d1c-9c6e-ded255d01916/>,
+                      <https://w3id.org/ontouml-models/distribution/78c22b1b-5af5-4780-be81-d35b544a83f3/>,
+                      <https://w3id.org/ontouml-models/distribution/d87d83c7-ed5f-439c-b14d-c5d752dbe627>,
+                      <https://w3id.org/ontouml-models/distribution/3e82a0e8-bdf2-4bc7-a701-a8509680fd49>,
+                      <https://w3id.org/ontouml-models/distribution/1b05a71a-d7fe-483e-a8b1-24d7148fc55a>,
+                      <https://w3id.org/ontouml-models/distribution/d3fe2608-3dac-40cb-8e92-aef349b38a59>,
+                      <https://w3id.org/ontouml-models/distribution/94a2ac5f-00de-4178-bf60-fa86d1bf75e3>,
+                      <https://w3id.org/ontouml-models/distribution/c3c704f8-2a32-4ccb-a642-10789926e4e6>,
+                      <https://w3id.org/ontouml-models/distribution/4c14360c-0319-4852-9ace-fc625f408268>,
+                      <https://w3id.org/ontouml-models/distribution/baab9559-f4bd-4079-b1f9-562a900ead30>,
+                      <https://w3id.org/ontouml-models/distribution/f590d05f-2d4b-462a-a0c1-bacb137ab6b5>,
+                      <https://w3id.org/ontouml-models/distribution/61b28ee5-cd61-46cf-916c-5e3ad48b7860>,
+                      <https://w3id.org/ontouml-models/distribution/cf93ad2d-64e6-43d0-87ee-8c38b58dca6b>,
+                      <https://w3id.org/ontouml-models/distribution/b196c56f-90da-4bd1-ab5d-014913b620b9>,
+                      <https://w3id.org/ontouml-models/distribution/c860803f-b094-41a1-b0c4-5d70a5baa964>,
+                      <https://w3id.org/ontouml-models/distribution/0b40f3e3-e4fa-46c8-a18d-acc711e607f2> .

--- a/models/rodrigues2019ontocrime/metadata.ttl
+++ b/models/rodrigues2019ontocrime/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/f0f7917c-32c0-411d-a4b0-cd2159fd1cf2/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -19,14 +18,37 @@
     dcat:theme lcc:K;
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:contributor <https://dblp.org/pid/56/7872>, <https://dblp.org/pid/15/3640>, <https://dblp.org/pid/94/2962>, <https://dblp.org/pid/212/6684>;
-    dcat:keyword "criminal law"@en, "law"@en;
-    mod:designedForTask ocmv:OntologicalAnalysis, ocmv:DecisionSupportSystem;
-    ocmv:context ocmv:Research;
+    dct:contributor <https://dblp.org/pid/56/7872>,
+                    <https://dblp.org/pid/15/3640>,
+                    <https://dblp.org/pid/94/2962>,
+                    <https://dblp.org/pid/212/6684>;
+    dcat:keyword "criminal law"@en,
+                 "law"@en;
     dct:source <https://doi.org/10.3233/AO-200223>;
-    ocmv:representationStyle ocmv:UfoStyle, ocmv:OntoumlStyle;
+    mod:designedForTask ocmv:OntologicalAnalysis,
+                        ocmv:DecisionSupportSystem;
+    ocmv:context ocmv:Research;
+    ocmv:representationStyle ocmv:UfoStyle,
+                             ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/rodrigues2019ontocrime"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/rodrigues2019ontocrime"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T18:12:38.650536182Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:12:38.650536182Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/f0f7917c-32c0-411d-a4b0-cd2159fd1cf2> dcat:distribution <https://w3id.org/ontouml-models/distribution/a2d7d59b-2369-4690-8fa4-267bb7993f49/>, <https://w3id.org/ontouml-models/distribution/91852dc0-94a8-4a7a-8836-2d1ef4778b38/>, <https://w3id.org/ontouml-models/distribution/d63d8962-9386-4529-a871-fbcae4b69257/>, <https://w3id.org/ontouml-models/distribution/155f518b-055b-4257-9f29-946397c69aeb>, <https://w3id.org/ontouml-models/distribution/47a32d03-3418-4a4b-b9d0-2884fe70ae4c>, <https://w3id.org/ontouml-models/distribution/0c3a5228-640b-476d-b890-b0822ba9d668>, <https://w3id.org/ontouml-models/distribution/04f9822c-b114-48b2-b68c-2d687118916a>, <https://w3id.org/ontouml-models/distribution/2235c93a-35b7-4aa8-8041-e12f81c9b068>, <https://w3id.org/ontouml-models/distribution/ebc98efc-8731-48d4-832f-967e6807f8b8>, <https://w3id.org/ontouml-models/distribution/b0b13de7-03c8-49b1-94c9-68286d2f4dc8>, <https://w3id.org/ontouml-models/distribution/3b8406a5-660a-4194-875b-8ad88c2fd30d>, <https://w3id.org/ontouml-models/distribution/f15e0ec8-0270-4cea-8484-c56d2f5aa46f>, <https://w3id.org/ontouml-models/distribution/69180f94-1f56-45bb-b27e-2d64568c840a>, <https://w3id.org/ontouml-models/distribution/07d32551-acae-48b8-a2ef-393301783b6a>, <https://w3id.org/ontouml-models/distribution/06d55a93-943f-4f1f-a2c3-f5b00b70af61>, <https://w3id.org/ontouml-models/distribution/e1e87fd4-69d0-4544-bd29-1a08e1b7e7d2>, <https://w3id.org/ontouml-models/distribution/2656d7a4-e741-4b66-ad80-e69f46f1884f>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/f0f7917c-32c0-411d-a4b0-cd2159fd1cf2> dcat:distribution <https://w3id.org/ontouml-models/distribution/a2d7d59b-2369-4690-8fa4-267bb7993f49/>,
+                      <https://w3id.org/ontouml-models/distribution/91852dc0-94a8-4a7a-8836-2d1ef4778b38/>,
+                      <https://w3id.org/ontouml-models/distribution/d63d8962-9386-4529-a871-fbcae4b69257/>,
+                      <https://w3id.org/ontouml-models/distribution/155f518b-055b-4257-9f29-946397c69aeb>,
+                      <https://w3id.org/ontouml-models/distribution/47a32d03-3418-4a4b-b9d0-2884fe70ae4c>,
+                      <https://w3id.org/ontouml-models/distribution/0c3a5228-640b-476d-b890-b0822ba9d668>,
+                      <https://w3id.org/ontouml-models/distribution/04f9822c-b114-48b2-b68c-2d687118916a>,
+                      <https://w3id.org/ontouml-models/distribution/2235c93a-35b7-4aa8-8041-e12f81c9b068>,
+                      <https://w3id.org/ontouml-models/distribution/ebc98efc-8731-48d4-832f-967e6807f8b8>,
+                      <https://w3id.org/ontouml-models/distribution/b0b13de7-03c8-49b1-94c9-68286d2f4dc8>,
+                      <https://w3id.org/ontouml-models/distribution/3b8406a5-660a-4194-875b-8ad88c2fd30d>,
+                      <https://w3id.org/ontouml-models/distribution/f15e0ec8-0270-4cea-8484-c56d2f5aa46f>,
+                      <https://w3id.org/ontouml-models/distribution/69180f94-1f56-45bb-b27e-2d64568c840a>,
+                      <https://w3id.org/ontouml-models/distribution/07d32551-acae-48b8-a2ef-393301783b6a>,
+                      <https://w3id.org/ontouml-models/distribution/06d55a93-943f-4f1f-a2c3-f5b00b70af61>,
+                      <https://w3id.org/ontouml-models/distribution/e1e87fd4-69d0-4544-bd29-1a08e1b7e7d2>,
+                      <https://w3id.org/ontouml-models/distribution/2656d7a4-e741-4b66-ad80-e69f46f1884f> .

--- a/models/rodrigues2019turbidite/metadata.ttl
+++ b/models/rodrigues2019turbidite/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/e3b58861-ccf1-4dc5-971d-cba03a3aaf88/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -19,14 +18,31 @@
     skos:editorialNote "there are multiple association classes from the same relator that are not allowed by VPP";
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:contributor <https://dblp.org/pid/151/1055>, <https://dblp.org/pid/135/0951>, <https://dblp.org/pid/256/4251>, <https://dblp.org/pid/a/MaraAbel>;
+    dct:contributor <https://dblp.org/pid/151/1055>,
+                    <https://dblp.org/pid/135/0951>,
+                    <https://dblp.org/pid/256/4251>,
+                    <https://dblp.org/pid/a/MaraAbel>;
     dcat:keyword "geology"@en;
-    mod:designedForTask ocmv:ConceptualClarification, ocmv:Interoperability;
-    ocmv:context ocmv:Research;
     dct:source <https://dblp.org/rec/conf/ontobras/RodriguesGKA19>;
+    mod:designedForTask ocmv:ConceptualClarification,
+                        ocmv:Interoperability;
+    ocmv:context ocmv:Research;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/rodrigues2019turbidite"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/rodrigues2019turbidite"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T18:13:07.390972212Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:13:07.390972212Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/e3b58861-ccf1-4dc5-971d-cba03a3aaf88> dcat:distribution <https://w3id.org/ontouml-models/distribution/950acc83-d5c8-4999-a7ba-53a61de08f71/>, <https://w3id.org/ontouml-models/distribution/7dae0976-6ccc-4088-ba3b-5ebdc9b9069a/>, <https://w3id.org/ontouml-models/distribution/88d74bca-86c7-43f8-83a6-46a47353342b/>, <https://w3id.org/ontouml-models/distribution/37991053-2ddd-4eee-bcb6-875ebf984e6c>, <https://w3id.org/ontouml-models/distribution/7f919b5e-916d-45d3-9ba5-fa83112c7f45>, <https://w3id.org/ontouml-models/distribution/4b6606cb-c8d7-4025-beff-04c9295bd926>, <https://w3id.org/ontouml-models/distribution/491517ab-5362-4c7c-8bfd-cdec217dea3d>, <https://w3id.org/ontouml-models/distribution/fbd0fc36-d80e-446a-b619-1d017243b1b8>, <https://w3id.org/ontouml-models/distribution/e7fe0ca1-bad9-4dac-b1e3-38344f53e900>, <https://w3id.org/ontouml-models/distribution/089328d3-6bae-4036-83d8-16aa4ba67e96>, <https://w3id.org/ontouml-models/distribution/e2039d6f-2ae7-4bad-a4b9-0e8ec16df301>, <https://w3id.org/ontouml-models/distribution/c3b8cd9a-1807-4808-9070-fc724d57aa83>, <https://w3id.org/ontouml-models/distribution/5e17c7cf-64d4-4945-9c18-4059e25cb15d>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/e3b58861-ccf1-4dc5-971d-cba03a3aaf88> dcat:distribution <https://w3id.org/ontouml-models/distribution/950acc83-d5c8-4999-a7ba-53a61de08f71/>,
+                      <https://w3id.org/ontouml-models/distribution/7dae0976-6ccc-4088-ba3b-5ebdc9b9069a/>,
+                      <https://w3id.org/ontouml-models/distribution/88d74bca-86c7-43f8-83a6-46a47353342b/>,
+                      <https://w3id.org/ontouml-models/distribution/37991053-2ddd-4eee-bcb6-875ebf984e6c>,
+                      <https://w3id.org/ontouml-models/distribution/7f919b5e-916d-45d3-9ba5-fa83112c7f45>,
+                      <https://w3id.org/ontouml-models/distribution/4b6606cb-c8d7-4025-beff-04c9295bd926>,
+                      <https://w3id.org/ontouml-models/distribution/491517ab-5362-4c7c-8bfd-cdec217dea3d>,
+                      <https://w3id.org/ontouml-models/distribution/fbd0fc36-d80e-446a-b619-1d017243b1b8>,
+                      <https://w3id.org/ontouml-models/distribution/e7fe0ca1-bad9-4dac-b1e3-38344f53e900>,
+                      <https://w3id.org/ontouml-models/distribution/089328d3-6bae-4036-83d8-16aa4ba67e96>,
+                      <https://w3id.org/ontouml-models/distribution/e2039d6f-2ae7-4bad-a4b9-0e8ec16df301>,
+                      <https://w3id.org/ontouml-models/distribution/c3b8cd9a-1807-4808-9070-fc724d57aa83>,
+                      <https://w3id.org/ontouml-models/distribution/5e17c7cf-64d4-4945-9c18-4059e25cb15d> .

--- a/models/romanenko2023what/metadata.ttl
+++ b/models/romanenko2023what/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/f7a6d395-077a-4a83-b554-f169733c2329/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -19,13 +18,19 @@
     skos:editorialNote "The ontology was created for user research study.";
     dct:language "en";
     dct:license <https://www.gnu.org/licenses/gpl-3.0.en.html>;
-    dct:contributor <https://dblp.org/pid/320/3107>, <https://dblp.org/pid/c/DiegoCalvanese>, <https://dblp.org/pid/11/78>;
+    dct:contributor <https://dblp.org/pid/320/3107>,
+                    <https://dblp.org/pid/c/DiegoCalvanese>,
+                    <https://dblp.org/pid/11/78>;
     dcat:keyword "library"@en;
     mod:designedForTask ocmv:Learning;
     ocmv:context ocmv:Research;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/romanenko2023what"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/romanenko2023what"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T18:13:29.215812785Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:13:29.215812785Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/f7a6d395-077a-4a83-b554-f169733c2329> dcat:distribution <https://w3id.org/ontouml-models/distribution/2f5d69a4-8724-401b-8d2e-e5181da2de22/>, <https://w3id.org/ontouml-models/distribution/f94c18dc-8c06-4e55-b600-3ebec1683cc5/>, <https://w3id.org/ontouml-models/distribution/9c72c4c4-4889-4aa4-8510-55a900c8d56f/>, <https://w3id.org/ontouml-models/distribution/4aa3d54c-dd8f-4ba5-ab45-e0a6fdf0dd55>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/f7a6d395-077a-4a83-b554-f169733c2329> dcat:distribution <https://w3id.org/ontouml-models/distribution/2f5d69a4-8724-401b-8d2e-e5181da2de22/>,
+                      <https://w3id.org/ontouml-models/distribution/f94c18dc-8c06-4e55-b600-3ebec1683cc5/>,
+                      <https://w3id.org/ontouml-models/distribution/9c72c4c4-4889-4aa4-8510-55a900c8d56f/>,
+                      <https://w3id.org/ontouml-models/distribution/4aa3d54c-dd8f-4ba5-ab45-e0a6fdf0dd55> .

--- a/models/saleme2019mulseonto/metadata.ttl
+++ b/models/saleme2019mulseonto/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/702dccd6-11ad-4a8a-889f-2c65bff7b64e/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -19,14 +18,30 @@
     skos:editorialNote "The ontology was documented as shown in the paper entitled `MulseOnto: a Reference Ontology to Support the Design of Mulsemedia Systems`";
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:contributor <https://dblp.org/pid/170/1631>, <https://dblp.org/pid/s/CelsoAlbertoSaibelSantos>, <https://dblp.org/pid/229/4259>, <https://dblp.org/pid/g/GeorgeGhinea>, <https://dblp.org/pid/a/FredericAndres>;
+    dct:contributor <https://dblp.org/pid/170/1631>,
+                    <https://dblp.org/pid/s/CelsoAlbertoSaibelSantos>,
+                    <https://dblp.org/pid/229/4259>,
+                    <https://dblp.org/pid/g/GeorgeGhinea>,
+                    <https://dblp.org/pid/a/FredericAndres>;
     dcat:keyword "mulsemedia systems"@en;
+    dct:source <https://dblp.org/rec/journals/jucs/SalemeSFGA19>,
+               <https://doi.org/10.1145/3281375.3281378>;
     mod:designedForTask ocmv:ConceptualClarification;
     ocmv:context ocmv:Research;
-    dct:source <https://dblp.org/rec/journals/jucs/SalemeSFGA19>, <https://doi.org/10.1145/3281375.3281378>;
     ocmv:representationStyle ocmv:UfoStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/saleme2019mulseonto"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/saleme2019mulseonto"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T18:13:36.935398647Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:13:36.935398647Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/702dccd6-11ad-4a8a-889f-2c65bff7b64e> dcat:distribution <https://w3id.org/ontouml-models/distribution/7bcdf4b0-bede-4a19-85f0-0a7bea011aa7/>, <https://w3id.org/ontouml-models/distribution/6aa9f95e-3c57-4ae2-b477-5899b62e7e1f/>, <https://w3id.org/ontouml-models/distribution/b246521c-e048-442c-acab-87233060b21b/>, <https://w3id.org/ontouml-models/distribution/a1600f14-9206-4b77-9162-97895c9b2028>, <https://w3id.org/ontouml-models/distribution/1c8444dd-8137-4d36-9c63-7fbb04682d91>, <https://w3id.org/ontouml-models/distribution/4f413978-013f-436a-a30a-43193fa7690a>, <https://w3id.org/ontouml-models/distribution/0e2f20b6-172d-4109-9e97-9a8eae3078cb>, <https://w3id.org/ontouml-models/distribution/6a595d62-13fa-422b-a827-85025e1e5ee2>, <https://w3id.org/ontouml-models/distribution/0db59c20-b6c7-4950-92cb-6256cc435f57>, <https://w3id.org/ontouml-models/distribution/8995bc94-091a-4424-aa97-5def2fcb60e4>, <https://w3id.org/ontouml-models/distribution/d72397b8-ebe8-4941-8c24-a90110243c5d>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/702dccd6-11ad-4a8a-889f-2c65bff7b64e> dcat:distribution <https://w3id.org/ontouml-models/distribution/7bcdf4b0-bede-4a19-85f0-0a7bea011aa7/>,
+                      <https://w3id.org/ontouml-models/distribution/6aa9f95e-3c57-4ae2-b477-5899b62e7e1f/>,
+                      <https://w3id.org/ontouml-models/distribution/b246521c-e048-442c-acab-87233060b21b/>,
+                      <https://w3id.org/ontouml-models/distribution/a1600f14-9206-4b77-9162-97895c9b2028>,
+                      <https://w3id.org/ontouml-models/distribution/1c8444dd-8137-4d36-9c63-7fbb04682d91>,
+                      <https://w3id.org/ontouml-models/distribution/4f413978-013f-436a-a30a-43193fa7690a>,
+                      <https://w3id.org/ontouml-models/distribution/0e2f20b6-172d-4109-9e97-9a8eae3078cb>,
+                      <https://w3id.org/ontouml-models/distribution/6a595d62-13fa-422b-a827-85025e1e5ee2>,
+                      <https://w3id.org/ontouml-models/distribution/0db59c20-b6c7-4950-92cb-6256cc435f57>,
+                      <https://w3id.org/ontouml-models/distribution/8995bc94-091a-4424-aa97-5def2fcb60e4>,
+                      <https://w3id.org/ontouml-models/distribution/d72397b8-ebe8-4941-8c24-a90110243c5d> .

--- a/models/sales2018competition/metadata.ttl
+++ b/models/sales2018competition/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/664d2c61-a600-4730-848d-83e46f7dec6e/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -17,14 +16,24 @@
     dcat:theme lcc:H;
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:contributor <https://dblp.org/pid/134/4947>, <https://dblp.org/pid/11/78>, <https://dblp.org/pid/65/6778>, <https://dblp.org/pid/m/JohnMylopoulos>;
-    dcat:keyword "competition"@en, "business"@en;
+    dct:contributor <https://dblp.org/pid/134/4947>,
+                    <https://dblp.org/pid/11/78>,
+                    <https://dblp.org/pid/65/6778>,
+                    <https://dblp.org/pid/m/JohnMylopoulos>;
+    dcat:keyword "competition"@en,
+                 "business"@en;
+    dct:source <https://dblp.org/rec/conf/vmbo/SalesGGM18>;
     mod:designedForTask ocmv:ConceptualClarification;
     ocmv:context ocmv:Research;
-    dct:source <https://dblp.org/rec/conf/vmbo/SalesGGM18>;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/sales2018competition"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/sales2018competition"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T18:13:56.116457511Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:13:56.116457511Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/664d2c61-a600-4730-848d-83e46f7dec6e> dcat:distribution <https://w3id.org/ontouml-models/distribution/ce97de16-6275-4aba-9389-c7f91c830dba/>, <https://w3id.org/ontouml-models/distribution/169e7a10-45ea-4375-ac19-362e940f19bb/>, <https://w3id.org/ontouml-models/distribution/106f274f-ba03-4055-a922-e00c6173d16f/>, <https://w3id.org/ontouml-models/distribution/f20db634-0f02-4cf9-a820-57aa7d0b759c>, <https://w3id.org/ontouml-models/distribution/1e7637b7-cf81-4da3-a5ad-b1cc97f04a8f>, <https://w3id.org/ontouml-models/distribution/f21f0dc2-4fa4-4d17-9882-31b1c4a6fd00>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/664d2c61-a600-4730-848d-83e46f7dec6e> dcat:distribution <https://w3id.org/ontouml-models/distribution/ce97de16-6275-4aba-9389-c7f91c830dba/>,
+                      <https://w3id.org/ontouml-models/distribution/169e7a10-45ea-4375-ac19-362e940f19bb/>,
+                      <https://w3id.org/ontouml-models/distribution/106f274f-ba03-4055-a922-e00c6173d16f/>,
+                      <https://w3id.org/ontouml-models/distribution/f20db634-0f02-4cf9-a820-57aa7d0b759c>,
+                      <https://w3id.org/ontouml-models/distribution/1e7637b7-cf81-4da3-a5ad-b1cc97f04a8f>,
+                      <https://w3id.org/ontouml-models/distribution/f21f0dc2-4fa4-4d17-9882-31b1c4a6fd00> .

--- a/models/sales2018cover/metadata.ttl
+++ b/models/sales2018cover/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/ef85708e-02ce-40b4-8fdb-57799201ee28/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -20,14 +19,42 @@
     dct:language "en";
     dcat:landingPage <https://github.com/unibz-core/value-and-risk-ontology>;
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:contributor <https://dblp.org/pid/134/4947>, <https://dblp.org/pid/b/FAraujoBaiao>, <https://dblp.org/pid/11/78>, <https://dblp.org/pid/91/3408>, <https://dblp.org/pid/65/6778>, <https://dblp.org/pid/m/JohnMylopoulos>;
-    dcat:keyword "value"@en, "risk"@en;
+    dct:contributor <https://dblp.org/pid/134/4947>,
+                    <https://dblp.org/pid/b/FAraujoBaiao>,
+                    <https://dblp.org/pid/11/78>,
+                    <https://dblp.org/pid/91/3408>,
+                    <https://dblp.org/pid/65/6778>,
+                    <https://dblp.org/pid/m/JohnMylopoulos>;
+    dcat:keyword "value"@en,
+                 "risk"@en;
+    dct:source <https://doi.org/10.1007/978-3-030-00847-5_11>,
+               <https://doi.org/10.1109/EDOC.2018.00028>;
     mod:designedForTask ocmv:ConceptualClarification;
     ocmv:context ocmv:Research;
-    dct:source <https://doi.org/10.1007/978-3-030-00847-5_11>, <https://doi.org/10.1109/EDOC.2018.00028>;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Core;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/sales2018cover"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/sales2018cover"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T18:14:07.077415055Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:14:07.077415055Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/ef85708e-02ce-40b4-8fdb-57799201ee28> dcat:distribution <https://w3id.org/ontouml-models/distribution/f84cb3d6-0a40-4ca4-9a97-b2add219c016/>, <https://w3id.org/ontouml-models/distribution/7a5184d2-7ec3-41df-a3df-97516b17c6e8/>, <https://w3id.org/ontouml-models/distribution/f9c8342a-ad52-4502-b27a-0cbd75752438/>, <https://w3id.org/ontouml-models/distribution/2e1ed5c8-6907-4378-adcb-13543baabc5e>, <https://w3id.org/ontouml-models/distribution/9ce6815a-73d5-424a-a9aa-562b0ebc96df>, <https://w3id.org/ontouml-models/distribution/4e074e27-e967-4cdc-911d-b5960d58ae55>, <https://w3id.org/ontouml-models/distribution/90986f39-d6da-4e61-a9c1-b7f14e614be3>, <https://w3id.org/ontouml-models/distribution/4ba5fe51-0e31-4e7f-b37c-78bb530cb108>, <https://w3id.org/ontouml-models/distribution/01b6b67c-af16-4965-a70b-cfa5e8676d5a>, <https://w3id.org/ontouml-models/distribution/4ce2f3b3-1c72-4d6b-85c5-de6900b9e9da>, <https://w3id.org/ontouml-models/distribution/136b701a-a72d-4120-83a3-b77212ed6ec0>, <https://w3id.org/ontouml-models/distribution/3a394245-f929-44db-834a-021ff70fb96d>, <https://w3id.org/ontouml-models/distribution/da7fde5d-7cf2-464a-a33f-cda281baf9fd>, <https://w3id.org/ontouml-models/distribution/96b42b9a-c19c-4120-a6be-254a8c09bbe3>, <https://w3id.org/ontouml-models/distribution/93090b25-8d83-414a-9389-28d7b0b9e52d>, <https://w3id.org/ontouml-models/distribution/045ef67e-b323-4344-96e6-5343c242b634>, <https://w3id.org/ontouml-models/distribution/0a166b75-5231-485e-a090-a6b14a8e678d>, <https://w3id.org/ontouml-models/distribution/11f8c1a8-0d81-4827-9c96-b07e58fa6596>, <https://w3id.org/ontouml-models/distribution/e202e8ff-0892-43e7-9b88-c591b1a1c493>, <https://w3id.org/ontouml-models/distribution/a8074c2c-a75e-40b7-986d-f9e4997ab3be>, <https://w3id.org/ontouml-models/distribution/63d649e0-f56e-46f7-bb26-19b6bc64645b>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/ef85708e-02ce-40b4-8fdb-57799201ee28> dcat:distribution <https://w3id.org/ontouml-models/distribution/f84cb3d6-0a40-4ca4-9a97-b2add219c016/>,
+                      <https://w3id.org/ontouml-models/distribution/7a5184d2-7ec3-41df-a3df-97516b17c6e8/>,
+                      <https://w3id.org/ontouml-models/distribution/f9c8342a-ad52-4502-b27a-0cbd75752438/>,
+                      <https://w3id.org/ontouml-models/distribution/2e1ed5c8-6907-4378-adcb-13543baabc5e>,
+                      <https://w3id.org/ontouml-models/distribution/9ce6815a-73d5-424a-a9aa-562b0ebc96df>,
+                      <https://w3id.org/ontouml-models/distribution/4e074e27-e967-4cdc-911d-b5960d58ae55>,
+                      <https://w3id.org/ontouml-models/distribution/90986f39-d6da-4e61-a9c1-b7f14e614be3>,
+                      <https://w3id.org/ontouml-models/distribution/4ba5fe51-0e31-4e7f-b37c-78bb530cb108>,
+                      <https://w3id.org/ontouml-models/distribution/01b6b67c-af16-4965-a70b-cfa5e8676d5a>,
+                      <https://w3id.org/ontouml-models/distribution/4ce2f3b3-1c72-4d6b-85c5-de6900b9e9da>,
+                      <https://w3id.org/ontouml-models/distribution/136b701a-a72d-4120-83a3-b77212ed6ec0>,
+                      <https://w3id.org/ontouml-models/distribution/3a394245-f929-44db-834a-021ff70fb96d>,
+                      <https://w3id.org/ontouml-models/distribution/da7fde5d-7cf2-464a-a33f-cda281baf9fd>,
+                      <https://w3id.org/ontouml-models/distribution/96b42b9a-c19c-4120-a6be-254a8c09bbe3>,
+                      <https://w3id.org/ontouml-models/distribution/93090b25-8d83-414a-9389-28d7b0b9e52d>,
+                      <https://w3id.org/ontouml-models/distribution/045ef67e-b323-4344-96e6-5343c242b634>,
+                      <https://w3id.org/ontouml-models/distribution/0a166b75-5231-485e-a090-a6b14a8e678d>,
+                      <https://w3id.org/ontouml-models/distribution/11f8c1a8-0d81-4827-9c96-b07e58fa6596>,
+                      <https://w3id.org/ontouml-models/distribution/e202e8ff-0892-43e7-9b88-c591b1a1c493>,
+                      <https://w3id.org/ontouml-models/distribution/a8074c2c-a75e-40b7-986d-f9e4997ab3be>,
+                      <https://w3id.org/ontouml-models/distribution/63d649e0-f56e-46f7-bb26-19b6bc64645b> .

--- a/models/santos2020valuenetworks/metadata.ttl
+++ b/models/santos2020valuenetworks/metadata.ttl
@@ -1,31 +1,36 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/87dea242-75d9-4b89-99f3-6f52c0855f3a/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:title "Ontology for Value Networks with Corporate Responsibility";
     dct:issued "2020"^^xsd:gYear;
     dcat:theme lcc:H;
     skos:editorialNote "The author does not explicitly give a name to the ontology. In the original work, she refers to it by \"Ontologia para Modelagem de Redes de Valor com Responsabilidade Corporativa\", which I translated here to \"Ontology for Value Networks with Corporate Responsibility\". The diagram name was given by the author.";
     dct:language "en";
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:contributor <https://dblp.org/pid/253/7660>;
-    dcat:keyword "value networks"@en, "corporate responsibility"@en;
+    dcat:keyword "value networks"@en,
+                 "corporate responsibility"@en;
+    dct:source <https://ppgcc.ufersa.edu.br/wp-content/uploads/sites/42/2021/02/DissertaçãoOt%C3%ADliaSantosUERN-UFERSAVDC.pdf>;
     mod:designedForTask ocmv:LanguageEngineering;
     ocmv:context ocmv:Research;
-    dct:source <https://ppgcc.ufersa.edu.br/wp-content/uploads/sites/42/2021/02/DissertaçãoOt%C3%ADliaSantosUERN-UFERSAVDC.pdf>;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/santos2020valuenetworks"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/santos2020valuenetworks"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T18:14:41.999159589Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:14:41.999159589Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/87dea242-75d9-4b89-99f3-6f52c0855f3a> dcat:distribution <https://w3id.org/ontouml-models/distribution/6eb5fef7-837f-49ef-8c8f-8d7a7ccc174f/>, <https://w3id.org/ontouml-models/distribution/e76e2bc1-8044-42e9-a8c7-9734069bff0e/>, <https://w3id.org/ontouml-models/distribution/d3314b04-455e-4410-a412-4570bc6ff0e4/>, <https://w3id.org/ontouml-models/distribution/02ddc4f5-b2ce-45a0-baa1-1234aa078711>, <https://w3id.org/ontouml-models/distribution/417b647f-be23-4c7a-a8c0-25b2fd18e440>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/87dea242-75d9-4b89-99f3-6f52c0855f3a> dcat:distribution <https://w3id.org/ontouml-models/distribution/6eb5fef7-837f-49ef-8c8f-8d7a7ccc174f/>,
+                      <https://w3id.org/ontouml-models/distribution/e76e2bc1-8044-42e9-a8c7-9734069bff0e/>,
+                      <https://w3id.org/ontouml-models/distribution/d3314b04-455e-4410-a412-4570bc6ff0e4/>,
+                      <https://w3id.org/ontouml-models/distribution/02ddc4f5-b2ce-45a0-baa1-1234aa078711>,
+                      <https://w3id.org/ontouml-models/distribution/417b647f-be23-4c7a-a8c0-25b2fd18e440> .

--- a/models/sariev2024maritime/metadata.ttl
+++ b/models/sariev2024maritime/metadata.ttl
@@ -1,36 +1,42 @@
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/model/sariev2024maritime/> a dcat:Dataset, mod:SemanticArtefact;
+<https://w3id.org/ontouml-models/model/sariev2024maritime/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
+    dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
     dct:title "Ontology for Digital Twin Development in Maritime Logistics";
     dct:issued "2024"^^xsd:gYear;
     dcat:theme lcc:H;
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:contributor <https://www.linkedin.com/in/bekbolot-sariev-7bb6b0265/>;
-    mod:designedForTask ocmv:ConceptualClarification, ocmv:Interoperability, ocmv:DecisionSupportSystem;
+    dcat:keyword "maritime logistics"@en,
+                 "digital twin"@en,
+                 "port management"@en,
+                 "vessel traffic management"@en;
+    dct:source <https://purl.utwente.nl/essays/101204>;
+    mod:designedForTask ocmv:ConceptualClarification,
+                        ocmv:Interoperability,
+                        ocmv:DecisionSupportSystem;
     ocmv:context ocmv:Research;
-    dct:source <https://purl.utwente.nl/essays/101204>.
-<https://w3id.org/ontouml-models/model/sariev2024maritime/> dcat:distribution <https://w3id.org/ontouml-models/model/sariev2024maritime/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/sariev2024maritime/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Ontology for Digital Twin Development in Maritime Logistics\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/sariev2024maritime/ontology.ttl>.
-<https://w3id.org/ontouml-models/model/sariev2024maritime/> dcat:distribution <https://w3id.org/ontouml-models/model/sariev2024maritime/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/sariev2024maritime/distribution/ttl> a dcat:Distribution;
-    dct:title "JSON distribution of \"Ontology for Digital Twin Development in Maritime Logistics\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/sariev2024maritime/ontology.json>.
-<https://w3id.org/ontouml-models/model/sariev2024maritime/> dcat:distribution <https://w3id.org/ontouml-models/model/sariev2024maritime/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/sariev2024maritime/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Ontology for Digital Twin Development in Maritime Logistics\""@en;
-    dcat:mediaType <https://www.visual-paradigm.com/vpp>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/sariev2024maritime/ontology.vpp>.
+    ocmv:representationStyle ocmv:OntoumlStyle;
+    ocmv:ontologyType ocmv:Domain;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/sariev2024maritime"^^xsd:anyURI;
+    fdpo:metadataIssued "2026-06-23T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/sariev2024maritime/> dcat:distribution <https://w3id.org/ontouml-models/model/sariev2024maritime/distribution/ttl>,
+                      <https://www.iana.org/assignments/media-types/text/turtle>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/sariev2024maritime/ontology.ttl>,
+                      <https://w3id.org/ontouml-models/model/sariev2024maritime/>,
+                      <https://www.iana.org/assignments/media-types/application/json>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/sariev2024maritime/ontology.json>,
+                      <https://www.visual-paradigm.com/vpp>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/sariev2024maritime/ontology.vpp> .

--- a/models/schoonderbeek2024eamon/metadata.ttl
+++ b/models/schoonderbeek2024eamon/metadata.ttl
@@ -1,37 +1,42 @@
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/model/schoonderbeek2024eamon/> a dcat:Dataset, mod:SemanticArtefact;
+<https://w3id.org/ontouml-models/model/schoonderbeek2024eamon/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
+    dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
     dct:title "Enterprise Architecture Modeling Ontology";
     mod:acronym "EAMOn";
     dct:issued "2024"^^xsd:gYear;
     dcat:theme lcc:T;
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:contributor <https://dblp.org/pid/381/4970>, <https://dblp.org/pid/p/ErikProper>;
-    mod:designedForTask ocmv:ConceptualClarification, ocmv:OntologicalAnalysis;
+    dct:contributor <https://dblp.org/pid/381/4970>,
+                    <https://dblp.org/pid/p/ErikProper>;
+    dcat:keyword "enterprise architecture model"@en,
+                 "model quality"@en,
+                 "architecture concept"@en;
+    dct:source <https://doi.org/10.1007/s10270-023-01146-w>;
+    mod:designedForTask ocmv:ConceptualClarification,
+                        ocmv:OntologicalAnalysis;
     ocmv:context ocmv:Research;
-    dct:source <https://doi.org/10.1007/s10270-023-01146-w>.
-<https://w3id.org/ontouml-models/model/schoonderbeek2024eamon/> dcat:distribution <https://w3id.org/ontouml-models/model/schoonderbeek2024eamon/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/schoonderbeek2024eamon/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Enterprise Architecture Modeling Ontology\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/schoonderbeek2024eamon/ontology.ttl>.
-<https://w3id.org/ontouml-models/model/schoonderbeek2024eamon/> dcat:distribution <https://w3id.org/ontouml-models/model/schoonderbeek2024eamon/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/schoonderbeek2024eamon/distribution/ttl> a dcat:Distribution;
-    dct:title "JSON distribution of \"Enterprise Architecture Modeling Ontology\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/schoonderbeek2024eamon/ontology.json>.
-<https://w3id.org/ontouml-models/model/schoonderbeek2024eamon/> dcat:distribution <https://w3id.org/ontouml-models/model/schoonderbeek2024eamon/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/schoonderbeek2024eamon/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Enterprise Architecture Modeling Ontology\""@en;
-    dcat:mediaType <https://www.visual-paradigm.com/vpp>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/schoonderbeek2024eamon/ontology.vpp>.
+    ocmv:representationStyle ocmv:OntoumlStyle;
+    ocmv:ontologyType ocmv:Domain;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/schoonderbeek2024eamon"^^xsd:anyURI;
+    fdpo:metadataIssued "2026-06-23T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/schoonderbeek2024eamon/> dcat:distribution <https://w3id.org/ontouml-models/model/schoonderbeek2024eamon/distribution/ttl>,
+                      <https://www.iana.org/assignments/media-types/text/turtle>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/schoonderbeek2024eamon/ontology.ttl>,
+                      <https://w3id.org/ontouml-models/model/schoonderbeek2024eamon/>,
+                      <https://www.iana.org/assignments/media-types/application/json>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/schoonderbeek2024eamon/ontology.json>,
+                      <https://www.visual-paradigm.com/vpp>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/schoonderbeek2024eamon/ontology.vpp> .

--- a/models/scientific-experiment2013/metadata.ttl
+++ b/models/scientific-experiment2013/metadata.ttl
@@ -1,35 +1,39 @@
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/model/scientific-experiment2013/> a dcat:Dataset, mod:SemanticArtefact;
+<https://w3id.org/ontouml-models/model/scientific-experiment2013/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
+    dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
     dct:title "Scientific Experiment Ontology";
     dct:issued "2013"^^xsd:gYear;
     dcat:theme lcc:Q;
     skos:editorialNote "Ontology created during an Ontology Engineering lecture by students who wanted to remain anonymous. The ontology was build in a different editor tool and imported to Visual Paradigm, the current diagrammation may not exactly match the original one.";
     dct:language "pt-br";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    mod:designedForTask ocmv:ConceptualClarification, ocmv:Learning;
-    ocmv:context ocmv:Classroom.
-<https://w3id.org/ontouml-models/model/scientific-experiment2013/> dcat:distribution <https://w3id.org/ontouml-models/model/scientific-experiment2013/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/scientific-experiment2013/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Scientific Experiment Ontology\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/scientific-experiment2013/ontology.ttl>.
-<https://w3id.org/ontouml-models/model/scientific-experiment2013/> dcat:distribution <https://w3id.org/ontouml-models/model/scientific-experiment2013/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/scientific-experiment2013/distribution/ttl> a dcat:Distribution;
-    dct:title "JSON distribution of \"Scientific Experiment Ontology\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/scientific-experiment2013/ontology.json>.
-<https://w3id.org/ontouml-models/model/scientific-experiment2013/> dcat:distribution <https://w3id.org/ontouml-models/model/scientific-experiment2013/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/scientific-experiment2013/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Scientific Experiment Ontology\""@en;
-    dcat:mediaType <https://www.visual-paradigm.com/vpp>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/scientific-experiment2013/ontology.vpp>.
+    dcat:keyword "science"@en,
+                 "scientific method"@en,
+                 "experiment"@en;
+    mod:designedForTask ocmv:ConceptualClarification,
+                        ocmv:Learning;
+    ocmv:context ocmv:Classroom;
+    ocmv:representationStyle ocmv:OntoumlStyle;
+    ocmv:ontologyType ocmv:Domain;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/scientific-experiment2013"^^xsd:anyURI;
+    fdpo:metadataIssued "2026-06-23T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/scientific-experiment2013/> dcat:distribution <https://w3id.org/ontouml-models/model/scientific-experiment2013/distribution/ttl>,
+                      <https://www.iana.org/assignments/media-types/text/turtle>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/scientific-experiment2013/ontology.ttl>,
+                      <https://w3id.org/ontouml-models/model/scientific-experiment2013/>,
+                      <https://www.iana.org/assignments/media-types/application/json>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/scientific-experiment2013/ontology.json>,
+                      <https://www.visual-paradigm.com/vpp>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/scientific-experiment2013/ontology.vpp> .

--- a/models/scientific-publication2013/metadata.ttl
+++ b/models/scientific-publication2013/metadata.ttl
@@ -1,35 +1,39 @@
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/model/scientific-publication2013/> a dcat:Dataset, mod:SemanticArtefact;
+<https://w3id.org/ontouml-models/model/scientific-publication2013/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
+    dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
     dct:title "Scientific Publication Ontology";
     dct:issued "2013"^^xsd:gYear;
     dcat:theme lcc:A;
     skos:editorialNote "Ontology created during an Ontology Engineering lecture by students who wanted to remain anonymous. The ontology was build in a different editor tool and imported to Visual Paradigm, the current diagrammation may not exactly match the original one.";
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    mod:designedForTask ocmv:ConceptualClarification, ocmv:Learning;
-    ocmv:context ocmv:Classroom.
-<https://w3id.org/ontouml-models/model/scientific-publication2013/> dcat:distribution <https://w3id.org/ontouml-models/model/scientific-publication2013/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/scientific-publication2013/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Scientific Publication Ontology\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/scientific-publication2013/ontology.ttl>.
-<https://w3id.org/ontouml-models/model/scientific-publication2013/> dcat:distribution <https://w3id.org/ontouml-models/model/scientific-publication2013/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/scientific-publication2013/distribution/ttl> a dcat:Distribution;
-    dct:title "JSON distribution of \"Scientific Publication Ontology\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/scientific-publication2013/ontology.json>.
-<https://w3id.org/ontouml-models/model/scientific-publication2013/> dcat:distribution <https://w3id.org/ontouml-models/model/scientific-publication2013/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/scientific-publication2013/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Scientific Publication Ontology\""@en;
-    dcat:mediaType <https://www.visual-paradigm.com/vpp>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/scientific-publication2013/ontology.vpp>.
+    dcat:keyword "publication"@en,
+                 "academy"@en,
+                 "science"@en;
+    mod:designedForTask ocmv:ConceptualClarification,
+                        ocmv:Learning;
+    ocmv:context ocmv:Classroom;
+    ocmv:representationStyle ocmv:OntoumlStyle;
+    ocmv:ontologyType ocmv:Domain;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/scientific-publication2013"^^xsd:anyURI;
+    fdpo:metadataIssued "2026-06-23T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/scientific-publication2013/> dcat:distribution <https://w3id.org/ontouml-models/model/scientific-publication2013/distribution/ttl>,
+                      <https://www.iana.org/assignments/media-types/text/turtle>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/scientific-publication2013/ontology.ttl>,
+                      <https://w3id.org/ontouml-models/model/scientific-publication2013/>,
+                      <https://www.iana.org/assignments/media-types/application/json>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/scientific-publication2013/ontology.json>,
+                      <https://www.visual-paradigm.com/vpp>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/scientific-publication2013/ontology.vpp> .

--- a/models/services2015/metadata.ttl
+++ b/models/services2015/metadata.ttl
@@ -1,35 +1,40 @@
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/model/services2015/> a dcat:Dataset, mod:SemanticArtefact;
+<https://w3id.org/ontouml-models/model/services2015/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
+    dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
     dct:title "Services Ontology";
     dct:issued "2015"^^xsd:gYear;
     dcat:theme lcc:H;
     skos:editorialNote "Author required to remain anonymous.";
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    dcat:keyword "service"@en,
+                 "service delivery"@en,
+                 "service negotiation"@en,
+                 "service offering"@en;
     mod:designedForTask ocmv:ConceptualClarification;
-    ocmv:context ocmv:Industry.
-<https://w3id.org/ontouml-models/model/services2015/> dcat:distribution <https://w3id.org/ontouml-models/model/services2015/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/services2015/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Services Ontology\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/services2015/ontology.ttl>.
-<https://w3id.org/ontouml-models/model/services2015/> dcat:distribution <https://w3id.org/ontouml-models/model/services2015/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/services2015/distribution/ttl> a dcat:Distribution;
-    dct:title "JSON distribution of \"Services Ontology\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/services2015/ontology.json>.
-<https://w3id.org/ontouml-models/model/services2015/> dcat:distribution <https://w3id.org/ontouml-models/model/services2015/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/services2015/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Services Ontology\""@en;
-    dcat:mediaType <https://www.visual-paradigm.com/vpp>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/services2015/ontology.vpp>.
+    ocmv:context ocmv:Industry;
+    ocmv:representationStyle ocmv:UfoStyle,
+                             ocmv:OntoumlStyle;
+    ocmv:ontologyType ocmv:Domain;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/services2015"^^xsd:anyURI;
+    fdpo:metadataIssued "2026-06-23T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/services2015/> dcat:distribution <https://w3id.org/ontouml-models/model/services2015/distribution/ttl>,
+                      <https://www.iana.org/assignments/media-types/text/turtle>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/services2015/ontology.ttl>,
+                      <https://w3id.org/ontouml-models/model/services2015/>,
+                      <https://www.iana.org/assignments/media-types/application/json>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/services2015/ontology.json>,
+                      <https://www.visual-paradigm.com/vpp>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/services2015/ontology.vpp> .

--- a/models/short-examples2013/metadata.ttl
+++ b/models/short-examples2013/metadata.ttl
@@ -1,35 +1,37 @@
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/model/short-examples2013/> a dcat:Dataset, mod:SemanticArtefact;
+<https://w3id.org/ontouml-models/model/short-examples2013/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
+    dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
     dct:title "Short Examples of OntoUML Ontologies";
     dct:issued "2013"^^xsd:gYear;
     dcat:theme lcc:Z;
     skos:editorialNote "Ontology created during an Ontology Engineering lecture by students who wanted to remain anonymous. The ontology was build in a different editor tool and imported to Visual Paradigm, the current diagrammation may not exactly match the original one.";
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    dcat:keyword "criminal investigation"@en,
+                 "ontouml"@en;
     mod:designedForTask ocmv:Learning;
-    ocmv:context ocmv:Classroom.
-<https://w3id.org/ontouml-models/model/short-examples2013/> dcat:distribution <https://w3id.org/ontouml-models/model/short-examples2013/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/short-examples2013/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Short Examples of OntoUML Ontologies\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/short-examples2013/ontology.ttl>.
-<https://w3id.org/ontouml-models/model/short-examples2013/> dcat:distribution <https://w3id.org/ontouml-models/model/short-examples2013/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/short-examples2013/distribution/ttl> a dcat:Distribution;
-    dct:title "JSON distribution of \"Short Examples of OntoUML Ontologies\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/short-examples2013/ontology.json>.
-<https://w3id.org/ontouml-models/model/short-examples2013/> dcat:distribution <https://w3id.org/ontouml-models/model/short-examples2013/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/short-examples2013/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Short Examples of OntoUML Ontologies\""@en;
-    dcat:mediaType <https://www.visual-paradigm.com/vpp>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/short-examples2013/ontology.vpp>.
+    ocmv:context ocmv:Classroom;
+    ocmv:representationStyle ocmv:OntoumlStyle;
+    ocmv:ontologyType ocmv:Domain;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/short-examples2013"^^xsd:anyURI;
+    fdpo:metadataIssued "2026-06-23T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/short-examples2013/> dcat:distribution <https://w3id.org/ontouml-models/model/short-examples2013/distribution/ttl>,
+                      <https://www.iana.org/assignments/media-types/text/turtle>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/short-examples2013/ontology.ttl>,
+                      <https://w3id.org/ontouml-models/model/short-examples2013/>,
+                      <https://www.iana.org/assignments/media-types/application/json>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/short-examples2013/ontology.json>,
+                      <https://www.visual-paradigm.com/vpp>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/short-examples2013/ontology.vpp> .

--- a/models/sikora2021online-education/metadata.ttl
+++ b/models/sikora2021online-education/metadata.ttl
@@ -1,32 +1,64 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/c3b6f81b-7d10-4e11-bdf2-4e291d0f8f70/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:title "Online Education Ontology";
     dct:issued "2021"^^xsd:gYear;
     dct:modified "2021"^^xsd:gYear;
     dcat:theme lcc:L;
     skos:editorialNote "there is a class \"comment\" that is both a \"kind\" and a \"relator\"";
     dct:language "en";
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:contributor <https://orcid.org/0000-0003-0155-6345>;
     dcat:keyword "education"@en;
+    dct:source <https://dspace.cvut.cz/handle/10467/95442>;
     mod:designedForTask ocmv:SoftwareEngineering;
     ocmv:context ocmv:Research;
-    dct:source <https://dspace.cvut.cz/handle/10467/95442>;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/sikora2021online-education"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/sikora2021online-education"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T18:14:51.359962306Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:14:51.359962306Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/c3b6f81b-7d10-4e11-bdf2-4e291d0f8f70> dcat:distribution <https://w3id.org/ontouml-models/distribution/b03c171f-b771-4ea0-9fa0-91024d89168e/>, <https://w3id.org/ontouml-models/distribution/26661f89-956e-4840-bbae-02503e01e524/>, <https://w3id.org/ontouml-models/distribution/7808aae7-83ba-42a9-8c55-acd8f716092b/>, <https://w3id.org/ontouml-models/distribution/4d80b145-6266-40a8-ba85-1d65a49cf4c0>, <https://w3id.org/ontouml-models/distribution/4d80b145-6266-40a8-ba85-1d65a49cf4c00>, <https://w3id.org/ontouml-models/distribution/4d80b145-6266-40a8-ba85-1d65a49cf4c01>, <https://w3id.org/ontouml-models/distribution/4d80b145-6266-40a8-ba85-1d65a49cf4c02>, <https://w3id.org/ontouml-models/distribution/8bdeb698-4585-4b01-be31-4097f7f75541>, <https://w3id.org/ontouml-models/distribution/b66c24e5-5a5a-4cbf-b915-24171417966f>, <https://w3id.org/ontouml-models/distribution/91640df3-4901-4717-9b3e-32112de7195c>, <https://w3id.org/ontouml-models/distribution/3f95fc2e-662d-41c0-a214-e782e8d0e3b0>, <https://w3id.org/ontouml-models/distribution/5cd0c10d-40bd-4ffb-a779-877cf0f1fb0f>, <https://w3id.org/ontouml-models/distribution/13d7a7bb-0382-4ff5-8f31-821bd07ca04d>, <https://w3id.org/ontouml-models/distribution/623766f3-4edb-4cd9-9f82-d483ff66734e>, <https://w3id.org/ontouml-models/distribution/679c9c8d-2d54-4121-849a-619574c64002>, <https://w3id.org/ontouml-models/distribution/857e2eed-6ea4-44f7-80cd-51c83681afb8>, <https://w3id.org/ontouml-models/distribution/857e2eed-6ea4-44f7-80cd-51c83681afb80>, <https://w3id.org/ontouml-models/distribution/857e2eed-6ea4-44f7-80cd-51c83681afb81>, <https://w3id.org/ontouml-models/distribution/857e2eed-6ea4-44f7-80cd-51c83681afb82>, <https://w3id.org/ontouml-models/distribution/6402fde4-a02e-4df7-aac5-6a2b733dcd9c>, <https://w3id.org/ontouml-models/distribution/64dc5702-8c25-43ad-972a-b4588b120c7c>, <https://w3id.org/ontouml-models/distribution/756b0027-3dd0-4f3f-ab46-1d30f74bfb73>, <https://w3id.org/ontouml-models/distribution/74ce77fe-4c69-474d-bc5f-2fb4493c51fe>, <https://w3id.org/ontouml-models/distribution/6ab29812-fa94-457b-b6e9-61bd79dd62a0>, <https://w3id.org/ontouml-models/distribution/8ebcfcb4-eaf2-474e-bc8f-9b954a31e7af>, <https://w3id.org/ontouml-models/distribution/dec761fb-ff58-46cf-aa61-74464a11e2cc>, <https://w3id.org/ontouml-models/distribution/793d36a5-7ea0-4468-8bc2-f5c9a7671d4b>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/c3b6f81b-7d10-4e11-bdf2-4e291d0f8f70> dcat:distribution <https://w3id.org/ontouml-models/distribution/b03c171f-b771-4ea0-9fa0-91024d89168e/>,
+                      <https://w3id.org/ontouml-models/distribution/26661f89-956e-4840-bbae-02503e01e524/>,
+                      <https://w3id.org/ontouml-models/distribution/7808aae7-83ba-42a9-8c55-acd8f716092b/>,
+                      <https://w3id.org/ontouml-models/distribution/4d80b145-6266-40a8-ba85-1d65a49cf4c0>,
+                      <https://w3id.org/ontouml-models/distribution/4d80b145-6266-40a8-ba85-1d65a49cf4c00>,
+                      <https://w3id.org/ontouml-models/distribution/4d80b145-6266-40a8-ba85-1d65a49cf4c01>,
+                      <https://w3id.org/ontouml-models/distribution/4d80b145-6266-40a8-ba85-1d65a49cf4c02>,
+                      <https://w3id.org/ontouml-models/distribution/8bdeb698-4585-4b01-be31-4097f7f75541>,
+                      <https://w3id.org/ontouml-models/distribution/b66c24e5-5a5a-4cbf-b915-24171417966f>,
+                      <https://w3id.org/ontouml-models/distribution/91640df3-4901-4717-9b3e-32112de7195c>,
+                      <https://w3id.org/ontouml-models/distribution/3f95fc2e-662d-41c0-a214-e782e8d0e3b0>,
+                      <https://w3id.org/ontouml-models/distribution/5cd0c10d-40bd-4ffb-a779-877cf0f1fb0f>,
+                      <https://w3id.org/ontouml-models/distribution/13d7a7bb-0382-4ff5-8f31-821bd07ca04d>,
+                      <https://w3id.org/ontouml-models/distribution/623766f3-4edb-4cd9-9f82-d483ff66734e>,
+                      <https://w3id.org/ontouml-models/distribution/679c9c8d-2d54-4121-849a-619574c64002>,
+                      <https://w3id.org/ontouml-models/distribution/857e2eed-6ea4-44f7-80cd-51c83681afb8>,
+                      <https://w3id.org/ontouml-models/distribution/857e2eed-6ea4-44f7-80cd-51c83681afb80>,
+                      <https://w3id.org/ontouml-models/distribution/857e2eed-6ea4-44f7-80cd-51c83681afb81>,
+                      <https://w3id.org/ontouml-models/distribution/857e2eed-6ea4-44f7-80cd-51c83681afb82>,
+                      <https://w3id.org/ontouml-models/distribution/6402fde4-a02e-4df7-aac5-6a2b733dcd9c>,
+                      <https://w3id.org/ontouml-models/distribution/64dc5702-8c25-43ad-972a-b4588b120c7c>,
+                      <https://w3id.org/ontouml-models/distribution/756b0027-3dd0-4f3f-ab46-1d30f74bfb73>,
+                      <https://w3id.org/ontouml-models/distribution/74ce77fe-4c69-474d-bc5f-2fb4493c51fe>,
+                      <https://w3id.org/ontouml-models/distribution/6ab29812-fa94-457b-b6e9-61bd79dd62a0>,
+                      <https://w3id.org/ontouml-models/distribution/8ebcfcb4-eaf2-474e-bc8f-9b954a31e7af>,
+                      <https://w3id.org/ontouml-models/distribution/dec761fb-ff58-46cf-aa61-74464a11e2cc>,
+                      <https://w3id.org/ontouml-models/distribution/793d36a5-7ea0-4468-8bc2-f5c9a7671d4b>,
+                      <https://w3id.org/ontouml-models/distribution/0be12cea-f13d-4b2b-93d4-e6b99a19b38e>,
+                      <https://w3id.org/ontouml-models/distribution/48cb0903-3b0c-49d4-a142-f8d8f16a9b4f>,
+                      <https://w3id.org/ontouml-models/distribution/49d69d4f-dd17-4ba6-9272-b219a3dd2479>,
+                      <https://w3id.org/ontouml-models/distribution/23984be2-a829-405b-b003-d65c3214565c>,
+                      <https://w3id.org/ontouml-models/distribution/86de3456-8fb7-42e1-a7fd-ddbd2cebdfd1>,
+                      <https://w3id.org/ontouml-models/distribution/920ee75d-5e48-4340-9a84-5beae5fdd408> .

--- a/models/silva2012itarchitecture/metadata.ttl
+++ b/models/silva2012itarchitecture/metadata.ttl
@@ -1,31 +1,47 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/65c6c4c6-a903-48dd-bd28-dcb4f0b8fe6d/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:title "IT Architecture Ontology (PAS 77:2006 Ontology)";
     dct:issued "2012"^^xsd:gYear;
     dct:modified "2012"^^xsd:gYear;
     dcat:theme lcc:T;
-    dct:language "en, pt-br";
-    dct:contributor <https://dblp.org/pid/119/6024>, <https://dblp.org/pid/119/6017>, <https://dblp.org/pid/119/6012>, <https://dblp.org/pid/06/10125>;
-    dcat:keyword "IT architecture"@en, "service continuity"@en;
-    mod:designedForTask ocmv:Interoperability, ocmv:OntologicalAnalysis;
+    dct:language "en",
+                 "pt-br";
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    dct:contributor <https://dblp.org/pid/119/6024>,
+                    <https://dblp.org/pid/119/6017>,
+                    <https://dblp.org/pid/119/6012>,
+                    <https://dblp.org/pid/06/10125>;
+    dcat:keyword "IT architecture"@en,
+                 "service continuity"@en;
+    dct:source <https://doi.org/10.1007/978-3-642-30567-2_12>,
+               <https://www.dline.info/jisr/fulltext/v3n2/1.pdf>;
+    mod:designedForTask ocmv:Interoperability,
+                        ocmv:OntologicalAnalysis;
     ocmv:context ocmv:Research;
-    dct:source <https://doi.org/10.1007/978-3-642-30567-2_12>, <https://www.dline.info/jisr/fulltext/v3n2/1.pdf>;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/silva2012itarchitecture"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/silva2012itarchitecture"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T18:15:35.74311328Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:15:35.74311328Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/65c6c4c6-a903-48dd-bd28-dcb4f0b8fe6d> dcat:distribution <https://w3id.org/ontouml-models/distribution/e8d04b21-786c-425e-9efc-48ef7846493d/>, <https://w3id.org/ontouml-models/distribution/1714ffe3-4a5a-49b9-af35-5b36d2b63b0a/>, <https://w3id.org/ontouml-models/distribution/a7645103-5f58-4edf-ab4d-4163b986733c/>, <https://w3id.org/ontouml-models/distribution/774d363b-5d23-4d12-892a-f474eae3bc88>, <https://w3id.org/ontouml-models/distribution/c28cb6bb-d731-4a0a-8c79-a2fcd84e4435>, <https://w3id.org/ontouml-models/distribution/a4245a71-8136-4054-b5bd-6c6b18ec65a5>, <https://w3id.org/ontouml-models/distribution/6fd7672f-1c91-4e81-b273-80671dac9f21>, <https://w3id.org/ontouml-models/distribution/034fad7d-3ae3-40d9-b009-e294d8dbf969>, <https://w3id.org/ontouml-models/distribution/f39eb53d-5e96-4c8c-9400-4fb1ecb543b4>, <https://w3id.org/ontouml-models/distribution/b42aa003-977e-4dd1-ba40-136ec28a58fe>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/65c6c4c6-a903-48dd-bd28-dcb4f0b8fe6d> dcat:distribution <https://w3id.org/ontouml-models/distribution/e8d04b21-786c-425e-9efc-48ef7846493d/>,
+                      <https://w3id.org/ontouml-models/distribution/1714ffe3-4a5a-49b9-af35-5b36d2b63b0a/>,
+                      <https://w3id.org/ontouml-models/distribution/a7645103-5f58-4edf-ab4d-4163b986733c/>,
+                      <https://w3id.org/ontouml-models/distribution/774d363b-5d23-4d12-892a-f474eae3bc88>,
+                      <https://w3id.org/ontouml-models/distribution/c28cb6bb-d731-4a0a-8c79-a2fcd84e4435>,
+                      <https://w3id.org/ontouml-models/distribution/a4245a71-8136-4054-b5bd-6c6b18ec65a5>,
+                      <https://w3id.org/ontouml-models/distribution/6fd7672f-1c91-4e81-b273-80671dac9f21>,
+                      <https://w3id.org/ontouml-models/distribution/034fad7d-3ae3-40d9-b009-e294d8dbf969>,
+                      <https://w3id.org/ontouml-models/distribution/f39eb53d-5e96-4c8c-9400-4fb1ecb543b4>,
+                      <https://w3id.org/ontouml-models/distribution/b42aa003-977e-4dd1-ba40-136ec28a58fe> .

--- a/models/silva2021sebim/metadata.ttl
+++ b/models/silva2021sebim/metadata.ttl
@@ -1,15 +1,16 @@
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/model/silva2021sebim/> a dcat:Dataset, mod:SemanticArtefact;
+<https://w3id.org/ontouml-models/model/silva2021sebim/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
+    dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
     dct:title "Semantic BIM";
     mod:acronym "SEBIM";
     dct:issued "2021"^^xsd:gYear;
@@ -19,22 +20,30 @@
     dct:language "en";
     dcat:landingPage <https://github.com/cgtsbr/sebim>;
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:contributor <https://dblp.org/pid/278/1460>, <https://dblp.org/pid/121/5314>;
-    mod:designedForTask ocmv:DecisionSupportSystem, ocmv:InformationRetrieval, ocmv:Interoperability;
-    ocmv:context ocmv:Research, ocmv:Industry;
-    dct:source <https://repositorio.ufmg.br/handle/1843/51648>, <https://repositorio.ufmg.br/handle/1843/51649>, <https://repositorio.ufmg.br/handle/1843/59093>, <https://repositorio.ufmg.br/handle/1843/59670>.
-<https://w3id.org/ontouml-models/model/silva2021sebim/> dcat:distribution <https://w3id.org/ontouml-models/model/silva2021sebim/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/silva2021sebim/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Semantic BIM\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/silva2021sebim/ontology.ttl>.
-<https://w3id.org/ontouml-models/model/silva2021sebim/> dcat:distribution <https://w3id.org/ontouml-models/model/silva2021sebim/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/silva2021sebim/distribution/ttl> a dcat:Distribution;
-    dct:title "JSON distribution of \"Semantic BIM\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/silva2021sebim/ontology.json>.
-<https://w3id.org/ontouml-models/model/silva2021sebim/> dcat:distribution <https://w3id.org/ontouml-models/model/silva2021sebim/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/silva2021sebim/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Semantic BIM\""@en;
-    dcat:mediaType <https://www.visual-paradigm.com/vpp>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/silva2021sebim/ontology.vpp>.
+    dct:contributor <https://dblp.org/pid/278/1460>,
+                    <https://dblp.org/pid/121/5314>;
+    dcat:keyword "building information modeling"@en,
+                 "sustainability"@en;
+    dct:source <https://repositorio.ufmg.br/handle/1843/51648>,
+               <https://repositorio.ufmg.br/handle/1843/51649>,
+               <https://repositorio.ufmg.br/handle/1843/59093>,
+               <https://repositorio.ufmg.br/handle/1843/59670>;
+    mod:designedForTask ocmv:DecisionSupportSystem,
+                        ocmv:InformationRetrieval,
+                        ocmv:Interoperability;
+    ocmv:context ocmv:Research,
+                 ocmv:Industry;
+    ocmv:representationStyle ocmv:OntoumlStyle;
+    ocmv:ontologyType ocmv:Domain;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/silva2021sebim"^^xsd:anyURI;
+    fdpo:metadataIssued "2026-06-23T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/silva2021sebim/> dcat:distribution <https://w3id.org/ontouml-models/model/silva2021sebim/distribution/ttl>,
+                      <https://www.iana.org/assignments/media-types/text/turtle>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/silva2021sebim/ontology.ttl>,
+                      <https://w3id.org/ontouml-models/model/silva2021sebim/>,
+                      <https://www.iana.org/assignments/media-types/application/json>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/silva2021sebim/ontology.json>,
+                      <https://www.visual-paradigm.com/vpp>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/silva2021sebim/ontology.vpp> .

--- a/models/silva2023onto4caal/metadata.ttl
+++ b/models/silva2023onto4caal/metadata.ttl
@@ -1,38 +1,48 @@
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/model/silva2023onto4caal/> a dcat:Dataset, mod:SemanticArtefact;
+<https://w3id.org/ontouml-models/model/silva2023onto4caal/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
+    dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
     dct:title "Requirements Ontology for AAL Systems";
     mod:acronym "Onto4CALL";
     dct:issued "2023"^^xsd:gYear;
     dcat:theme lcc:T;
     dct:language "en";
-    dcat:landingPage <https://github.com/timoteogomes/Nota-o-UML-da-Onto4CAAL>, <https://github.com/timoteogomes/Notacao-UML-da-Onto4Elev>;
+    dcat:landingPage <https://github.com/timoteogomes/Nota-o-UML-da-Onto4CAAL>,
+                     <https://github.com/timoteogomes/Notacao-UML-da-Onto4Elev>;
     dct:license <https://creativecommons.org/licenses/by-nc-nd/3.0/br/>;
-    dct:contributor <https://dblp.org/pid/237/7238>, <https://dblp.org/pid/31/5316>;
-    mod:designedForTask ocmv:ConceptualClarification, ocmv:DecisionSupportSystem, ocmv:Interoperability;
+    dct:contributor <https://dblp.org/pid/237/7238>,
+                    <https://dblp.org/pid/31/5316>;
+    dcat:keyword "ambient assisted living"@en,
+                 "assistive technology"@en,
+                 "healthcare services"@en;
+    dct:source <https://repositorio.ufpe.br/handle/123456789/50033>,
+               <https://doi.org/10.1093/comjnl/bxad053>,
+               <http://wer.inf.puc-rio.br/WERpapers/artigos/artigos_WER22/WER_2022_Camera_ready_paper_34.pdf>,
+               <http://www.inf.puc-rio.br/~wer/WERpapers/artigos/artigos_WER21/WER_2021_paper_16.pdf>;
+    mod:designedForTask ocmv:ConceptualClarification,
+                        ocmv:DecisionSupportSystem,
+                        ocmv:Interoperability;
     ocmv:context ocmv:Research;
-    dct:source <https://repositorio.ufpe.br/handle/123456789/50033>, <https://doi.org/10.1093/comjnl/bxad053>, <http://wer.inf.puc-rio.br/WERpapers/artigos/artigos_WER22/WER_2022_Camera_ready_paper_34.pdf>, <http://www.inf.puc-rio.br/~wer/WERpapers/artigos/artigos_WER21/WER_2021_paper_16.pdf>.
-<https://w3id.org/ontouml-models/model/silva2023onto4caal/> dcat:distribution <https://w3id.org/ontouml-models/model/silva2023onto4caal/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/silva2023onto4caal/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Requirements Ontology for AAL Systems\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/silva2023onto4caal/ontology.ttl>.
-<https://w3id.org/ontouml-models/model/silva2023onto4caal/> dcat:distribution <https://w3id.org/ontouml-models/model/silva2023onto4caal/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/silva2023onto4caal/distribution/ttl> a dcat:Distribution;
-    dct:title "JSON distribution of \"Requirements Ontology for AAL Systems\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/silva2023onto4caal/ontology.json>.
-<https://w3id.org/ontouml-models/model/silva2023onto4caal/> dcat:distribution <https://w3id.org/ontouml-models/model/silva2023onto4caal/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/silva2023onto4caal/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Requirements Ontology for AAL Systems\""@en;
-    dcat:mediaType <https://www.visual-paradigm.com/vpp>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/silva2023onto4caal/ontology.vpp>.
+    ocmv:representationStyle ocmv:OntoumlStyle;
+    ocmv:ontologyType ocmv:Domain;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/silva2023onto4caal"^^xsd:anyURI;
+    fdpo:metadataIssued "2026-06-23T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/silva2023onto4caal/> dcat:distribution <https://w3id.org/ontouml-models/model/silva2023onto4caal/distribution/ttl>,
+                      <https://www.iana.org/assignments/media-types/text/turtle>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/silva2023onto4caal/ontology.ttl>,
+                      <https://w3id.org/ontouml-models/model/silva2023onto4caal/>,
+                      <https://www.iana.org/assignments/media-types/application/json>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/silva2023onto4caal/ontology.json>,
+                      <https://www.visual-paradigm.com/vpp>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/silva2023onto4caal/ontology.vpp> .

--- a/models/silva2023onto4elev/metadata.ttl
+++ b/models/silva2023onto4elev/metadata.ttl
@@ -1,38 +1,49 @@
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/model/silva2023onto4elev/> a dcat:Dataset, mod:SemanticArtefact;
+<https://w3id.org/ontouml-models/model/silva2023onto4elev/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
+    dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
     dct:title "Requirements Ontology for Vertical Lifting Platform";
     mod:acronym "Onto4Elev";
     dct:issued "2023"^^xsd:gYear;
     dcat:theme lcc:T;
     dct:language "en";
-    dcat:landingPage <https://github.com/timoteogomes/Nota-o-UML-da-Onto4CAAL>, <https://github.com/timoteogomes/Notacao-UML-da-Onto4Elev>;
+    dcat:landingPage <https://github.com/timoteogomes/Nota-o-UML-da-Onto4CAAL>,
+                     <https://github.com/timoteogomes/Notacao-UML-da-Onto4Elev>;
     dct:license <https://creativecommons.org/licenses/by-nc-nd/3.0/br/>;
-    dct:contributor <https://dblp.org/pid/237/7238>, <https://dblp.org/pid/31/5316>;
-    mod:designedForTask ocmv:ConceptualClarification, ocmv:DecisionSupportSystem, ocmv:Interoperability;
+    dct:contributor <https://dblp.org/pid/237/7238>,
+                    <https://dblp.org/pid/31/5316>;
+    dcat:keyword "vertical elevation platforms"@en,
+                 "ambient assisted living"@en,
+                 "assistive technology"@en,
+                 "healthcare services"@en;
+    dct:source <https://repositorio.ufpe.br/handle/123456789/50033>,
+               <https://doi.org/10.1093/comjnl/bxad053>,
+               <http://wer.inf.puc-rio.br/WERpapers/artigos/artigos_WER22/WER_2022_Camera_ready_paper_34.pdf>,
+               <http://www.inf.puc-rio.br/~wer/WERpapers/artigos/artigos_WER21/WER_2021_paper_16.pdf>;
+    mod:designedForTask ocmv:ConceptualClarification,
+                        ocmv:DecisionSupportSystem,
+                        ocmv:Interoperability;
     ocmv:context ocmv:Research;
-    dct:source <https://repositorio.ufpe.br/handle/123456789/50033>, <https://doi.org/10.1093/comjnl/bxad053>, <http://wer.inf.puc-rio.br/WERpapers/artigos/artigos_WER22/WER_2022_Camera_ready_paper_34.pdf>, <http://www.inf.puc-rio.br/~wer/WERpapers/artigos/artigos_WER21/WER_2021_paper_16.pdf>.
-<https://w3id.org/ontouml-models/model/silva2023onto4elev/> dcat:distribution <https://w3id.org/ontouml-models/model/silva2023onto4elev/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/silva2023onto4elev/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Requirements Ontology for Vertical Lifting Platform\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/silva2023onto4elev/ontology.ttl>.
-<https://w3id.org/ontouml-models/model/silva2023onto4elev/> dcat:distribution <https://w3id.org/ontouml-models/model/silva2023onto4elev/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/silva2023onto4elev/distribution/ttl> a dcat:Distribution;
-    dct:title "JSON distribution of \"Requirements Ontology for Vertical Lifting Platform\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/silva2023onto4elev/ontology.json>.
-<https://w3id.org/ontouml-models/model/silva2023onto4elev/> dcat:distribution <https://w3id.org/ontouml-models/model/silva2023onto4elev/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/silva2023onto4elev/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Requirements Ontology for Vertical Lifting Platform\""@en;
-    dcat:mediaType <https://www.visual-paradigm.com/vpp>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/silva2023onto4elev/ontology.vpp>.
+    ocmv:representationStyle ocmv:OntoumlStyle;
+    ocmv:ontologyType ocmv:Domain;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/silva2023onto4elev"^^xsd:anyURI;
+    fdpo:metadataIssued "2026-06-23T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/silva2023onto4elev/> dcat:distribution <https://w3id.org/ontouml-models/model/silva2023onto4elev/distribution/ttl>,
+                      <https://www.iana.org/assignments/media-types/text/turtle>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/silva2023onto4elev/ontology.ttl>,
+                      <https://w3id.org/ontouml-models/model/silva2023onto4elev/>,
+                      <https://www.iana.org/assignments/media-types/application/json>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/silva2023onto4elev/ontology.json>,
+                      <https://www.visual-paradigm.com/vpp>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/silva2023onto4elev/ontology.vpp> .

--- a/models/silveira2021oap/metadata.ttl
+++ b/models/silveira2021oap/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/3585c8fe-d974-4ef3-801f-597cc683a1d2/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -17,16 +16,28 @@
     dct:issued "2021"^^xsd:gYear;
     dcat:theme lcc:L;
     skos:editorialNote "The ontology was documented based on the authors' paper. Diagram 2 was included on authors' request specified in issue 177 of the GitHub repository.";
-    dct:language "pt-br, en";
+    dct:language "pt-br",
+                 "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:contributor <https://dblp.org/pid/286/2286>, <https://dblp.org/pid/80/6127>, <https://dblp.org/pid/157/9229>, <https://dblp.org/pid/58/7028>;
-    dcat:keyword "pedagogical architectures"@en, "pedagogy"@en;
+    dct:contributor <https://dblp.org/pid/286/2286>,
+                    <https://dblp.org/pid/80/6127>,
+                    <https://dblp.org/pid/157/9229>,
+                    <https://dblp.org/pid/58/7028>;
+    dcat:keyword "pedagogical architectures"@en,
+                 "pedagogy"@en;
+    dct:source <https://sol.sbc.org.br/index.php/sbie/article/view/18040/17874>;
     mod:designedForTask ocmv:ConceptualClarification;
     ocmv:context ocmv:Research;
-    dct:source <https://sol.sbc.org.br/index.php/sbie/article/view/18040/17874>;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/silveira2021oap"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/silveira2021oap"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T18:15:53.824425978Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:15:53.824425978Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/3585c8fe-d974-4ef3-801f-597cc683a1d2> dcat:distribution <https://w3id.org/ontouml-models/distribution/aaef387b-f3b4-42a6-9242-7b77d2282e9c/>, <https://w3id.org/ontouml-models/distribution/7d477b00-0027-40e1-95e6-a9ec5b2f2ab0/>, <https://w3id.org/ontouml-models/distribution/78b2aad3-b04e-4094-b737-b0151ac0f723/>, <https://w3id.org/ontouml-models/distribution/37ab61c3-0c00-4a3b-b066-950658b85599>, <https://w3id.org/ontouml-models/distribution/f3eef6a4-8bac-4fe6-bbd1-922796be143a>, <https://w3id.org/ontouml-models/distribution/7cfdba38-bef9-40dc-9e84-5ec46baa938b>, <https://w3id.org/ontouml-models/distribution/1fdbc47e-c36d-49e4-90b5-c994e53eb753>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/3585c8fe-d974-4ef3-801f-597cc683a1d2> dcat:distribution <https://w3id.org/ontouml-models/distribution/aaef387b-f3b4-42a6-9242-7b77d2282e9c/>,
+                      <https://w3id.org/ontouml-models/distribution/7d477b00-0027-40e1-95e6-a9ec5b2f2ab0/>,
+                      <https://w3id.org/ontouml-models/distribution/78b2aad3-b04e-4094-b737-b0151ac0f723/>,
+                      <https://w3id.org/ontouml-models/distribution/37ab61c3-0c00-4a3b-b066-950658b85599>,
+                      <https://w3id.org/ontouml-models/distribution/f3eef6a4-8bac-4fe6-bbd1-922796be143a>,
+                      <https://w3id.org/ontouml-models/distribution/7cfdba38-bef9-40dc-9e84-5ec46baa938b>,
+                      <https://w3id.org/ontouml-models/distribution/1fdbc47e-c36d-49e4-90b5-c994e53eb753> .

--- a/models/soares2024fair/metadata.ttl
+++ b/models/soares2024fair/metadata.ttl
@@ -1,37 +1,60 @@
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/model/soares2024fair/> a dcat:Dataset, mod:SemanticArtefact;
+<https://w3id.org/ontouml-models/model/soares2024fair/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
+    dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
     dct:title "Conceptual Model of a FAIR Metadata Schema";
     mod:acronym "FAIR Metadata Schema";
     dct:issued "2024"^^xsd:gYear;
     dcat:theme lcc:T;
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:contributor <https://dblp.org/pid/331/1678>, <https://dblp.org/pid/p/LuisFerreiraPires>, <https://dblp.org/pid/68/84>, <https://dblp.org/pid/63/9777>, <https://dblp.org/pid/205/0604>, <https://dblp.org/pid/15/5508>, <https://dblp.org/pid/19/6474>, <https://dblp.org/pid/44/1984>, <https://dblp.org/pid/331/1865>, <https://dblp.org/pid/121/5232>, <https://dblp.org/pid/92/5149>, <https://dblp.org/pid/77/7381>, <https://dblp.org/pid/00/2863>, <https://dblp.org/pid/91/10025>, <https://dblp.org/pid/181/6647>, <https://dblp.org/pid/331/1682>, <https://dblp.org/pid/89/2110>, <https://dblp.org/pid/92/3940>, <https://dblp.org/pid/82/9539> ;
-    mod:designedForTask ocmv:ConceptualClarification, ocmv:Interoperability;
+    dct:contributor <https://dblp.org/pid/331/1678>,
+                    <https://dblp.org/pid/p/LuisFerreiraPires>,
+                    <https://dblp.org/pid/68/84>,
+                    <https://dblp.org/pid/63/9777>,
+                    <https://dblp.org/pid/205/0604>,
+                    <https://dblp.org/pid/15/5508>,
+                    <https://dblp.org/pid/19/6474>,
+                    <https://dblp.org/pid/44/1984>,
+                    <https://dblp.org/pid/331/1865>,
+                    <https://dblp.org/pid/121/5232>,
+                    <https://dblp.org/pid/92/5149>,
+                    <https://dblp.org/pid/77/7381>,
+                    <https://dblp.org/pid/00/2863>,
+                    <https://dblp.org/pid/91/10025>,
+                    <https://dblp.org/pid/181/6647>,
+                    <https://dblp.org/pid/331/1682>,
+                    <https://dblp.org/pid/89/2110>,
+                    <https://dblp.org/pid/92/3940>,
+                    <https://dblp.org/pid/82/9539>;
+    dcat:keyword "metadata"@en,
+                 "fair principles"@en,
+                 "data schema"@en;
+    dct:source <https://ceur-ws.org/Vol-3849/forum4.pdf>;
+    mod:designedForTask ocmv:ConceptualClarification,
+                        ocmv:Interoperability;
     ocmv:context ocmv:Research;
-    dct:source <https://ceur-ws.org/Vol-3849/forum4.pdf>.
-<https://w3id.org/ontouml-models/model/soares2024fair/> dcat:distribution <https://w3id.org/ontouml-models/model/soares2024fair/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/soares2024fair/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Conceptual Model of a FAIR Metadata Schema\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/soares2024fair/ontology.ttl>.
-<https://w3id.org/ontouml-models/model/soares2024fair/> dcat:distribution <https://w3id.org/ontouml-models/model/soares2024fair/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/soares2024fair/distribution/ttl> a dcat:Distribution;
-    dct:title "JSON distribution of \"Conceptual Model of a FAIR Metadata Schema\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/soares2024fair/ontology.json>.
-<https://w3id.org/ontouml-models/model/soares2024fair/> dcat:distribution <https://w3id.org/ontouml-models/model/soares2024fair/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/soares2024fair/distribution/vpp> a dcat:Distribution;
-    dct:title "Visual Paradigm distribution of \"Conceptual Model of a FAIR Metadata Schema\""@en;
-    dcat:mediaType <https://www.visual-paradigm.com/vpp>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/soares2024fair/ontology.vpp>.
+    ocmv:representationStyle ocmv:OntoumlStyle;
+    ocmv:ontologyType ocmv:Domain;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/soares2024fair"^^xsd:anyURI;
+    fdpo:metadataIssued "2026-06-23T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/soares2024fair/> dcat:distribution <https://w3id.org/ontouml-models/model/soares2024fair/distribution/ttl>,
+                      <https://www.iana.org/assignments/media-types/text/turtle>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/soares2024fair/ontology.ttl>,
+                      <https://w3id.org/ontouml-models/model/soares2024fair/>,
+                      <https://www.iana.org/assignments/media-types/application/json>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/soares2024fair/ontology.json>,
+                      <https://w3id.org/ontouml-models/model/soares2024fair/distribution/vpp>,
+                      <https://www.visual-paradigm.com/vpp>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/soares2024fair/ontology.vpp> .

--- a/models/social-contract/metadata.ttl
+++ b/models/social-contract/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/3a5e93f8-8a29-47cb-be7d-9c5609d754a8/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -22,7 +21,12 @@
     ocmv:context ocmv:Classroom;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/social-contract"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/social-contract"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T18:16:06.210053842Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:16:06.210053842Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/3a5e93f8-8a29-47cb-be7d-9c5609d754a8> dcat:distribution <https://w3id.org/ontouml-models/distribution/5e09f3d1-bec6-435a-9bdf-f1f183210914/>, <https://w3id.org/ontouml-models/distribution/31f8df7d-c3b6-45f2-884b-7466fd6d0bfc/>, <https://w3id.org/ontouml-models/distribution/7fb87c89-ce4c-456f-bd51-2d9fa28d26f8/>, <https://w3id.org/ontouml-models/distribution/3d8e86ec-1652-40b9-9019-f31f23ba9491>, <https://w3id.org/ontouml-models/distribution/fd91e758-9a0d-43da-912c-872d8f8110c3>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/3a5e93f8-8a29-47cb-be7d-9c5609d754a8> dcat:distribution <https://w3id.org/ontouml-models/distribution/5e09f3d1-bec6-435a-9bdf-f1f183210914/>,
+                      <https://w3id.org/ontouml-models/distribution/31f8df7d-c3b6-45f2-884b-7466fd6d0bfc/>,
+                      <https://w3id.org/ontouml-models/distribution/7fb87c89-ce4c-456f-bd51-2d9fa28d26f8/>,
+                      <https://w3id.org/ontouml-models/distribution/3d8e86ec-1652-40b9-9019-f31f23ba9491>,
+                      <https://w3id.org/ontouml-models/distribution/fd91e758-9a0d-43da-912c-872d8f8110c3> .

--- a/models/social-contracts2013/metadata.ttl
+++ b/models/social-contracts2013/metadata.ttl
@@ -1,35 +1,40 @@
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/model/social-contracts2013/> a dcat:Dataset, mod:SemanticArtefact;
+<https://w3id.org/ontouml-models/model/social-contracts2013/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
+    dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
     dct:title "State and Social Contracts Ontology";
     dct:issued "2013"^^xsd:gYear;
     dcat:theme lcc:K;
     skos:editorialNote "Ontology created during a lecture by students who wanted to remain anonymous. The ontology was build in a different editor tool and imported to Visual Paradigm, the current diagrammation may not exactly match the original one.";
     dct:language "pt-br";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    mod:designedForTask ocmv:ConceptualClarification, ocmv:Learning;
-    ocmv:context ocmv:Classroom.
-<https://w3id.org/ontouml-models/model/social-contracts2013/> dcat:distribution <https://w3id.org/ontouml-models/model/social-contracts2013/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/social-contracts2013/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"State and Social Contracts Ontology\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/social-contracts2013/ontology.ttl>.
-<https://w3id.org/ontouml-models/model/social-contracts2013/> dcat:distribution <https://w3id.org/ontouml-models/model/social-contracts2013/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/social-contracts2013/distribution/ttl> a dcat:Distribution;
-    dct:title "JSON distribution of \"State and Social Contracts Ontology\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/social-contracts2013/ontology.json>.
-<https://w3id.org/ontouml-models/model/social-contracts2013/> dcat:distribution <https://w3id.org/ontouml-models/model/social-contracts2013/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/social-contracts2013/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"State and Social Contracts Ontology\""@en;
-    dcat:mediaType <https://www.visual-paradigm.com/vpp>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/social-contracts2013/ontology.vpp>.
+    dcat:keyword "state"@en,
+                 "social contracts"@en,
+                 "society"@en,
+                 "law"@en;
+    mod:designedForTask ocmv:ConceptualClarification,
+                        ocmv:Learning;
+    ocmv:context ocmv:Classroom;
+    ocmv:representationStyle ocmv:OntoumlStyle;
+    ocmv:ontologyType ocmv:Domain;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/social-contracts2013"^^xsd:anyURI;
+    fdpo:metadataIssued "2026-06-23T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/social-contracts2013/> dcat:distribution <https://w3id.org/ontouml-models/model/social-contracts2013/distribution/ttl>,
+                      <https://www.iana.org/assignments/media-types/text/turtle>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/social-contracts2013/ontology.ttl>,
+                      <https://w3id.org/ontouml-models/model/social-contracts2013/>,
+                      <https://www.iana.org/assignments/media-types/application/json>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/social-contracts2013/ontology.json>,
+                      <https://www.visual-paradigm.com/vpp>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/social-contracts2013/ontology.vpp> .

--- a/models/sousa2022triponto/metadata.ttl
+++ b/models/sousa2022triponto/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/5cf371b9-49ce-4d94-8718-80c8743ec335/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -20,12 +19,19 @@
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:contributor <https://orcid.org/0000-0002-0952-9571>;
-    dcat:keyword "trip"@en, "travel"@en;
+    dcat:keyword "trip"@en,
+                 "travel"@en;
     mod:designedForTask ocmv:ConceptualClarification;
     ocmv:context ocmv:Classroom;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/sousa2022triponto"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/sousa2022triponto"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T18:16:15.916321656Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:16:15.916321656Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/5cf371b9-49ce-4d94-8718-80c8743ec335> dcat:distribution <https://w3id.org/ontouml-models/distribution/ca5096a4-78f7-419a-95e2-1d5b95a09560/>, <https://w3id.org/ontouml-models/distribution/6d7929de-2a65-4d58-a213-28228ccd7739/>, <https://w3id.org/ontouml-models/distribution/b1ebfa41-3481-48d0-a3ca-1ab6d12c4882/>, <https://w3id.org/ontouml-models/distribution/98303ee6-4572-4c52-83c9-aa918b49cb9b>, <https://w3id.org/ontouml-models/distribution/a4fa5a47-4c4c-4af2-a8f3-ba1c8e784e24>, <https://w3id.org/ontouml-models/distribution/6b45540a-3bbd-4f45-b000-bc7c1ed2a73c>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/5cf371b9-49ce-4d94-8718-80c8743ec335> dcat:distribution <https://w3id.org/ontouml-models/distribution/ca5096a4-78f7-419a-95e2-1d5b95a09560/>,
+                      <https://w3id.org/ontouml-models/distribution/6d7929de-2a65-4d58-a213-28228ccd7739/>,
+                      <https://w3id.org/ontouml-models/distribution/b1ebfa41-3481-48d0-a3ca-1ab6d12c4882/>,
+                      <https://w3id.org/ontouml-models/distribution/98303ee6-4572-4c52-83c9-aa918b49cb9b>,
+                      <https://w3id.org/ontouml-models/distribution/a4fa5a47-4c4c-4af2-a8f3-ba1c8e784e24>,
+                      <https://w3id.org/ontouml-models/distribution/6b45540a-3bbd-4f45-b000-bc7c1ed2a73c> .

--- a/models/spmo2017/metadata.ttl
+++ b/models/spmo2017/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/aff42152-f0e2-4e62-957f-c9b7b3f45df5/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -21,14 +20,33 @@
     dct:language "en";
     dcat:landingPage <https://dev.nemo.inf.ufes.br/seon/SPMO.html>;
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:contributor <https://dblp.org/pid/168/0042>, <https://dblp.org/pid/97/7540>, <https://dblp.org/pid/229/4259>, <https://dblp.org/pid/37/528>, <https://dblp.org/pid/189/5932>, <https://dblp.org/pid/11/78>;
+    dct:contributor <https://dblp.org/pid/168/0042>,
+                    <https://dblp.org/pid/97/7540>,
+                    <https://dblp.org/pid/229/4259>,
+                    <https://dblp.org/pid/37/528>,
+                    <https://dblp.org/pid/189/5932>,
+                    <https://dblp.org/pid/11/78>;
     dcat:keyword "software project management"@en;
-    mod:designedForTask ocmv:ConceptualClarification, ocmv:SoftwareEngineering;
+    dct:source <https://nemo.inf.ufes.br/wp-content/papercite-data/pdf/software_engineering_standards_harmonization__an_ontology_based_approach_2017.pdf>,
+               <https://doi.org/10.1007/978-3-319-49004-5_34>,
+               <https://doi.org/10.5753/sbqs.2016.15152>,
+               <https://dblp.org/rec/conf/ontobras/BastosBF15>,
+               <https://doi.org/10.1007/s13740-018-0089-z>;
+    mod:designedForTask ocmv:ConceptualClarification,
+                        ocmv:SoftwareEngineering;
     ocmv:context ocmv:Research;
-    dct:source <https://nemo.inf.ufes.br/wp-content/papercite-data/pdf/software_engineering_standards_harmonization__an_ontology_based_approach_2017.pdf>, <https://doi.org/10.1007/978-3-319-49004-5_34>, <https://doi.org/10.5753/sbqs.2016.15152>, <https://dblp.org/rec/conf/ontobras/BastosBF15>, <https://doi.org/10.1007/s13740-018-0089-z>;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/spmo2017"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/spmo2017"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T18:16:26.98122754Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:16:26.98122754Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/aff42152-f0e2-4e62-957f-c9b7b3f45df5> dcat:distribution <https://w3id.org/ontouml-models/distribution/ecb32d95-6ad5-4ef6-b637-7e9aae17b744/>, <https://w3id.org/ontouml-models/distribution/868b8730-6ec5-4f04-b161-f44b13caa53e/>, <https://w3id.org/ontouml-models/distribution/f5114fcd-8e97-4237-ad24-bd56e28b4d6f/>, <https://w3id.org/ontouml-models/distribution/820d43c6-7600-4b23-811b-b5780a12a48e>, <https://w3id.org/ontouml-models/distribution/e9d89fe3-d792-4b8f-8f4f-991048139465>, <https://w3id.org/ontouml-models/distribution/561dddd3-bf83-4029-a953-d2bde93c6568>, <https://w3id.org/ontouml-models/distribution/77f9c7f4-c4f0-4125-83d6-79dfeae6b3ac>, <https://w3id.org/ontouml-models/distribution/8888e112-6eac-424a-b627-8f21e9f9596e>, <https://w3id.org/ontouml-models/distribution/0f921a64-2cca-440a-bd39-163cba0fd443>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/aff42152-f0e2-4e62-957f-c9b7b3f45df5> dcat:distribution <https://w3id.org/ontouml-models/distribution/ecb32d95-6ad5-4ef6-b637-7e9aae17b744/>,
+                      <https://w3id.org/ontouml-models/distribution/868b8730-6ec5-4f04-b161-f44b13caa53e/>,
+                      <https://w3id.org/ontouml-models/distribution/f5114fcd-8e97-4237-ad24-bd56e28b4d6f/>,
+                      <https://w3id.org/ontouml-models/distribution/820d43c6-7600-4b23-811b-b5780a12a48e>,
+                      <https://w3id.org/ontouml-models/distribution/e9d89fe3-d792-4b8f-8f4f-991048139465>,
+                      <https://w3id.org/ontouml-models/distribution/561dddd3-bf83-4029-a953-d2bde93c6568>,
+                      <https://w3id.org/ontouml-models/distribution/77f9c7f4-c4f0-4125-83d6-79dfeae6b3ac>,
+                      <https://w3id.org/ontouml-models/distribution/8888e112-6eac-424a-b627-8f21e9f9596e>,
+                      <https://w3id.org/ontouml-models/distribution/0f921a64-2cca-440a-bd39-163cba0fd443> .

--- a/models/spo2017/metadata.ttl
+++ b/models/spo2017/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/5ea6c44d-0aa9-4ba2-bfc4-9ff926c92888/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -21,14 +20,62 @@
     dct:language "en";
     dcat:landingPage <https://dev.nemo.inf.ufes.br/seon/SPO.html>;
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:contributor <https://dblp.org/pid/229/4259>, <https://dblp.org/pid/97/2784>, <https://dblp.org/pid/09/10361>, <https://dblp.org/pid/11/78>, <https://dblp.org/pid/37/528>, <https://dblp.org/pid/97/7540>, <https://dblp.org/pid/189/5932>, <https://dblp.org/pid/75/5043>;
+    dct:contributor <https://dblp.org/pid/229/4259>,
+                    <https://dblp.org/pid/97/2784>,
+                    <https://dblp.org/pid/09/10361>,
+                    <https://dblp.org/pid/11/78>,
+                    <https://dblp.org/pid/37/528>,
+                    <https://dblp.org/pid/97/7540>,
+                    <https://dblp.org/pid/189/5932>,
+                    <https://dblp.org/pid/75/5043>;
     dcat:keyword "software process"@en;
-    mod:designedForTask ocmv:ConceptualClarification, ocmv:Interoperability, ocmv:SoftwareEngineering;
+    dct:source <https://www.cos.ufrj.br/uploadfile/publicacao/736.pdf>,
+               <https://nemo.inf.ufes.br/wp-content/papercite-data/pdf/establishing_a_common_vocabulary_for_software_organizations_understand_software_processes_2005.pdf>,
+               <https://www.inderscienceonline.com/doi/abs/10.1504/IJBPIM.2009.032281>,
+               <http://www.inf.ufes.br/~rguizzardi/publications/guizzardi-falbo-guizzardi-IDEAS2008.pdf>,
+               <https://dblp.org/rec/journals/jidm/BringuenteFG11>,
+               <https://nemo.inf.ufes.br/wp-content/papercite-data/pdf/software_engineering_standards_harmonization__an_ontology_based_approach_2017.pdf>;
+    mod:designedForTask ocmv:ConceptualClarification,
+                        ocmv:Interoperability,
+                        ocmv:SoftwareEngineering;
     ocmv:context ocmv:Research;
-    dct:source <https://www.cos.ufrj.br/uploadfile/publicacao/736.pdf>, <https://nemo.inf.ufes.br/wp-content/papercite-data/pdf/establishing_a_common_vocabulary_for_software_organizations_understand_software_processes_2005.pdf>, <https://www.inderscienceonline.com/doi/abs/10.1504/IJBPIM.2009.032281>, <http://www.inf.ufes.br/~rguizzardi/publications/guizzardi-falbo-guizzardi-IDEAS2008.pdf>, <https://dblp.org/rec/journals/jidm/BringuenteFG11>, <https://nemo.inf.ufes.br/wp-content/papercite-data/pdf/software_engineering_standards_harmonization__an_ontology_based_approach_2017.pdf>;
-    ocmv:representationStyle ocmv:UfoStyle, ocmv:OntoumlStyle;
+    ocmv:representationStyle ocmv:UfoStyle,
+                             ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Core;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/spo2017"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/spo2017"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T18:16:42.625360696Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:16:42.625360696Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/5ea6c44d-0aa9-4ba2-bfc4-9ff926c92888> dcat:distribution <https://w3id.org/ontouml-models/distribution/14ac31e2-249c-4f69-b0fe-d37fd5519097/>, <https://w3id.org/ontouml-models/distribution/9d0d6623-e103-4108-a288-3c0b427f58ee/>, <https://w3id.org/ontouml-models/distribution/0f33cb26-0d2d-4359-a9d0-f90e6434657b/>, <https://w3id.org/ontouml-models/distribution/1b189a4a-c30c-4436-980b-23259c3f1d8d>, <https://w3id.org/ontouml-models/distribution/81c3c81f-5dd2-4dce-8a4b-2f1288e6d7db>, <https://w3id.org/ontouml-models/distribution/9cab4cae-0bb0-4848-9ee7-cc2cb70ac402>, <https://w3id.org/ontouml-models/distribution/d2af2fc8-3c06-4c3a-991b-38a78c8601ea>, <https://w3id.org/ontouml-models/distribution/6575de49-1652-44b3-8ab6-b812d55b7378>, <https://w3id.org/ontouml-models/distribution/cabd8eec-f659-433c-aea5-287946c24a9b>, <https://w3id.org/ontouml-models/distribution/f6a504e2-8b20-4e36-8751-c617a3dfa523>, <https://w3id.org/ontouml-models/distribution/28cf5a43-a628-4107-94ae-b0e2c2790ecd>, <https://w3id.org/ontouml-models/distribution/b83413a8-a182-45dc-8e21-a1775436f688>, <https://w3id.org/ontouml-models/distribution/4430ebda-9d39-41aa-bfd5-c80b2ac81652>, <https://w3id.org/ontouml-models/distribution/b104e68b-2fdd-4b3e-8149-a3f292b6b9ec>, <https://w3id.org/ontouml-models/distribution/f0daff9e-063f-416d-8898-87132d9d0d65>, <https://w3id.org/ontouml-models/distribution/96fe1557-216e-4b53-8abe-a296a89cd6c2>, <https://w3id.org/ontouml-models/distribution/48690b2a-6ae7-434a-b8d5-64ced4772cd9>, <https://w3id.org/ontouml-models/distribution/3f2418c9-5b85-42a1-88b1-33a67b9ebcdd>, <https://w3id.org/ontouml-models/distribution/bfd5844e-64c6-454f-96d6-1f8b8978b6fe>, <https://w3id.org/ontouml-models/distribution/d59dbfe4-e7f4-43a1-badc-8204b103ee31>, <https://w3id.org/ontouml-models/distribution/1407180e-8f3f-4a11-b66e-02154d31dcfa>, <https://w3id.org/ontouml-models/distribution/2773f8b3-670b-47f2-8138-35b70d8d7e42>, <https://w3id.org/ontouml-models/distribution/575dc9b1-57d6-4396-8587-2d8f9ad35209>, <https://w3id.org/ontouml-models/distribution/d4462d90-b946-4979-a4f9-3f7a31544e8a>, <https://w3id.org/ontouml-models/distribution/c6fb1eef-ad0c-4422-a72d-b9137616fc96>, <https://w3id.org/ontouml-models/distribution/38a0420a-d6ce-4eff-8794-2baf6356b62f>, <https://w3id.org/ontouml-models/distribution/be62ffa1-77a8-4001-bb95-3f26161db20a>, <https://w3id.org/ontouml-models/distribution/a420cf1b-3b62-40f5-beab-a7eb5c5fd790>, <https://w3id.org/ontouml-models/distribution/895c3011-3b23-46a2-b6e2-41be9192cf8a>, <https://w3id.org/ontouml-models/distribution/653011a4-5dc0-4633-9e25-5ce18c5210b9>, <https://w3id.org/ontouml-models/distribution/b79af4e3-a9d4-421f-924b-a4ade1a60dff>, <https://w3id.org/ontouml-models/distribution/45ded867-0e05-4565-bea1-837f6bf49367>, <https://w3id.org/ontouml-models/distribution/3fbe8d35-befd-45f0-982b-5580db0c60ac>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/5ea6c44d-0aa9-4ba2-bfc4-9ff926c92888> dcat:distribution <https://w3id.org/ontouml-models/distribution/14ac31e2-249c-4f69-b0fe-d37fd5519097/>,
+                      <https://w3id.org/ontouml-models/distribution/9d0d6623-e103-4108-a288-3c0b427f58ee/>,
+                      <https://w3id.org/ontouml-models/distribution/0f33cb26-0d2d-4359-a9d0-f90e6434657b/>,
+                      <https://w3id.org/ontouml-models/distribution/1b189a4a-c30c-4436-980b-23259c3f1d8d>,
+                      <https://w3id.org/ontouml-models/distribution/81c3c81f-5dd2-4dce-8a4b-2f1288e6d7db>,
+                      <https://w3id.org/ontouml-models/distribution/9cab4cae-0bb0-4848-9ee7-cc2cb70ac402>,
+                      <https://w3id.org/ontouml-models/distribution/d2af2fc8-3c06-4c3a-991b-38a78c8601ea>,
+                      <https://w3id.org/ontouml-models/distribution/6575de49-1652-44b3-8ab6-b812d55b7378>,
+                      <https://w3id.org/ontouml-models/distribution/cabd8eec-f659-433c-aea5-287946c24a9b>,
+                      <https://w3id.org/ontouml-models/distribution/f6a504e2-8b20-4e36-8751-c617a3dfa523>,
+                      <https://w3id.org/ontouml-models/distribution/28cf5a43-a628-4107-94ae-b0e2c2790ecd>,
+                      <https://w3id.org/ontouml-models/distribution/b83413a8-a182-45dc-8e21-a1775436f688>,
+                      <https://w3id.org/ontouml-models/distribution/4430ebda-9d39-41aa-bfd5-c80b2ac81652>,
+                      <https://w3id.org/ontouml-models/distribution/b104e68b-2fdd-4b3e-8149-a3f292b6b9ec>,
+                      <https://w3id.org/ontouml-models/distribution/f0daff9e-063f-416d-8898-87132d9d0d65>,
+                      <https://w3id.org/ontouml-models/distribution/96fe1557-216e-4b53-8abe-a296a89cd6c2>,
+                      <https://w3id.org/ontouml-models/distribution/48690b2a-6ae7-434a-b8d5-64ced4772cd9>,
+                      <https://w3id.org/ontouml-models/distribution/3f2418c9-5b85-42a1-88b1-33a67b9ebcdd>,
+                      <https://w3id.org/ontouml-models/distribution/bfd5844e-64c6-454f-96d6-1f8b8978b6fe>,
+                      <https://w3id.org/ontouml-models/distribution/d59dbfe4-e7f4-43a1-badc-8204b103ee31>,
+                      <https://w3id.org/ontouml-models/distribution/1407180e-8f3f-4a11-b66e-02154d31dcfa>,
+                      <https://w3id.org/ontouml-models/distribution/2773f8b3-670b-47f2-8138-35b70d8d7e42>,
+                      <https://w3id.org/ontouml-models/distribution/575dc9b1-57d6-4396-8587-2d8f9ad35209>,
+                      <https://w3id.org/ontouml-models/distribution/d4462d90-b946-4979-a4f9-3f7a31544e8a>,
+                      <https://w3id.org/ontouml-models/distribution/c6fb1eef-ad0c-4422-a72d-b9137616fc96>,
+                      <https://w3id.org/ontouml-models/distribution/38a0420a-d6ce-4eff-8794-2baf6356b62f>,
+                      <https://w3id.org/ontouml-models/distribution/be62ffa1-77a8-4001-bb95-3f26161db20a>,
+                      <https://w3id.org/ontouml-models/distribution/a420cf1b-3b62-40f5-beab-a7eb5c5fd790>,
+                      <https://w3id.org/ontouml-models/distribution/895c3011-3b23-46a2-b6e2-41be9192cf8a>,
+                      <https://w3id.org/ontouml-models/distribution/653011a4-5dc0-4633-9e25-5ce18c5210b9>,
+                      <https://w3id.org/ontouml-models/distribution/b79af4e3-a9d4-421f-924b-a4ade1a60dff>,
+                      <https://w3id.org/ontouml-models/distribution/45ded867-0e05-4565-bea1-837f6bf49367>,
+                      <https://w3id.org/ontouml-models/distribution/3fbe8d35-befd-45f0-982b-5580db0c60ac> .

--- a/models/sportbooking2021/metadata.ttl
+++ b/models/sportbooking2021/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/1df923e9-f84b-4c79-8b54-19d5d67325f6/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -19,13 +18,25 @@
     skos:editorialNote "The ontology was designed as a course assignment by MSc students and meant to support the development of a mobile application on this domain.";
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:contributor <https://it.linkedin.com/in/edoardo-bianchi-31a6ba15a>, <https://it.linkedin.com/in/ricardopessinato>, <https://www.linkedin.com/in/orea-kicaj-0/>, <https://www.linkedin.com/in/airiaddy/>;
+    dct:contributor <https://it.linkedin.com/in/edoardo-bianchi-31a6ba15a>,
+                    <https://it.linkedin.com/in/ricardopessinato>,
+                    <https://www.linkedin.com/in/orea-kicaj-0/>,
+                    <https://www.linkedin.com/in/airiaddy/>;
     dcat:keyword "sports"@en;
-    mod:designedForTask ocmv:SoftwareEngineering, ocmv:Learning;
+    mod:designedForTask ocmv:SoftwareEngineering,
+                        ocmv:Learning;
     ocmv:context ocmv:Classroom;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/sportbooking2021"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/sportbooking2021"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T18:17:36.938485984Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:17:36.938485984Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/1df923e9-f84b-4c79-8b54-19d5d67325f6> dcat:distribution <https://w3id.org/ontouml-models/distribution/a939b50b-047a-46fa-9967-fb20b97f2bae/>, <https://w3id.org/ontouml-models/distribution/5dd4250e-a1a2-4cf9-9d70-e7c256415e0b/>, <https://w3id.org/ontouml-models/distribution/927a5257-bc4c-4182-afa1-1773944d2e52/>, <https://w3id.org/ontouml-models/distribution/5850d13f-b546-4e26-90e9-8f30e1c811d4>, <https://w3id.org/ontouml-models/distribution/34407ddb-ad16-44f6-8775-eacbe6eb3cfa>, <https://w3id.org/ontouml-models/distribution/5d88159c-6bfc-47a4-ae04-87d9e4d64117>, <https://w3id.org/ontouml-models/distribution/0e8a5b88-0e27-465f-92a4-eb521cd220fe>, <https://w3id.org/ontouml-models/distribution/f7c1116e-5c3a-4016-83c2-9fe01430bccf>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/1df923e9-f84b-4c79-8b54-19d5d67325f6> dcat:distribution <https://w3id.org/ontouml-models/distribution/a939b50b-047a-46fa-9967-fb20b97f2bae/>,
+                      <https://w3id.org/ontouml-models/distribution/5dd4250e-a1a2-4cf9-9d70-e7c256415e0b/>,
+                      <https://w3id.org/ontouml-models/distribution/927a5257-bc4c-4182-afa1-1773944d2e52/>,
+                      <https://w3id.org/ontouml-models/distribution/5850d13f-b546-4e26-90e9-8f30e1c811d4>,
+                      <https://w3id.org/ontouml-models/distribution/34407ddb-ad16-44f6-8775-eacbe6eb3cfa>,
+                      <https://w3id.org/ontouml-models/distribution/5d88159c-6bfc-47a4-ae04-87d9e4d64117>,
+                      <https://w3id.org/ontouml-models/distribution/0e8a5b88-0e27-465f-92a4-eb521cd220fe>,
+                      <https://w3id.org/ontouml-models/distribution/f7c1116e-5c3a-4016-83c2-9fe01430bccf> .

--- a/models/srro-ontology/metadata.ttl
+++ b/models/srro-ontology/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/b80dd4c8-7cb9-4f0e-b8ac-ce17a0931a63/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -23,7 +22,12 @@
     ocmv:context ocmv:Classroom;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/srro-ontology"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/srro-ontology"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T18:17:50.752577781Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:17:50.752577781Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/b80dd4c8-7cb9-4f0e-b8ac-ce17a0931a63> dcat:distribution <https://w3id.org/ontouml-models/distribution/a7c0b077-0cc9-4c2b-bf7d-22dce821aa03/>, <https://w3id.org/ontouml-models/distribution/6986b5a2-85e9-401e-87c1-fde9e143f787/>, <https://w3id.org/ontouml-models/distribution/afff765f-eb0e-4f39-a61a-3000d206434d/>, <https://w3id.org/ontouml-models/distribution/ac7dd9a7-5e1b-42d6-82cb-e3ccfafe6721>, <https://w3id.org/ontouml-models/distribution/35b65516-313b-4d19-8316-2210b6af49aa>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/b80dd4c8-7cb9-4f0e-b8ac-ce17a0931a63> dcat:distribution <https://w3id.org/ontouml-models/distribution/a7c0b077-0cc9-4c2b-bf7d-22dce821aa03/>,
+                      <https://w3id.org/ontouml-models/distribution/6986b5a2-85e9-401e-87c1-fde9e143f787/>,
+                      <https://w3id.org/ontouml-models/distribution/afff765f-eb0e-4f39-a61a-3000d206434d/>,
+                      <https://w3id.org/ontouml-models/distribution/ac7dd9a7-5e1b-42d6-82cb-e3ccfafe6721>,
+                      <https://w3id.org/ontouml-models/distribution/35b65516-313b-4d19-8316-2210b6af49aa> .

--- a/models/stock-broker2021/metadata.ttl
+++ b/models/stock-broker2021/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/8728fdd1-9c4e-46ef-a244-e20407ad16ec/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -23,7 +22,12 @@
     ocmv:context ocmv:Classroom;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/stock-broker2021"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/stock-broker2021"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T18:17:59.775801583Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:17:59.775801583Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/8728fdd1-9c4e-46ef-a244-e20407ad16ec> dcat:distribution <https://w3id.org/ontouml-models/distribution/3e1780de-7507-4557-97be-4a11dd7406b3/>, <https://w3id.org/ontouml-models/distribution/4def00ea-8cac-4311-960f-ec9bd282990f/>, <https://w3id.org/ontouml-models/distribution/6e06ff52-f6a1-47cd-b333-739191f15fc2/>, <https://w3id.org/ontouml-models/distribution/73046a8b-6260-4e33-8d07-41ace524a144>, <https://w3id.org/ontouml-models/distribution/17f37bc1-19e6-4f99-ab41-5d892ce7fabc>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/8728fdd1-9c4e-46ef-a244-e20407ad16ec> dcat:distribution <https://w3id.org/ontouml-models/distribution/3e1780de-7507-4557-97be-4a11dd7406b3/>,
+                      <https://w3id.org/ontouml-models/distribution/4def00ea-8cac-4311-960f-ec9bd282990f/>,
+                      <https://w3id.org/ontouml-models/distribution/6e06ff52-f6a1-47cd-b333-739191f15fc2/>,
+                      <https://w3id.org/ontouml-models/distribution/73046a8b-6260-4e33-8d07-41ace524a144>,
+                      <https://w3id.org/ontouml-models/distribution/17f37bc1-19e6-4f99-ab41-5d892ce7fabc> .

--- a/models/swo2016/metadata.ttl
+++ b/models/swo2016/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/1c5f6781-3bd6-4258-be2a-2442957a0d9c/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -21,14 +20,31 @@
     dct:language "en";
     dcat:landingPage <https://dev.nemo.inf.ufes.br/seon/SwO.html>;
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:contributor <https://dblp.org/pid/37/528>, <https://dblp.org/pid/229/4259>, <https://dblp.org/pid/97/7540>, <https://dblp.org/pid/189/5932>, <https://dblp.org/pid/11/78>, <https://dblp.org/pid/182/7298>, <https://dblp.org/pid/80/10831>, <https://dblp.org/pid/75/5043>, <https://dblp.org/pid/72/3662>;
-    dcat:keyword "software engineering"@en, "software"@en;
-    mod:designedForTask ocmv:ConceptualClarification, ocmv:Interoperability;
+    dct:contributor <https://dblp.org/pid/37/528>,
+                    <https://dblp.org/pid/229/4259>,
+                    <https://dblp.org/pid/97/7540>,
+                    <https://dblp.org/pid/189/5932>,
+                    <https://dblp.org/pid/11/78>,
+                    <https://dblp.org/pid/182/7298>,
+                    <https://dblp.org/pid/80/10831>,
+                    <https://dblp.org/pid/75/5043>,
+                    <https://dblp.org/pid/72/3662>;
+    dcat:keyword "software engineering"@en,
+                 "software"@en;
+    dct:source <https://nemo.inf.ufes.br/wp-content/papercite-data/pdf/software_engineering_standards_harmonization__an_ontology_based_approach_2017.pdf>,
+               <https://doi.org/10.1007/978-3-319-49004-5_34>,
+               <https://doi.org/10.3233/AO-180197>;
+    mod:designedForTask ocmv:ConceptualClarification,
+                        ocmv:Interoperability;
     ocmv:context ocmv:Research;
-    dct:source <https://nemo.inf.ufes.br/wp-content/papercite-data/pdf/software_engineering_standards_harmonization__an_ontology_based_approach_2017.pdf>, <https://doi.org/10.1007/978-3-319-49004-5_34>, <https://doi.org/10.3233/AO-180197>;
     ocmv:representationStyle ocmv:UfoStyle;
     ocmv:ontologyType ocmv:Core;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/swo2016"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/swo2016"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T18:18:08.97202517Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:18:08.97202517Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/1c5f6781-3bd6-4258-be2a-2442957a0d9c> dcat:distribution <https://w3id.org/ontouml-models/distribution/7dc2bddc-69aa-4071-b078-560059dc6a92/>, <https://w3id.org/ontouml-models/distribution/9350449b-4cf9-483e-abd5-4ac603042d84/>, <https://w3id.org/ontouml-models/distribution/f16cd52f-e6f4-4585-a73f-e86fae655636/>, <https://w3id.org/ontouml-models/distribution/c88e23b1-aca3-4d54-a1fe-d70305c84845>, <https://w3id.org/ontouml-models/distribution/10bf3a6a-3a6e-4da7-9543-47b75953cc9b>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/1c5f6781-3bd6-4258-be2a-2442957a0d9c> dcat:distribution <https://w3id.org/ontouml-models/distribution/7dc2bddc-69aa-4071-b078-560059dc6a92/>,
+                      <https://w3id.org/ontouml-models/distribution/9350449b-4cf9-483e-abd5-4ac603042d84/>,
+                      <https://w3id.org/ontouml-models/distribution/f16cd52f-e6f4-4585-a73f-e86fae655636/>,
+                      <https://w3id.org/ontouml-models/distribution/c88e23b1-aca3-4d54-a1fe-d70305c84845>,
+                      <https://w3id.org/ontouml-models/distribution/10bf3a6a-3a6e-4da7-9543-47b75953cc9b> .

--- a/models/telecom-equipment2013/metadata.ttl
+++ b/models/telecom-equipment2013/metadata.ttl
@@ -1,35 +1,38 @@
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/model/telecom-equipment2013/> a dcat:Dataset, mod:SemanticArtefact;
+<https://w3id.org/ontouml-models/model/telecom-equipment2013/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
+    dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
     dct:title "Telecommunications Equipment";
     dct:issued "2013"^^xsd:gYear;
     dcat:theme lcc:T;
     skos:editorialNote "Ontology created during an Ontology Engineering lecture by students who wanted to remain anonymous. The ontology was build in a different editor tool and imported to Visual Paradigm, the current diagrammation may not exactly match the original one.";
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    mod:designedForTask ocmv:ConceptualClarification, ocmv:Learning;
-    ocmv:context ocmv:Classroom.
-<https://w3id.org/ontouml-models/model/telecom-equipment2013/> dcat:distribution <https://w3id.org/ontouml-models/model/telecom-equipment2013/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/telecom-equipment2013/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Telecommunications Equipment\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/telecom-equipment2013/ontology.ttl>.
-<https://w3id.org/ontouml-models/model/telecom-equipment2013/> dcat:distribution <https://w3id.org/ontouml-models/model/telecom-equipment2013/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/telecom-equipment2013/distribution/ttl> a dcat:Distribution;
-    dct:title "JSON distribution of \"Telecommunications Equipment\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/telecom-equipment2013/ontology.json>.
-<https://w3id.org/ontouml-models/model/telecom-equipment2013/> dcat:distribution <https://w3id.org/ontouml-models/model/telecom-equipment2013/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/telecom-equipment2013/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Telecommunications Equipment\""@en;
-    dcat:mediaType <https://www.visual-paradigm.com/vpp>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/telecom-equipment2013/ontology.vpp>.
+    dcat:keyword "telecommunications"@en,
+                 "equipment"@en;
+    mod:designedForTask ocmv:ConceptualClarification,
+                        ocmv:Learning;
+    ocmv:context ocmv:Classroom;
+    ocmv:representationStyle ocmv:OntoumlStyle;
+    ocmv:ontologyType ocmv:Domain;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/telecom-equipment2013"^^xsd:anyURI;
+    fdpo:metadataIssued "2026-06-23T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/telecom-equipment2013/> dcat:distribution <https://w3id.org/ontouml-models/model/telecom-equipment2013/distribution/ttl>,
+                      <https://www.iana.org/assignments/media-types/text/turtle>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/telecom-equipment2013/ontology.ttl>,
+                      <https://w3id.org/ontouml-models/model/telecom-equipment2013/>,
+                      <https://www.iana.org/assignments/media-types/application/json>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/telecom-equipment2013/ontology.json>,
+                      <https://www.visual-paradigm.com/vpp>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/telecom-equipment2013/ontology.vpp> .

--- a/models/tender2013/metadata.ttl
+++ b/models/tender2013/metadata.ttl
@@ -1,35 +1,39 @@
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/model/tender2013/> a dcat:Dataset, mod:SemanticArtefact;
+<https://w3id.org/ontouml-models/model/tender2013/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
+    dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
     dct:title "Tender Ontology";
     dct:issued "2013"^^xsd:gYear;
     dcat:theme lcc:H;
     skos:editorialNote "Ontology created during an Ontology Engineering lecture by students who wanted to remain anonymous. The ontology was build in a different editor tool and imported to Visual Paradigm, the current diagrammation may not exactly match the original one.";
     dct:language "pt-br";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    mod:designedForTask ocmv:ConceptualClarification, ocmv:Learning;
-    ocmv:context ocmv:Classroom.
-<https://w3id.org/ontouml-models/model/tender2013/> dcat:distribution <https://w3id.org/ontouml-models/model/tender2013/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/tender2013/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Tender Ontology\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/tender2013/ontology.ttl>.
-<https://w3id.org/ontouml-models/model/tender2013/> dcat:distribution <https://w3id.org/ontouml-models/model/tender2013/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/tender2013/distribution/ttl> a dcat:Distribution;
-    dct:title "JSON distribution of \"Tender Ontology\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/tender2013/ontology.json>.
-<https://w3id.org/ontouml-models/model/tender2013/> dcat:distribution <https://w3id.org/ontouml-models/model/tender2013/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/tender2013/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Tender Ontology\""@en;
-    dcat:mediaType <https://www.visual-paradigm.com/vpp>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/tender2013/ontology.vpp>.
+    dcat:keyword "tender"@en,
+                 "bidding"@en,
+                 "auction"@en;
+    mod:designedForTask ocmv:ConceptualClarification,
+                        ocmv:Learning;
+    ocmv:context ocmv:Classroom;
+    ocmv:representationStyle ocmv:OntoumlStyle;
+    ocmv:ontologyType ocmv:Domain;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/tender2013"^^xsd:anyURI;
+    fdpo:metadataIssued "2026-06-23T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/tender2013/> dcat:distribution <https://w3id.org/ontouml-models/model/tender2013/distribution/ttl>,
+                      <https://www.iana.org/assignments/media-types/text/turtle>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/tender2013/ontology.ttl>,
+                      <https://w3id.org/ontouml-models/model/tender2013/>,
+                      <https://www.iana.org/assignments/media-types/application/json>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/tender2013/ontology.json>,
+                      <https://www.visual-paradigm.com/vpp>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/tender2013/ontology.vpp> .

--- a/models/tesolin2023hint/metadata.ttl
+++ b/models/tesolin2023hint/metadata.ttl
@@ -1,15 +1,16 @@
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/model/tesolin2023hint/> a dcat:Dataset, mod:SemanticArtefact;
+<https://w3id.org/ontouml-models/model/tesolin2023hint/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
+    dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
     dct:title "Heterogeneous wIreless Network onTology";
     mod:acronym "hint";
     dct:issued "2023"^^xsd:gYear;
@@ -17,22 +18,30 @@
     skos:editorialNote "This model contains a n-ary relation. These relations are not supported by the current JSON exportation feature. Hence, to be able to generate the ontology.json file, this n-ary relation was temporarily excluded (but it is kept in the vpp file).";
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:contributor <https://dblp.org/pid/166/2068>, <https://dblp.org/pid/342/7506>, <https://dblp.org/pid/125/7740>, <https://dblp.org/pid/c/MariaClaudiaReisCavalcanti>;
-    mod:designedForTask ocmv:ConceptualClarification, ocmv:DecisionSupportSystem, ocmv:OntologicalAnalysis;
+    dct:contributor <https://dblp.org/pid/166/2068>,
+                    <https://dblp.org/pid/342/7506>,
+                    <https://dblp.org/pid/125/7740>,
+                    <https://dblp.org/pid/c/MariaClaudiaReisCavalcanti>;
+    dcat:keyword "mobile networks"@en,
+                 "seamless handover"@en,
+                 "telecommunications"@en;
+    dct:source <https://doi.org/10.1016/j.future.2023.08.008>,
+               <https://ceur-ws.org/Vol-3346/Paper6.pdf>;
+    mod:designedForTask ocmv:ConceptualClarification,
+                        ocmv:DecisionSupportSystem,
+                        ocmv:OntologicalAnalysis;
     ocmv:context ocmv:Research;
-    dct:source <https://doi.org/10.1016/j.future.2023.08.008>, <https://ceur-ws.org/Vol-3346/Paper6.pdf>.
-<https://w3id.org/ontouml-models/model/tesolin2023hint/> dcat:distribution <https://w3id.org/ontouml-models/model/tesolin2023hint/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/tesolin2023hint/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Heterogeneous wIreless Network onTology\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/tesolin2023hint/ontology.ttl>.
-<https://w3id.org/ontouml-models/model/tesolin2023hint/> dcat:distribution <https://w3id.org/ontouml-models/model/tesolin2023hint/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/tesolin2023hint/distribution/ttl> a dcat:Distribution;
-    dct:title "JSON distribution of \"Heterogeneous wIreless Network onTology\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/tesolin2023hint/ontology.json>.
-<https://w3id.org/ontouml-models/model/tesolin2023hint/> dcat:distribution <https://w3id.org/ontouml-models/model/tesolin2023hint/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/tesolin2023hint/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Heterogeneous wIreless Network onTology\""@en;
-    dcat:mediaType <https://www.visual-paradigm.com/vpp>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/tesolin2023hint/ontology.vpp>.
+    ocmv:representationStyle ocmv:OntoumlStyle;
+    ocmv:ontologyType ocmv:Domain;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/tesolin2023hint"^^xsd:anyURI;
+    fdpo:metadataIssued "2026-06-23T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/tesolin2023hint/> dcat:distribution <https://w3id.org/ontouml-models/model/tesolin2023hint/distribution/ttl>,
+                      <https://www.iana.org/assignments/media-types/text/turtle>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/tesolin2023hint/ontology.ttl>,
+                      <https://w3id.org/ontouml-models/model/tesolin2023hint/>,
+                      <https://www.iana.org/assignments/media-types/application/json>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/tesolin2023hint/ontology.json>,
+                      <https://www.visual-paradigm.com/vpp>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/tesolin2023hint/ontology.vpp> .

--- a/models/tourbo2021/metadata.ttl
+++ b/models/tourbo2021/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/3c99f544-a5b2-4bd2-bcde-7c689d077c62/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -20,13 +19,23 @@
     skos:editorialNote "The ontology was designed as a course assignment by MSc students and meant to support the development of a mobile application on this domain. We could not locate an URI for the author \"Tom Robin Adolph\".";
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:contributor <https://it.linkedin.com/in/thomas-borsani-54116b1b2>, <https://www.linkedin.com/in/evalinalisbeth/>, <https://www.linkedin.com/in/alessandro-sottovia-665154221/>;
-    dcat:keyword "tourism"@en, "tour guide"@en;
-    mod:designedForTask ocmv:SoftwareEngineering, ocmv:Learning;
+    dct:contributor <https://it.linkedin.com/in/thomas-borsani-54116b1b2>,
+                    <https://www.linkedin.com/in/evalinalisbeth/>,
+                    <https://www.linkedin.com/in/alessandro-sottovia-665154221/>;
+    dcat:keyword "tourism"@en,
+                 "tour guide"@en;
+    mod:designedForTask ocmv:SoftwareEngineering,
+                        ocmv:Learning;
     ocmv:context ocmv:Classroom;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/tourbo2021"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/tourbo2021"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T18:18:18.342435956Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:18:18.342435956Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/3c99f544-a5b2-4bd2-bcde-7c689d077c62> dcat:distribution <https://w3id.org/ontouml-models/distribution/e7e3a7a1-9277-4f49-b381-eeefcbbca142/>, <https://w3id.org/ontouml-models/distribution/b6e234b9-2acc-495a-8964-834c834bee85/>, <https://w3id.org/ontouml-models/distribution/d60969e4-5f31-49a5-8228-9817f264e74b/>, <https://w3id.org/ontouml-models/distribution/f9782efa-ca85-4077-b494-55cc569d15c9>, <https://w3id.org/ontouml-models/distribution/d2aeee45-2029-4279-b26e-f35c6b76ec0f>, <https://w3id.org/ontouml-models/distribution/9e49edad-3b96-4334-b1dd-d2d87239b76e>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/3c99f544-a5b2-4bd2-bcde-7c689d077c62> dcat:distribution <https://w3id.org/ontouml-models/distribution/e7e3a7a1-9277-4f49-b381-eeefcbbca142/>,
+                      <https://w3id.org/ontouml-models/distribution/b6e234b9-2acc-495a-8964-834c834bee85/>,
+                      <https://w3id.org/ontouml-models/distribution/d60969e4-5f31-49a5-8228-9817f264e74b/>,
+                      <https://w3id.org/ontouml-models/distribution/f9782efa-ca85-4077-b494-55cc569d15c9>,
+                      <https://w3id.org/ontouml-models/distribution/d2aeee45-2029-4279-b26e-f35c6b76ec0f>,
+                      <https://w3id.org/ontouml-models/distribution/9e49edad-3b96-4334-b1dd-d2d87239b76e> .

--- a/models/unimatch-ontology2022/metadata.ttl
+++ b/models/unimatch-ontology2022/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/51036663-ba06-4fd0-9244-f984146a335a/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -19,13 +18,21 @@
     skos:editorialNote "Ontology created for the course \"Information System Design Course\" at the Free University of Bozen-Bolzano.";
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:contributor <https://orcid.org/0000-0001-5500-6301>, <https://dblp.org/pid/273/7024>, <https://dblp.org/pid/258/0384>, <https://orcid.org/0000-0001-9993-4484>;
+    dct:contributor <https://orcid.org/0000-0001-5500-6301>,
+                    <https://dblp.org/pid/273/7024>,
+                    <https://dblp.org/pid/258/0384>,
+                    <https://orcid.org/0000-0001-9993-4484>;
     dcat:keyword "education"@en;
-    mod:designedForTask ocmv:SoftwareEngineering, ocmv:Learning;
+    mod:designedForTask ocmv:SoftwareEngineering,
+                        ocmv:Learning;
     ocmv:context ocmv:Classroom;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Application;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/unimatch-ontology2022"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/unimatch-ontology2022"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T18:18:29.37191225Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:18:29.37191225Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/51036663-ba06-4fd0-9244-f984146a335a> dcat:distribution <https://w3id.org/ontouml-models/distribution/da98e8d8-3aaf-4096-8529-c6e665746e36/>, <https://w3id.org/ontouml-models/distribution/da14de62-f69e-4964-8218-ea54b1b1ec84/>, <https://w3id.org/ontouml-models/distribution/5894a069-4b1a-4d1e-adce-3766a0fd3db9/>, <https://w3id.org/ontouml-models/distribution/d663917a-10ff-4e0e-8744-0cd2f31d0773>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/51036663-ba06-4fd0-9244-f984146a335a> dcat:distribution <https://w3id.org/ontouml-models/distribution/da98e8d8-3aaf-4096-8529-c6e665746e36/>,
+                      <https://w3id.org/ontouml-models/distribution/da14de62-f69e-4964-8218-ea54b1b1ec84/>,
+                      <https://w3id.org/ontouml-models/distribution/5894a069-4b1a-4d1e-adce-3766a0fd3db9/>,
+                      <https://w3id.org/ontouml-models/distribution/d663917a-10ff-4e0e-8744-0cd2f31d0773> .

--- a/models/university-ontology/metadata.ttl
+++ b/models/university-ontology/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/8ef525ba-e4e6-48a7-9512-b1338ba45769/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -23,7 +22,14 @@
     ocmv:context ocmv:Classroom;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/university-ontology"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/university-ontology"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T18:18:37.312006928Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:18:37.312006928Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/8ef525ba-e4e6-48a7-9512-b1338ba45769> dcat:distribution <https://w3id.org/ontouml-models/distribution/52ae3c15-0f1f-40ea-a11f-52d0cca0b5f2/>, <https://w3id.org/ontouml-models/distribution/6f385b83-4f38-46af-b285-c78ffb91016c/>, <https://w3id.org/ontouml-models/distribution/68f15233-fb59-41d5-8638-88d82dbdcdb7/>, <https://w3id.org/ontouml-models/distribution/9da72aa9-4b0b-49d9-96ff-8499128f8c39>, <https://w3id.org/ontouml-models/distribution/1c4f5437-b39e-40c7-969b-3602a74603bf>, <https://w3id.org/ontouml-models/distribution/cf4d5920-3677-464a-8022-3a069eaaab5e>, <https://w3id.org/ontouml-models/distribution/ee58deb3-b6b5-46b1-a061-5a8e5dd96801>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/8ef525ba-e4e6-48a7-9512-b1338ba45769> dcat:distribution <https://w3id.org/ontouml-models/distribution/52ae3c15-0f1f-40ea-a11f-52d0cca0b5f2/>,
+                      <https://w3id.org/ontouml-models/distribution/6f385b83-4f38-46af-b285-c78ffb91016c/>,
+                      <https://w3id.org/ontouml-models/distribution/68f15233-fb59-41d5-8638-88d82dbdcdb7/>,
+                      <https://w3id.org/ontouml-models/distribution/9da72aa9-4b0b-49d9-96ff-8499128f8c39>,
+                      <https://w3id.org/ontouml-models/distribution/1c4f5437-b39e-40c7-969b-3602a74603bf>,
+                      <https://w3id.org/ontouml-models/distribution/cf4d5920-3677-464a-8022-3a069eaaab5e>,
+                      <https://w3id.org/ontouml-models/distribution/ee58deb3-b6b5-46b1-a061-5a8e5dd96801> .

--- a/models/valaski2020medical-appointment/metadata.ttl
+++ b/models/valaski2020medical-appointment/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/03f684a6-3a6c-4cc0-8ca6-6375f74d5081/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -17,14 +16,21 @@
     dcat:theme lcc:R;
     dct:language "pt-br";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:contributor <https://dblp.org/pid/06/11109>, <https://dblp.org/pid/05/2483>, <https://dblp.org/pid/82/191>;
+    dct:contributor <https://dblp.org/pid/06/11109>,
+                    <https://dblp.org/pid/05/2483>,
+                    <https://dblp.org/pid/82/191>;
     dcat:keyword "medical appointment"@en;
+    dct:source <https://dblp.org/rec/conf/cibse/ValaskiRM20>;
     mod:designedForTask ocmv:ConceptualClarification;
     ocmv:context ocmv:Research;
-    dct:source <https://dblp.org/rec/conf/cibse/ValaskiRM20>;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/valaski2020medical-appointment"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/valaski2020medical-appointment"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T18:18:49.572867619Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:18:49.572867619Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/03f684a6-3a6c-4cc0-8ca6-6375f74d5081> dcat:distribution <https://w3id.org/ontouml-models/distribution/5c7fa526-9462-4786-9594-a7106676f1c3/>, <https://w3id.org/ontouml-models/distribution/f24c545a-bb23-4979-a5f0-786927d96134/>, <https://w3id.org/ontouml-models/distribution/f2981c88-5e53-4596-af46-ba94ca6a145c/>, <https://w3id.org/ontouml-models/distribution/d4270242-a50b-48d8-a5af-758683327a4a>, <https://w3id.org/ontouml-models/distribution/b7839c64-9489-4091-90d5-4e37d3e2d626>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/03f684a6-3a6c-4cc0-8ca6-6375f74d5081> dcat:distribution <https://w3id.org/ontouml-models/distribution/5c7fa526-9462-4786-9594-a7106676f1c3/>,
+                      <https://w3id.org/ontouml-models/distribution/f24c545a-bb23-4979-a5f0-786927d96134/>,
+                      <https://w3id.org/ontouml-models/distribution/f2981c88-5e53-4596-af46-ba94ca6a145c/>,
+                      <https://w3id.org/ontouml-models/distribution/d4270242-a50b-48d8-a5af-758683327a4a>,
+                      <https://w3id.org/ontouml-models/distribution/b7839c64-9489-4091-90d5-4e37d3e2d626> .

--- a/models/van-ee2021modular/metadata.ttl
+++ b/models/van-ee2021modular/metadata.ttl
@@ -1,31 +1,59 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/c6ec6f27-cffa-4a38-9927-8e6b921e996a/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:title "Modular Construction Ontology";
     dct:issued "2021"^^xsd:gYear;
     dct:modified "2021"^^xsd:gYear;
     dcat:theme lcc:T;
-    skos:editorialNote "From the author:\nThe ontology is designed for a Dutch company in the PDEng trajectory of Tim van Ee (t.vanee@utwente.nl). As it is (currently) developed for the specific context of the company, its generalizability for the industry might be limited.\nThe core of the ontology is based on the Building Product Ontology (BPO), the Ontology for Managing Ontologies (OMG), and several others of which the most prominent are indicated below.\nBPO - <https://w3id.org/bpo#>\nOmg - <https://w3id.org/omg#>\nFog - <https://w3id.org/fog#>\nQudt - <http://qudt.org/schema/qudt#>\nSchema - <http://schema.org#>\nSeas - <https://w3id.org/seas#>\nThe ontology is still under development, any comments, suggestions or feedback is welcome!\n---------\nFrom the reviewers:\nThe classes that had clear RDF namespaces in their names were moved into their associated packages. The same couldn't be done for associations, attributes, and instances.\nClasses whose label joined multiple RDF elements were interpreted as \"owl:sameAs\" declarations. As such, each of the classes were reproduced into their namespaces/packages and the \"owl:sameAs\" declaration was translated as generalizations of each of them into a new class. No stereotype has been given to the introduced classes to avoid too many changes on the author's original intended model.\n";
-    dct:language "en, nl";
+    skos:editorialNote """From the author:
+The ontology is designed for a Dutch company in the PDEng trajectory of Tim van Ee (t.vanee@utwente.nl). As it is (currently) developed for the specific context of the company, its generalizability for the industry might be limited.
+The core of the ontology is based on the Building Product Ontology (BPO), the Ontology for Managing Ontologies (OMG), and several others of which the most prominent are indicated below.
+BPO - <https://w3id.org/bpo#>
+Omg - <https://w3id.org/omg#>
+Fog - <https://w3id.org/fog#>
+Qudt - <http://qudt.org/schema/qudt#>
+Schema - <http://schema.org#>
+Seas - <https://w3id.org/seas#>
+The ontology is still under development, any comments, suggestions or feedback is welcome!
+---------
+From the reviewers:
+The classes that had clear RDF namespaces in their names were moved into their associated packages. The same couldn't be done for associations, attributes, and instances.
+Classes whose label joined multiple RDF elements were interpreted as "owl:sameAs" declarations. As such, each of the classes were reproduced into their namespaces/packages and the "owl:sameAs" declaration was translated as generalizations of each of them into a new class. No stereotype has been given to the introduced classes to avoid too many changes on the author's original intended model.
+""";
+    dct:language "en",
+                 "nl";
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:contributor <https://www.linkedin.com/in/tim-van-ee-911887136/>;
     dcat:keyword "construction"@en;
-    mod:designedForTask ocmv:Interoperability, ocmv:SoftwareEngineering;
-    ocmv:context ocmv:Research, ocmv:Industry;
+    mod:designedForTask ocmv:Interoperability,
+                        ocmv:SoftwareEngineering;
+    ocmv:context ocmv:Research,
+                 ocmv:Industry;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Application;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/van-ee2021modular"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/van-ee2021modular"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T18:18:59.076803004Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:18:59.076803004Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/c6ec6f27-cffa-4a38-9927-8e6b921e996a> dcat:distribution <https://w3id.org/ontouml-models/distribution/9b158615-87dd-4118-8eb0-2481a53029f7/>, <https://w3id.org/ontouml-models/distribution/15762e63-c636-4839-a60e-199fff2c104e/>, <https://w3id.org/ontouml-models/distribution/60ca44fe-4fca-41e7-8c65-a7c3cb5b2f2c/>, <https://w3id.org/ontouml-models/distribution/e5389097-f11b-4f6e-aca6-f3a5d42ea583>, <https://w3id.org/ontouml-models/distribution/5661e697-3f4f-4f1f-aa1c-52e8a66084e7>, <https://w3id.org/ontouml-models/distribution/23e8fe21-505a-440b-840d-c67cf393f579>, <https://w3id.org/ontouml-models/distribution/36f7cc11-3ae2-44fc-ac15-255263ecc171>, <https://w3id.org/ontouml-models/distribution/fb0298e8-0230-46a1-9583-8b0f11993fba>, <https://w3id.org/ontouml-models/distribution/a6d077bc-cd53-481b-98b5-565e93011ccd>, <https://w3id.org/ontouml-models/distribution/55f804f2-d0cd-46f4-9b07-8b137300161f>, <https://w3id.org/ontouml-models/distribution/879c4b80-7617-4b9f-83b5-fa565900f0aa>, <https://w3id.org/ontouml-models/distribution/5d5ed42d-0703-4892-a0fe-e7973d987eed>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/c6ec6f27-cffa-4a38-9927-8e6b921e996a> dcat:distribution <https://w3id.org/ontouml-models/distribution/9b158615-87dd-4118-8eb0-2481a53029f7/>,
+                      <https://w3id.org/ontouml-models/distribution/15762e63-c636-4839-a60e-199fff2c104e/>,
+                      <https://w3id.org/ontouml-models/distribution/60ca44fe-4fca-41e7-8c65-a7c3cb5b2f2c/>,
+                      <https://w3id.org/ontouml-models/distribution/e5389097-f11b-4f6e-aca6-f3a5d42ea583>,
+                      <https://w3id.org/ontouml-models/distribution/5661e697-3f4f-4f1f-aa1c-52e8a66084e7>,
+                      <https://w3id.org/ontouml-models/distribution/23e8fe21-505a-440b-840d-c67cf393f579>,
+                      <https://w3id.org/ontouml-models/distribution/36f7cc11-3ae2-44fc-ac15-255263ecc171>,
+                      <https://w3id.org/ontouml-models/distribution/fb0298e8-0230-46a1-9583-8b0f11993fba>,
+                      <https://w3id.org/ontouml-models/distribution/a6d077bc-cd53-481b-98b5-565e93011ccd>,
+                      <https://w3id.org/ontouml-models/distribution/55f804f2-d0cd-46f4-9b07-8b137300161f>,
+                      <https://w3id.org/ontouml-models/distribution/879c4b80-7617-4b9f-83b5-fa565900f0aa>,
+                      <https://w3id.org/ontouml-models/distribution/5d5ed42d-0703-4892-a0fe-e7973d987eed> .

--- a/models/van-wingerde2020smart-contracts/metadata.ttl
+++ b/models/van-wingerde2020smart-contracts/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/e9489d3d-035b-41c9-b13f-e5bc7aee0ed2/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -18,14 +17,24 @@
     dcat:theme lcc:T;
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:contributor <https://dblp.org/pid/246/2103>, <https://dblp.org/pid/70/260>;
+    dct:contributor <https://dblp.org/pid/246/2103>,
+                    <https://dblp.org/pid/70/260>;
     dcat:keyword "business processes"@en;
+    dct:source <https://doi.org/10.1109/CBI49978.2020.00032>;
     mod:designedForTask ocmv:ConceptualClarification;
     ocmv:context ocmv:Research;
-    dct:source <https://doi.org/10.1109/CBI49978.2020.00032>;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/van-wingerde2020smart-contracts"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/van-wingerde2020smart-contracts"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T18:19:19.290257929Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:19:19.290257929Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/e9489d3d-035b-41c9-b13f-e5bc7aee0ed2> dcat:distribution <https://w3id.org/ontouml-models/distribution/90c360da-de86-4166-8a01-047492d199b9/>, <https://w3id.org/ontouml-models/distribution/6a83bef9-1911-4395-b653-eb93e18f4bae/>, <https://w3id.org/ontouml-models/distribution/5b9217cb-457f-4cab-8490-dc3c609cd209/>, <https://w3id.org/ontouml-models/distribution/c4a69b15-bcbf-4131-ae4b-78ae68814b5c>, <https://w3id.org/ontouml-models/distribution/70e6eb92-2f3a-4f82-9d95-9b1f482cc92a>, <https://w3id.org/ontouml-models/distribution/db1544d7-4347-4dbd-87e5-f0993e99b9c5>, <https://w3id.org/ontouml-models/distribution/ba721e57-2320-4aed-8357-2104d8670c49>, <https://w3id.org/ontouml-models/distribution/c33028c5-1843-45c1-bf73-7a5c656fc66b>, <https://w3id.org/ontouml-models/distribution/21b5d09a-33c0-43c8-a89d-e4c308aedbf1>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/e9489d3d-035b-41c9-b13f-e5bc7aee0ed2> dcat:distribution <https://w3id.org/ontouml-models/distribution/90c360da-de86-4166-8a01-047492d199b9/>,
+                      <https://w3id.org/ontouml-models/distribution/6a83bef9-1911-4395-b653-eb93e18f4bae/>,
+                      <https://w3id.org/ontouml-models/distribution/5b9217cb-457f-4cab-8490-dc3c609cd209/>,
+                      <https://w3id.org/ontouml-models/distribution/c4a69b15-bcbf-4131-ae4b-78ae68814b5c>,
+                      <https://w3id.org/ontouml-models/distribution/70e6eb92-2f3a-4f82-9d95-9b1f482cc92a>,
+                      <https://w3id.org/ontouml-models/distribution/db1544d7-4347-4dbd-87e5-f0993e99b9c5>,
+                      <https://w3id.org/ontouml-models/distribution/ba721e57-2320-4aed-8357-2104d8670c49>,
+                      <https://w3id.org/ontouml-models/distribution/c33028c5-1843-45c1-bf73-7a5c656fc66b>,
+                      <https://w3id.org/ontouml-models/distribution/21b5d09a-33c0-43c8-a89d-e4c308aedbf1> .

--- a/models/vieira2020weathering/metadata.ttl
+++ b/models/vieira2020weathering/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/06130cd9-ba26-4324-9f1e-88bd03b88ca9/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -17,14 +16,34 @@
     dcat:theme lcc:Q;
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:contributor <https://dblp.org/pid/278/1436>, <https://dblp.org/pid/151/1055>, <https://dblp.org/pid/a/MaraAbel>;
-    dcat:keyword "weathering processes"@en, "geology"@en;
+    dct:contributor <https://dblp.org/pid/278/1436>,
+                    <https://dblp.org/pid/151/1055>,
+                    <https://dblp.org/pid/a/MaraAbel>;
+    dcat:keyword "weathering processes"@en,
+                 "geology"@en;
+    dct:source <https://dblp.org/rec/conf/ontobras/VieiraRA20>;
     mod:designedForTask ocmv:ConceptualClarification;
     ocmv:context ocmv:Research;
-    dct:source <https://dblp.org/rec/conf/ontobras/VieiraRA20>;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/vieira2020weathering"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/vieira2020weathering"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T18:19:35.128736292Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:19:35.128736292Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/06130cd9-ba26-4324-9f1e-88bd03b88ca9> dcat:distribution <https://w3id.org/ontouml-models/distribution/cea35d08-2468-4228-a8b2-16c54ceb8846/>, <https://w3id.org/ontouml-models/distribution/c0b494a5-ac3a-4dff-9910-2efefe03bf08/>, <https://w3id.org/ontouml-models/distribution/205e740a-b0ce-421f-921a-ebdcf8ba4ce4/>, <https://w3id.org/ontouml-models/distribution/11c95765-7df7-4533-a3fe-11f8b1548783>, <https://w3id.org/ontouml-models/distribution/6a4001c5-a4e2-4b53-b41b-c942d92983d4>, <https://w3id.org/ontouml-models/distribution/532b6019-1476-4338-924f-d5f0a3a38610>, <https://w3id.org/ontouml-models/distribution/7a8e7a94-93f9-447f-9d2d-1e3d70e36397>, <https://w3id.org/ontouml-models/distribution/505d9e17-8f0d-4fe0-895d-d411743605f5>, <https://w3id.org/ontouml-models/distribution/cb15c54f-8903-4bb9-96da-f39f49f37e30>, <https://w3id.org/ontouml-models/distribution/cd1c5bdb-faad-4f82-81b0-31265396befc>, <https://w3id.org/ontouml-models/distribution/18e6206e-e58e-4c8e-a288-fe16e7249316>, <https://w3id.org/ontouml-models/distribution/78b5d963-6b9b-4cc1-8615-539e94f6839f>, <https://w3id.org/ontouml-models/distribution/251bbe9f-a000-4c3e-88e3-4c3271669136>, <https://w3id.org/ontouml-models/distribution/1b8ba82d-4daf-44d7-b9fd-fb0cd846927a>, <https://w3id.org/ontouml-models/distribution/f8c52e39-ceb2-45cb-81b3-97266c9091df>, <https://w3id.org/ontouml-models/distribution/3265ee18-4907-4837-a724-85d548f81ae5>, <https://w3id.org/ontouml-models/distribution/8411bca5-d2bc-461e-ab21-44033d44e415>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/06130cd9-ba26-4324-9f1e-88bd03b88ca9> dcat:distribution <https://w3id.org/ontouml-models/distribution/cea35d08-2468-4228-a8b2-16c54ceb8846/>,
+                      <https://w3id.org/ontouml-models/distribution/c0b494a5-ac3a-4dff-9910-2efefe03bf08/>,
+                      <https://w3id.org/ontouml-models/distribution/205e740a-b0ce-421f-921a-ebdcf8ba4ce4/>,
+                      <https://w3id.org/ontouml-models/distribution/11c95765-7df7-4533-a3fe-11f8b1548783>,
+                      <https://w3id.org/ontouml-models/distribution/6a4001c5-a4e2-4b53-b41b-c942d92983d4>,
+                      <https://w3id.org/ontouml-models/distribution/532b6019-1476-4338-924f-d5f0a3a38610>,
+                      <https://w3id.org/ontouml-models/distribution/7a8e7a94-93f9-447f-9d2d-1e3d70e36397>,
+                      <https://w3id.org/ontouml-models/distribution/505d9e17-8f0d-4fe0-895d-d411743605f5>,
+                      <https://w3id.org/ontouml-models/distribution/cb15c54f-8903-4bb9-96da-f39f49f37e30>,
+                      <https://w3id.org/ontouml-models/distribution/cd1c5bdb-faad-4f82-81b0-31265396befc>,
+                      <https://w3id.org/ontouml-models/distribution/18e6206e-e58e-4c8e-a288-fe16e7249316>,
+                      <https://w3id.org/ontouml-models/distribution/78b5d963-6b9b-4cc1-8615-539e94f6839f>,
+                      <https://w3id.org/ontouml-models/distribution/251bbe9f-a000-4c3e-88e3-4c3271669136>,
+                      <https://w3id.org/ontouml-models/distribution/1b8ba82d-4daf-44d7-b9fd-fb0cd846927a>,
+                      <https://w3id.org/ontouml-models/distribution/f8c52e39-ceb2-45cb-81b3-97266c9091df>,
+                      <https://w3id.org/ontouml-models/distribution/3265ee18-4907-4837-a724-85d548f81ae5>,
+                      <https://w3id.org/ontouml-models/distribution/8411bca5-d2bc-461e-ab21-44033d44e415> .

--- a/models/weigand2021artifact/metadata.ttl
+++ b/models/weigand2021artifact/metadata.ttl
@@ -1,14 +1,13 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/9746dec7-6303-4b95-88bc-712c95def0b8/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
@@ -16,17 +15,37 @@
     dct:issued "2020"^^xsd:gYear;
     dct:modified "2021"^^xsd:gYear;
     dcat:theme lcc:T;
-    skos:editorialNote "Some classes are in gray in certain diagrams and pink in other. This raises a question about the value of \"restrictedTo\" they have assigned to them. In the case of \"Technical Object\", I'm keeping the inherited/default value of \"functional complex\" in these cases as it makes sense in the context and seems to be the most reasonable choice. In the case of \"Artifact design\", however, I'm setting \"restrictedTo\" to \"relator\" as it was set to green in Visual Paradigm's OntoUML plugin, even though the context suggests it should also be a \"functional complex\".\nIn different diagrams, the «characterization» relation \"Attributed Capacities\" is set in opposite direction. We are keeping the direction from the «quality» to the «roleMixin».\n";
+    skos:editorialNote """Some classes are in gray in certain diagrams and pink in other. This raises a question about the value of "restrictedTo" they have assigned to them. In the case of "Technical Object", I'm keeping the inherited/default value of "functional complex" in these cases as it makes sense in the context and seems to be the most reasonable choice. In the case of "Artifact design", however, I'm setting "restrictedTo" to "relator" as it was set to green in Visual Paradigm's OntoUML plugin, even though the context suggests it should also be a "functional complex".
+In different diagrams, the «characterization» relation "Attributed Capacities" is set in opposite direction. We are keeping the direction from the «quality» to the «roleMixin».
+""";
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:contributor <https://dblp.org/pid/70/260>, <https://dblp.org/pid/j/PaulJohannesson>, <https://dblp.org/pid/23/4576>;
-    dcat:keyword "design science"@en, "IT artifact"@en, "information systems"@en;
+    dct:contributor <https://dblp.org/pid/70/260>,
+                    <https://dblp.org/pid/j/PaulJohannesson>,
+                    <https://dblp.org/pid/23/4576>;
+    dcat:keyword "design science"@en,
+                 "IT artifact"@en,
+                 "information systems"@en;
+    dct:source <https://doi.org/10.1007/978-3-030-50316-1_8>,
+               <https://doi.org/10.1016/j.datak.2021.101878>;
     mod:designedForTask ocmv:ConceptualClarification;
     ocmv:context ocmv:Research;
-    dct:source <https://doi.org/10.1007/978-3-030-50316-1_8>, <https://doi.org/10.1016/j.datak.2021.101878>;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Core;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/weigand2021artifact"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/weigand2021artifact"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T18:20:03.753840629Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:20:03.753840629Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/9746dec7-6303-4b95-88bc-712c95def0b8> dcat:distribution <https://w3id.org/ontouml-models/distribution/e636ee11-36bf-4716-aaf3-9333ba8d0a6d/>, <https://w3id.org/ontouml-models/distribution/a1c42118-ade7-45d4-bd2d-bb9a0f38702b/>, <https://w3id.org/ontouml-models/distribution/cb93bba9-2da7-479e-838f-eaf15481e5a9/>, <https://w3id.org/ontouml-models/distribution/fd4247af-cfff-45b7-afe5-3ac200bfeaf9>, <https://w3id.org/ontouml-models/distribution/ea5492a2-5bea-4c66-bc21-093efe3ce552>, <https://w3id.org/ontouml-models/distribution/eea44330-1f62-431e-bf70-9e2021ee6d3d>, <https://w3id.org/ontouml-models/distribution/5a4815de-acd0-4410-867d-c2bf68d90b36>, <https://w3id.org/ontouml-models/distribution/78b3f8b3-360f-4d93-8ff0-0397d3b186e4>, <https://w3id.org/ontouml-models/distribution/8e5a7dc5-83c3-4eee-bd0a-0d4bf4123a71>, <https://w3id.org/ontouml-models/distribution/ae5a9391-9385-4381-a42e-b7b570d8c24c>, <https://w3id.org/ontouml-models/distribution/9f6a060c-653e-43e3-a08c-fa52e4ed0082>, <https://w3id.org/ontouml-models/distribution/57cf63f1-a0db-4777-8acc-cc08482eeace>, <https://w3id.org/ontouml-models/distribution/84a206e6-58f4-4ffc-afc5-29e95afc5aef>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/9746dec7-6303-4b95-88bc-712c95def0b8> dcat:distribution <https://w3id.org/ontouml-models/distribution/e636ee11-36bf-4716-aaf3-9333ba8d0a6d/>,
+                      <https://w3id.org/ontouml-models/distribution/a1c42118-ade7-45d4-bd2d-bb9a0f38702b/>,
+                      <https://w3id.org/ontouml-models/distribution/cb93bba9-2da7-479e-838f-eaf15481e5a9/>,
+                      <https://w3id.org/ontouml-models/distribution/fd4247af-cfff-45b7-afe5-3ac200bfeaf9>,
+                      <https://w3id.org/ontouml-models/distribution/ea5492a2-5bea-4c66-bc21-093efe3ce552>,
+                      <https://w3id.org/ontouml-models/distribution/eea44330-1f62-431e-bf70-9e2021ee6d3d>,
+                      <https://w3id.org/ontouml-models/distribution/5a4815de-acd0-4410-867d-c2bf68d90b36>,
+                      <https://w3id.org/ontouml-models/distribution/78b3f8b3-360f-4d93-8ff0-0397d3b186e4>,
+                      <https://w3id.org/ontouml-models/distribution/8e5a7dc5-83c3-4eee-bd0a-0d4bf4123a71>,
+                      <https://w3id.org/ontouml-models/distribution/ae5a9391-9385-4381-a42e-b7b570d8c24c>,
+                      <https://w3id.org/ontouml-models/distribution/9f6a060c-653e-43e3-a08c-fa52e4ed0082>,
+                      <https://w3id.org/ontouml-models/distribution/57cf63f1-a0db-4777-8acc-cc08482eeace>,
+                      <https://w3id.org/ontouml-models/distribution/84a206e6-58f4-4ffc-afc5-29e95afc5aef> .

--- a/models/xhani2023xmlpo/metadata.ttl
+++ b/models/xhani2023xmlpo/metadata.ttl
@@ -1,15 +1,16 @@
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/model/xhani2023xmlpo/> a dcat:Dataset, mod:SemanticArtefact;
+<https://w3id.org/ontouml-models/model/xhani2023xmlpo/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
+    dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
     dct:title "Explainable Machine Learning Pipeline Ontology";
     mod:acronym "XMLPO";
     dct:issued "2023"^^xsd:gYear;
@@ -18,22 +19,28 @@
     skos:editorialNote "Updated version.";
     dct:language "en";
     dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:contributor <https://orcid.org/0000-0003-2536-0574>, <https://dblp.org/pid/74/7740>, <https://dblp.org/pid/s/MartenvanSinderen>, <https://dblp.org/pid/p/LuisFerreiraPires>;
+    dct:contributor <https://orcid.org/0000-0003-2536-0574>,
+                    <https://dblp.org/pid/74/7740>,
+                    <https://dblp.org/pid/s/MartenvanSinderen>,
+                    <https://dblp.org/pid/p/LuisFerreiraPires>;
+    dcat:keyword "explainability"@en,
+                 "machine learning models"@en;
+    dct:source <https://doi.org/10.3990/1.9789036558594>,
+               <https://www.utwente.nl/en/eemcs/fois2024/resources/papers/xhani-next-generation-cross-sectoral-data-platform-for-the-agri-food-sector.pdf>,
+               <https://www.utwente.nl/en/eemcs/fois2024/resources/papers/xhani-et-al-xmlpo.pdf>;
     mod:designedForTask ocmv:ConceptualClarification;
     ocmv:context ocmv:Research;
-    dct:source <https://doi.org/10.3990/1.9789036558594>, <https://www.utwente.nl/en/eemcs/fois2024/resources/papers/xhani-next-generation-cross-sectoral-data-platform-for-the-agri-food-sector.pdf>, <https://www.utwente.nl/en/eemcs/fois2024/resources/papers/xhani-et-al-xmlpo.pdf>.
-<https://w3id.org/ontouml-models/model/xhani2023xmlpo/> dcat:distribution <https://w3id.org/ontouml-models/model/xhani2023xmlpo/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/xhani2023xmlpo/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Explainable Machine Learning Pipeline Ontology\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/xhani2023xmlpo/ontology.ttl>.
-<https://w3id.org/ontouml-models/model/xhani2023xmlpo/> dcat:distribution <https://w3id.org/ontouml-models/model/xhani2023xmlpo/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/xhani2023xmlpo/distribution/ttl> a dcat:Distribution;
-    dct:title "JSON distribution of \"Explainable Machine Learning Pipeline Ontology\""@en;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/xhani2023xmlpo/ontology.json>.
-<https://w3id.org/ontouml-models/model/xhani2023xmlpo/> dcat:distribution <https://w3id.org/ontouml-models/model/xhani2023xmlpo/distribution/ttl>.
-<https://w3id.org/ontouml-models/model/xhani2023xmlpo/distribution/ttl> a dcat:Distribution;
-    dct:title "Turtle distribution of \"Explainable Machine Learning Pipeline Ontology\""@en;
-    dcat:mediaType <https://www.visual-paradigm.com/vpp>;
-    dcat:downloadURL <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/xhani2023xmlpo/ontology.vpp>.
+    ocmv:representationStyle ocmv:OntoumlStyle;
+    ocmv:ontologyType ocmv:Domain;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/xhani2023xmlpo"^^xsd:anyURI;
+    fdpo:metadataIssued "2026-06-23T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/xhani2023xmlpo/> dcat:distribution <https://w3id.org/ontouml-models/model/xhani2023xmlpo/distribution/ttl>,
+                      <https://www.iana.org/assignments/media-types/text/turtle>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/xhani2023xmlpo/ontology.ttl>,
+                      <https://w3id.org/ontouml-models/model/xhani2023xmlpo/>,
+                      <https://www.iana.org/assignments/media-types/application/json>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/xhani2023xmlpo/ontology.json>,
+                      <https://www.visual-paradigm.com/vpp>,
+                      <https://raw.githubusercontent.com/unibz-core/ontouml-models/master/xhani2023xmlpo/ontology.vpp> .

--- a/models/zanetti2019orm-o/metadata.ttl
+++ b/models/zanetti2019orm-o/metadata.ttl
@@ -1,32 +1,42 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/c528d763-ff22-4d52-9e03-e881b41805ce/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:title "Object/Relational Mapping Ontology";
     mod:acronym "ORM-O";
     dct:issued "2019"^^xsd:gYear;
     dcat:theme lcc:T;
     skos:editorialNote "The ontology was documented based on the author's paper.";
     dct:language "en";
-    dct:contributor <https://dblp.org/pid/256/4242>, <https://dblp.org/pid/230/6733>, <https://dblp.org/pid/72/3662>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    dct:contributor <https://dblp.org/pid/256/4242>,
+                    <https://dblp.org/pid/230/6733>,
+                    <https://dblp.org/pid/72/3662>;
     dcat:keyword "frameworks object/relational mapping"@en;
+    dct:source <https://dblp.org/rec/conf/ontobras/ZanettiAS19>;
     mod:designedForTask ocmv:ConceptualClarification;
     ocmv:context ocmv:Research;
-    dct:source <https://dblp.org/rec/conf/ontobras/ZanettiAS19>;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/zanetti2019orm-o"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/zanetti2019orm-o"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T18:20:25.574199631Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:20:25.574199631Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/c528d763-ff22-4d52-9e03-e881b41805ce> dcat:distribution <https://w3id.org/ontouml-models/distribution/00adef72-c45f-420e-aabb-9183fb5f25ae/>, <https://w3id.org/ontouml-models/distribution/1fba6c3c-9df4-4f7f-b374-cee0530be3f4/>, <https://w3id.org/ontouml-models/distribution/3a1005fe-971a-44f0-adc6-168a3477adb7/>, <https://w3id.org/ontouml-models/distribution/e1271a9a-2d30-4ad6-a53f-3127948bad48>, <https://w3id.org/ontouml-models/distribution/a182e9c1-b9cf-45b2-b061-92d162f9a490>, <https://w3id.org/ontouml-models/distribution/be2b2b3b-493a-4702-ae0c-04500dae8c10>, <https://w3id.org/ontouml-models/distribution/508ca6cf-6940-4f4f-ad74-064c200c675b>, <https://w3id.org/ontouml-models/distribution/3ca09a09-e25e-422e-b1a8-aa25a56015b9>, <https://w3id.org/ontouml-models/distribution/1999a0f1-cf5e-4c04-9aa4-98fe47996c09>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/c528d763-ff22-4d52-9e03-e881b41805ce> dcat:distribution <https://w3id.org/ontouml-models/distribution/00adef72-c45f-420e-aabb-9183fb5f25ae/>,
+                      <https://w3id.org/ontouml-models/distribution/1fba6c3c-9df4-4f7f-b374-cee0530be3f4/>,
+                      <https://w3id.org/ontouml-models/distribution/3a1005fe-971a-44f0-adc6-168a3477adb7/>,
+                      <https://w3id.org/ontouml-models/distribution/e1271a9a-2d30-4ad6-a53f-3127948bad48>,
+                      <https://w3id.org/ontouml-models/distribution/a182e9c1-b9cf-45b2-b061-92d162f9a490>,
+                      <https://w3id.org/ontouml-models/distribution/be2b2b3b-493a-4702-ae0c-04500dae8c10>,
+                      <https://w3id.org/ontouml-models/distribution/508ca6cf-6940-4f4f-ad74-064c200c675b>,
+                      <https://w3id.org/ontouml-models/distribution/3ca09a09-e25e-422e-b1a8-aa25a56015b9>,
+                      <https://w3id.org/ontouml-models/distribution/1999a0f1-cf5e-4c04-9aa4-98fe47996c09> .

--- a/models/zhou2017hazard-ontology-robotic-strolling/metadata.ttl
+++ b/models/zhou2017hazard-ontology-robotic-strolling/metadata.ttl
@@ -1,32 +1,42 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/c7dbcd4e-e12a-4f9f-a20c-e08137c36db5/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:title "Robotic Strolling System";
     dct:issued "2017"^^xsd:gYear;
     dct:modified "2017"^^xsd:gYear;
     dcat:theme lcc:T;
     skos:editorialNote "This ontology was built as a use case for evaluating importance of the Hazard Ontology.";
     dct:language "en";
-    dct:contributor <https://dblp.org/pid/143/1123>, <https://dblp.org/pid/36/2701>, <https://dblp.org/pid/53/2238>, <https://dblp.org/pid/35/160>;
-    dcat:keyword "robotic strolling system"@en, "safety"@en, "hazard"@en;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    dct:contributor <https://dblp.org/pid/143/1123>,
+                    <https://dblp.org/pid/36/2701>,
+                    <https://dblp.org/pid/53/2238>,
+                    <https://dblp.org/pid/35/160>;
+    dcat:keyword "robotic strolling system"@en,
+                 "safety"@en,
+                 "hazard"@en;
+    dct:source <http://urn.kb.se/resolve?urn=urn:nbn:se:mdh:diva-37386>,
+               <https://doi.org/10.1109/ICSRS.2017.8272856>;
     mod:designedForTask ocmv:OntologicalAnalysis;
     ocmv:context ocmv:Research;
-    dct:source <http://urn.kb.se/resolve?urn=urn:nbn:se:mdh:diva-37386>, <https://doi.org/10.1109/ICSRS.2017.8272856>;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/zhou2017hazard-ontology-robotic-strolling"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/zhou2017hazard-ontology-robotic-strolling"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T18:20:41.066388527Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:20:41.066388527Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/c7dbcd4e-e12a-4f9f-a20c-e08137c36db5> dcat:distribution <https://w3id.org/ontouml-models/distribution/b709fd18-79b6-429b-a323-465254b9f34d/>, <https://w3id.org/ontouml-models/distribution/c30ed359-c2eb-436b-8958-0596f9a5cc6c/>, <https://w3id.org/ontouml-models/distribution/dc505fe5-5fc5-416a-92bb-3813adf3c0ad/>, <https://w3id.org/ontouml-models/distribution/e594a578-fae5-4ea3-92e6-5c7681c48f0b>, <https://w3id.org/ontouml-models/distribution/219aaf3e-8af9-4d45-a4d9-4ebf90b70a3f>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/c7dbcd4e-e12a-4f9f-a20c-e08137c36db5> dcat:distribution <https://w3id.org/ontouml-models/distribution/b709fd18-79b6-429b-a323-465254b9f34d/>,
+                      <https://w3id.org/ontouml-models/distribution/c30ed359-c2eb-436b-8958-0596f9a5cc6c/>,
+                      <https://w3id.org/ontouml-models/distribution/dc505fe5-5fc5-416a-92bb-3813adf3c0ad/>,
+                      <https://w3id.org/ontouml-models/distribution/e594a578-fae5-4ea3-92e6-5c7681c48f0b>,
+                      <https://w3id.org/ontouml-models/distribution/219aaf3e-8af9-4d45-a4d9-4ebf90b70a3f> .

--- a/models/zhou2017hazard-ontology-train-control/metadata.ttl
+++ b/models/zhou2017hazard-ontology-train-control/metadata.ttl
@@ -1,32 +1,44 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/0ea32c8f-85e8-4749-97b9-24b59ae41dbd/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:title "Train Control System";
     dct:issued "2017"^^xsd:gYear;
     dct:modified "2017"^^xsd:gYear;
     dcat:theme lcc:T;
     skos:editorialNote "This ontology was built as a use case for evaluating importance of the Hazard Ontology.";
     dct:language "en";
-    dct:contributor <https://dblp.org/pid/143/1123>, <https://dblp.org/pid/36/2701>, <https://dblp.org/pid/53/2238>, <https://dblp.org/pid/35/160>;
-    dcat:keyword "train control system"@en, "safety"@en, "hazard"@en;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    dct:contributor <https://dblp.org/pid/143/1123>,
+                    <https://dblp.org/pid/36/2701>,
+                    <https://dblp.org/pid/53/2238>,
+                    <https://dblp.org/pid/35/160>;
+    dcat:keyword "train control system"@en,
+                 "safety"@en,
+                 "hazard"@en;
+    dct:source <http://urn.kb.se/resolve?urn=urn:nbn:se:mdh:diva-37386>,
+               <https://doi.org/10.1109/ICSRS.2017.8272856>;
     mod:designedForTask ocmv:OntologicalAnalysis;
     ocmv:context ocmv:Research;
-    dct:source <http://urn.kb.se/resolve?urn=urn:nbn:se:mdh:diva-37386>, <https://doi.org/10.1109/ICSRS.2017.8272856>;
     ocmv:representationStyle ocmv:OntoumlStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/zhou2017hazard-ontology-train-control"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/zhou2017hazard-ontology-train-control"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T18:20:51.467454286Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:20:51.467454286Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/0ea32c8f-85e8-4749-97b9-24b59ae41dbd> dcat:distribution <https://w3id.org/ontouml-models/distribution/e31b4d0f-4abb-47fd-b4e9-600d5811b821/>, <https://w3id.org/ontouml-models/distribution/8ef09e9f-ada6-4952-9e9f-34e0986b6b04/>, <https://w3id.org/ontouml-models/distribution/80e6ab1d-9a9a-4865-b446-5b930153dc2c/>, <https://w3id.org/ontouml-models/distribution/9b77c2a0-da42-458d-9d93-b92320f4ceff>, <https://w3id.org/ontouml-models/distribution/17ecd8ff-a496-43eb-80c4-501a690243b8>, <https://w3id.org/ontouml-models/distribution/1a9e225e-38bf-49df-979c-13b9004b26a7>, <https://w3id.org/ontouml-models/distribution/2f433ae4-2e2e-4d89-9fd2-3710e96308c2>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/0ea32c8f-85e8-4749-97b9-24b59ae41dbd> dcat:distribution <https://w3id.org/ontouml-models/distribution/e31b4d0f-4abb-47fd-b4e9-600d5811b821/>,
+                      <https://w3id.org/ontouml-models/distribution/8ef09e9f-ada6-4952-9e9f-34e0986b6b04/>,
+                      <https://w3id.org/ontouml-models/distribution/80e6ab1d-9a9a-4865-b446-5b930153dc2c/>,
+                      <https://w3id.org/ontouml-models/distribution/9b77c2a0-da42-458d-9d93-b92320f4ceff>,
+                      <https://w3id.org/ontouml-models/distribution/17ecd8ff-a496-43eb-80c4-501a690243b8>,
+                      <https://w3id.org/ontouml-models/distribution/1a9e225e-38bf-49df-979c-13b9004b26a7>,
+                      <https://w3id.org/ontouml-models/distribution/2f433ae4-2e2e-4d89-9fd2-3710e96308c2> .

--- a/models/zhou2017hazard/metadata.ttl
+++ b/models/zhou2017hazard/metadata.ttl
@@ -1,18 +1,16 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix lcc: <http://id.loc.gov/authorities/classification/>.
-@prefix mod: <https://w3id.org/mod#>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix lcc: <http://id.loc.gov/authorities/classification/> .
+@prefix mod: <https://w3id.org/mod#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 <https://w3id.org/ontouml-models/model/e28bed62-0a6b-49a4-a3a9-01c8e4f527e3/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource;
     dct:isPartOf <https://w3id.org/ontouml-models/catalog/b663ca18-8085-44a7-bcfe-2c2b5ba1faa8>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:title "Hazard Ontology";
     mod:acronym "HO";
     dct:issued "2017"^^xsd:gYear;
@@ -20,14 +18,25 @@
     dcat:theme lcc:H;
     skos:editorialNote "The paper in which the hazard ontology is proposed contains use cases that extend the ontology. These were not included but in the folder hazard-ontology-use-cases2017.";
     dct:language "en";
-    dct:contributor <https://dblp.org/pid/143/1123>, <https://dblp.org/pid/36/2701>, <https://dblp.org/pid/53/2238>, <https://dblp.org/pid/35/160>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    dct:contributor <https://dblp.org/pid/143/1123>,
+                    <https://dblp.org/pid/36/2701>,
+                    <https://dblp.org/pid/53/2238>,
+                    <https://dblp.org/pid/35/160>;
     dcat:keyword "hazard"@en;
+    dct:source <http://urn.kb.se/resolve?urn=urn:nbn:se:mdh:diva-37386>,
+               <https://doi.org/10.1109/ICSRS.2017.8272856>,
+               <https://doi.org/10.1109/SEAA.2017.48>;
     mod:designedForTask ocmv:ConceptualClarification;
     ocmv:context ocmv:Research;
-    dct:source <http://urn.kb.se/resolve?urn=urn:nbn:se:mdh:diva-37386>, <https://doi.org/10.1109/ICSRS.2017.8272856>, <https://doi.org/10.1109/SEAA.2017.48>;
     ocmv:representationStyle ocmv:UfoStyle;
     ocmv:ontologyType ocmv:Domain;
-    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/zhou2017hazard"^^xsd:anyURI ;
+    ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/zhou2017hazard"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T18:21:04.152104584Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:21:04.152104584Z"^^xsd:dateTime .
-    <https://w3id.org/ontouml-models/model/e28bed62-0a6b-49a4-a3a9-01c8e4f527e3> dcat:distribution <https://w3id.org/ontouml-models/distribution/93bbe0fc-3e47-4037-b4bf-1fb5b88664b1/>, <https://w3id.org/ontouml-models/distribution/d9c7230e-3e8b-4be3-a9e9-8be974d68086/>, <https://w3id.org/ontouml-models/distribution/20051c47-c7b7-4ec9-bb5f-cc09e110ebb8/>, <https://w3id.org/ontouml-models/distribution/577739c1-9341-4224-9f8b-dce26d195383>, <https://w3id.org/ontouml-models/distribution/16ed48c3-b042-41cc-a9d4-04301817795e>.
+    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+
+<https://w3id.org/ontouml-models/model/e28bed62-0a6b-49a4-a3a9-01c8e4f527e3> dcat:distribution <https://w3id.org/ontouml-models/distribution/93bbe0fc-3e47-4037-b4bf-1fb5b88664b1/>,
+                      <https://w3id.org/ontouml-models/distribution/d9c7230e-3e8b-4be3-a9e9-8be974d68086/>,
+                      <https://w3id.org/ontouml-models/distribution/20051c47-c7b7-4ec9-bb5f-cc09e110ebb8/>,
+                      <https://w3id.org/ontouml-models/distribution/577739c1-9341-4224-9f8b-dce26d195383>,
+                      <https://w3id.org/ontouml-models/distribution/16ed48c3-b042-41cc-a9d4-04301817795e> .


### PR DESCRIPTION
## Summary

This PR regenerates the model-level `metadata.ttl` files in `models/` using the `metadata.yaml` → `metadata.ttl` converter.

The PR is intentionally limited to generated model-level metadata files:

- only `models/**/metadata.ttl` files are updated;
- no `metadata.yaml` files are modified;
- no distribution-specific metadata files are modified;
- no model artifacts are modified;
- no converter implementation files are modified.

## Motivation

This regeneration applies the current converter to make existing model-level `metadata.ttl` files consistent with their corresponding `metadata.yaml` files.

The goal is to normalize generated RDF metadata before further catalog automation work, while preserving catalog-managed values where appropriate.

## Generation command

The files were generated with:

```bash
python scripts/metadata_yaml_to_ttl.py --all --models-dir models --allow-missing-license --metadata-timestamp PASTE_TIMESTAMP_HERE
```

A fixed UTC timestamp was used instead of `--metadata-timestamp now` to make the regeneration deterministic and easier to review.

## Timestamp policy

The regeneration follows the converter’s FDP timestamp policy:

- preserve existing `fdpo:metadataIssued` values when they are already available;
- initialize missing `fdpo:metadataIssued` values with the fixed migration timestamp;
- update `fdpo:metadataModified` only when the generated `metadata.ttl` content changes;
- preserve `fdpo:metadataModified` when the regenerated output is unchanged.

The migration timestamp used in this PR is:

```text
PASTE_TIMESTAMP_HERE
```

## License handling

The regeneration used `--allow-missing-license` because some legacy datasets do not yet have license information in `metadata.yaml`.

This option only relaxes missing-license errors. It does not suppress available license metadata:

- if `metadata.yaml` contains `license`, `dct:license` is generated;
- if `metadata.yaml` lacks `license` but existing `metadata.ttl` contains `dct:license`, the existing license is preserved;
- if neither source contains license information, `dct:license` is omitted and a warning is reported.

## Preservation behavior

The converter preserves catalog-managed values from existing `metadata.ttl` files where applicable, including:

- stable model IRIs;
- catalog links through `dct:isPartOf`;
- storage URLs through `ocmv:storageUrl`;
- existing `fdpo:metadataIssued`;
- existing distribution links through `dcat:distribution`;
- existing license values when needed for legacy datasets.

## Expected changes

The resulting changes may include:

- normalized Turtle formatting;
- updated `fdpo:metadataModified` values for changed files;
- initialized `fdpo:metadataIssued` values for files where the field was previously missing;
- regenerated descriptive metadata from `metadata.yaml`;
- preserved catalog-managed identifiers and distribution links;
- omission of unsupported or unnecessary namespace prefixes.

## Verification

The regeneration was checked by rerunning the converter in check mode with the same timestamp:

```bash
python scripts/metadata_yaml_to_ttl.py --all --models-dir models --allow-missing-license --metadata-timestamp PASTE_TIMESTAMP_HERE --check
```

The PR diff was also checked to ensure that only `models/**/metadata.ttl` files were modified.

## Notes

This PR does not change the converter implementation. It only applies the converter to regenerate existing model-level catalog metadata.