### PR TITLE
Prepare PNG metadata generation for YAML-based metadata workflow

### DIFF
--- a/scripts/generate-png-metadata.md
+++ b/scripts/generate-png-metadata.md
@@ -16,14 +16,34 @@ models/example/new-diagrams/main-diagram.png
 models/example/metadata-png-n-main-diagram.ttl
 ```
 
+## Purpose and pipeline role
+
+The script generates distribution-level metadata for PNG diagram images. It is intended to run **before** model-level `metadata.ttl` is generated.
+
+The model-level source of truth is `metadata.yaml`. The PNG generator does **not** update `metadata.ttl`, and it does **not** add model-level `dcat:distribution` triples. Instead, each generated PNG metadata file points back to the model with `dct:isPartOf`.
+
+For existing catalog datasets, the script preserves the already published model W3ID used in `dct:isPartOf`. When an existing model-level `metadata.ttl` is present, its model subject is treated as the canonical model URI. If `metadata.ttl` is absent, the script falls back to existing `metadata-png-*.ttl` files. This is not a generation-order dependency: when `metadata.ttl` is absent, the script still runs and uses the same deterministic UUIDv5 model URI strategy as `scripts/metadata_yaml_to_ttl.py`.
+
+Recommended future generation order:
+
+```text
+metadata.yaml + PNG files
+  -> metadata-png-*.ttl
+
+metadata.yaml + metadata-png-*.ttl + other distribution metadata
+  -> metadata.ttl
+```
+
+This document only describes the PNG metadata generator. No GitHub Actions workflow, CI configuration, or full automation pipeline is created by this script.
+
 ## Generated RDF semantics
 
-For each PNG file, the script creates a `dcat:Distribution` metadata file following the same RDF pattern used by existing generated distribution files such as `metadata-json.ttl`, `metadata-turtle.ttl`, and `metadata-vpp.ttl`.
+For each PNG file, the script creates a `dcat:Distribution` metadata file following the RDF pattern used by existing generated distribution files such as `metadata-json.ttl`, `metadata-turtle.ttl`, and `metadata-vpp.ttl`.
 
 The generated distribution includes:
 
 - `rdf:type dcat:Distribution`
-- `dct:isPartOf`, pointing to the model dataset
+- `dct:isPartOf`, pointing to the preserved or generated model dataset URI
 - `dct:issued`, derived from the model-level `metadata.yaml`
 - `dct:license`, copied from existing PNG metadata or derived from model-level `metadata.yaml` when available
 - `dct:title`
@@ -34,36 +54,48 @@ The generated distribution includes:
 - `fdpo:metadataIssued`
 - `fdpo:metadataModified`
 
-The script does **not** read or update `metadata.ttl`, and it does **not** add model-level `dcat:distribution` triples. Distribution metadata files point back to the model with `dct:isPartOf`; the separate `metadata.ttl` generation step should read the generated `metadata-png-*.ttl` files and add the corresponding model-level `dcat:distribution` links.
-
-## Pipeline role
-
-The intended generation pipeline is:
-
-```text
-metadata.yaml + PNG files
-  -> metadata-png-*.ttl
-
-metadata.yaml + metadata-png-*.ttl + other distribution metadata
-  -> metadata.ttl
-```
-
-In this pipeline, `metadata.yaml` is the canonical input file. The `metadata-png-*.ttl` files are generated distribution metadata files. The model-level `metadata.ttl` file is a later aggregation product and should not be used as an input by this PNG generator.
-
 ## Existing metadata preservation
 
 When regenerating an existing PNG metadata file, the script preserves curated values that should not be changed accidentally:
 
 - the existing distribution URI;
+- the existing model URI used in `dct:isPartOf`;
 - `dct:title`;
 - `skos:editorialNote`;
 - `dcat:downloadURL`;
 - `dct:license`;
-- the exact lexical values of `fdpo:metadataIssued` and `fdpo:metadataModified`.
+- the exact lexical value of `fdpo:metadataIssued`;
+- the exact lexical value of `fdpo:metadataModified` when the regenerated file is otherwise unchanged.
 
-Preserving the exact timestamp lexical values avoids changes such as nanosecond truncation or conversion from `Z` to `+00:00` when existing `xsd:dateTime` literals are parsed.
+Preserving exact timestamp lexical values avoids changes such as nanosecond truncation or conversion from `Z` to `+00:00` when existing `xsd:dateTime` literals are parsed.
 
-For existing files, the script still regenerates the remaining triples from the model metadata and script defaults, including `dct:isPartOf`, `dct:issued`, `dcat:mediaType`, and `ocmv:isComplete`. The script preserves an existing PNG-level `dct:license`; if none exists, it copies the model-level `dct:license` when available.
+Timestamp handling follows the same maintenance strategy used by `scripts/metadata_yaml_to_ttl.py`:
+
+- if an existing PNG metadata file has `fdpo:metadataIssued`, that value is preserved;
+- if there is no existing PNG metadata file, or the existing file has no `fdpo:metadataIssued`, the value is initialized from `--metadata-timestamp`;
+- if an existing PNG metadata file changes during regeneration, `fdpo:metadataModified` is updated from `--metadata-timestamp`;
+- if an existing PNG metadata file is already up to date, `fdpo:metadataModified` is preserved.
+
+For existing files, the script still regenerates the remaining triples from model metadata and script defaults, including `dct:issued`, `dcat:mediaType`, and `ocmv:isComplete`. The `dct:isPartOf` value is preserved from existing `metadata.ttl` when present, or otherwise from existing PNG metadata.
+
+## License handling
+
+By default, model-level `metadata.yaml` must contain a usable `license` value. This matches the policy of `scripts/metadata_yaml_to_ttl.py`: license metadata is mandatory unless the legacy-compatibility option is explicitly used.
+
+Use `--allow-missing-license` only for legacy datasets that intentionally lack license metadata:
+
+```bash
+python scripts/generate_png_metadata.py models/<model-directory> --allow-missing-license \
+  --metadata-timestamp 2024-01-02T03:04:05Z
+```
+
+When `--allow-missing-license` is used and no model-level license is present:
+
+- an existing PNG-level `dct:license` is preserved when regenerating an existing `metadata-png-*.ttl` file;
+- new PNG metadata files omit `dct:license`;
+- generation continues so older catalog entries can be processed.
+
+When `--allow-missing-license` is not used, missing or unusable license metadata is a fatal error. This keeps license metadata enforceable for future datasets.
 
 ## Defaults for new PNG metadata files
 
@@ -73,7 +105,7 @@ For new files, the script generates a catalog-style title:
 PNG distribution of diagram '<diagram label>' from the <model title> (<version>)
 ```
 
-The diagram label is derived from the filename stem by replacing spaces, underscores, and hyphens with spaces. For example:
+The diagram label is derived from the filename stem by replacing spaces, underscores, and hyphens with spaces.
 
 | PNG filename | Diagram label |
 | --- | --- |
@@ -96,7 +128,7 @@ The default editorial notes are:
 
 ## Distribution identifiers
 
-Existing target metadata files keep their current distribution URI. This avoids changing already published W3IDs. Existing catalog PNG distribution identifiers were historically generated as opaque UUIDs, and many of them are UUIDv4 values. The script treats all existing distribution identifiers as persistent opaque identifiers and never replaces them during regeneration.
+Existing target metadata files keep their current distribution URI. This avoids changing already published W3IDs.
 
 For new PNG metadata files, the script creates a deterministic UUIDv5 distribution URI under:
 
@@ -112,9 +144,18 @@ The deterministic UUID input is:
 
 For example, if the same PNG filename exists in both `original-diagrams` and `new-diagrams`, the generated UUIDs differ because the diagram folder is part of the UUID input.
 
-This differs from the catalog's likely original JavaScript generation approach, which appears to have generated UUIDv4 identifiers for new distribution metadata. This is not a compatibility problem because the URI pattern remains the same and UUIDs are treated as opaque identifiers. The compatibility rule is: preserve existing distribution URIs; use deterministic UUIDv5 only when creating metadata for PNG diagrams that do not already have a metadata file.
+This keeps new-file generation reproducible while preserving the catalog's established UUID-based distribution URI pattern.
 
-The UUIDv5 approach makes new-file generation reproducible while preserving the catalog's established UUID-based distribution URI pattern.
+## Model identifiers used in `dct:isPartOf`
+
+The script resolves the model URI for PNG distribution metadata in this order:
+
+1. the subject URI of an existing model-level `metadata.ttl`, when available;
+2. an existing `dct:isPartOf` value in any `metadata-png-*.ttl` file in the dataset folder, when `metadata.ttl` is absent;
+3. an explicit HTTP(S) model URI in `metadata.yaml`, if present;
+4. a deterministic UUIDv5 URI generated from the dataset folder name, using the same strategy as `scripts/metadata_yaml_to_ttl.py`.
+
+This prevents existing UUID-based model W3IDs such as `https://w3id.org/ontouml-models/model/<uuid>` from being replaced by folder-name IRIs such as `https://w3id.org/ontouml-models/model/<folder-name>` during PNG metadata regeneration. For new datasets where no model-level `metadata.ttl` exists yet, the deterministic UUIDv5 fallback keeps the PNG generator compatible with the later `metadata.yaml` to `metadata.ttl` conversion step.
 
 ## Download URLs
 
@@ -135,17 +176,7 @@ https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/<model-di
 
 Existing `dcat:downloadURL` values are preserved when regenerating existing metadata files.
 
-When generating new URLs, path segments are URL-quoted where needed, but commas are left unescaped to match the existing catalog style. For example, the script generates:
-
-```text
-lifts,-ski-slopes,-and-snowparks.png
-```
-
-not:
-
-```text
-lifts%2C-ski-slopes%2C-and-snowparks.png
-```
+When generating new URLs, path segments are URL-quoted where needed, but commas are left unescaped to match the existing catalog style.
 
 ## Optional file-derived metadata
 
@@ -160,7 +191,7 @@ PNG validation always checks the PNG signature, IHDR chunk, chunk boundaries, CR
 
 ## Requirements
 
-Install the automation dependencies:
+Install the script dependencies:
 
 ```bash
 python -m pip install -r scripts/requirements.txt
@@ -172,34 +203,55 @@ The PNG metadata generator requires `rdflib` and `PyYAML`. Tests require `pytest
 
 Run from the repository root.
 
+Commands that create new PNG metadata files, initialize missing `fdpo:metadataIssued`, or update `fdpo:metadataModified` require `--metadata-timestamp`. Use a fixed timestamp for deterministic automation runs. Use `--metadata-timestamp now` only for manual, intentionally non-deterministic execution.
+
 Generate metadata for one dataset folder:
 
 ```bash
-python scripts/generate_png_metadata.py models/<model-directory>
+python scripts/generate_png_metadata.py models/<model-directory> \
+  --metadata-timestamp 2024-01-02T03:04:05Z
 ```
 
 Generate metadata for multiple dataset folders:
 
 ```bash
-python scripts/generate_png_metadata.py models/<model-1> models/<model-2>
+python scripts/generate_png_metadata.py models/<model-1> models/<model-2> \
+  --metadata-timestamp 2024-01-02T03:04:05Z
 ```
 
 Generate metadata for all dataset folders under `models/`:
 
 ```bash
-python scripts/generate_png_metadata.py --all --models-dir models
+python scripts/generate_png_metadata.py --all --models-dir models \
+  --metadata-timestamp 2024-01-02T03:04:05Z
+```
+
+Generate all PNG metadata while allowing legacy datasets without license metadata:
+
+```bash
+python scripts/generate_png_metadata.py --all --models-dir models --allow-missing-license \
+  --metadata-timestamp 2024-01-02T03:04:05Z
 ```
 
 Preview generation without writing files:
 
 ```bash
-python scripts/generate_png_metadata.py models/<model-directory> --dry-run
+python scripts/generate_png_metadata.py models/<model-directory> --dry-run \
+  --metadata-timestamp 2024-01-02T03:04:05Z
+```
+
+Check whether files are up to date without writing them. The command exits with code `1` if any PNG metadata file would change:
+
+```bash
+python scripts/generate_png_metadata.py models/<model-directory> --check \
+  --metadata-timestamp 2024-01-02T03:04:05Z
 ```
 
 Fail when a generated file already exists. This check is atomic at dataset level: no metadata files are written if any target already exists:
 
 ```bash
-python scripts/generate_png_metadata.py models/<model-directory> --no-overwrite
+python scripts/generate_png_metadata.py models/<model-directory> --no-overwrite \
+  --metadata-timestamp 2024-01-02T03:04:05Z
 ```
 
 Use a different repository or branch in generated `dcat:downloadURL` values:
@@ -207,39 +259,39 @@ Use a different repository or branch in generated `dcat:downloadURL` values:
 ```bash
 python scripts/generate_png_metadata.py models/<model-directory> \
   --repository pedropaulofb/ontouml-models-dev \
-  --branch master
+  --branch master \
+  --metadata-timestamp 2024-01-02T03:04:05Z
 ```
 
 Use a different repository-relative models path in generated `dcat:downloadURL` values:
 
 ```bash
 python scripts/generate_png_metadata.py models/<model-directory> \
-  --models-dir-name models
+  --models-dir-name models \
+  --metadata-timestamp 2024-01-02T03:04:05Z
 ```
 
-Use a fixed timestamp for new metadata files, or for existing metadata files that do not already contain `fdpo:metadataIssued` or `fdpo:metadataModified`. The value must use an `xsd:dateTime` lexical form such as `2024-01-02T03:04:05Z`:
+Use a fixed timestamp for new metadata files, for existing metadata files that do not already contain `fdpo:metadataIssued`, or for existing metadata files that will change and therefore need an updated `fdpo:metadataModified`. The value must use an `xsd:dateTime` lexical form such as `2024-01-02T03:04:05Z`:
 
 ```bash
 python scripts/generate_png_metadata.py models/<model-directory> \
   --metadata-timestamp 2024-01-02T03:04:05Z
 ```
 
+Use `--metadata-timestamp now` only when a non-deterministic current execution timestamp is intentionally desired.
+
 Add optional file-derived metadata:
 
 ```bash
-python scripts/generate_png_metadata.py models/<model-directory> --include-file-metadata
-```
-
-Require model-level license metadata:
-
-```bash
-python scripts/generate_png_metadata.py models/<model-directory> --require-license
+python scripts/generate_png_metadata.py models/<model-directory> --include-file-metadata \
+  --metadata-timestamp 2024-01-02T03:04:05Z
 ```
 
 Run from inside a dataset folder that contains `metadata.yaml`:
 
 ```bash
-python ../../scripts/generate_png_metadata.py
+python ../../scripts/generate_png_metadata.py \
+  --metadata-timestamp 2024-01-02T03:04:05Z
 ```
 
 ## Command-line arguments
@@ -249,15 +301,19 @@ python ../../scripts/generate_png_metadata.py
 | `datasets` | No | current directory if it contains `metadata.yaml` | One or more model dataset folders to process. |
 | `--all` | No | off | Process all dataset folders below `--models-dir`. Cannot be combined with explicit dataset folders. |
 | `--models-dir PATH` | No | `models` | Models directory used with `--all`. |
+| `--allow-missing-license` | No | off | Allow legacy datasets without license metadata. Without it, license is mandatory. |
+| `--check` | No | off | Do not write files; exit `1` if any PNG metadata file would change. |
+| `--dry-run` | No | off | Validate inputs and report files that would be generated without writing them. |
+| `--format {text,json}` | No | `text` | Summary output format for non-interactive use. |
+| `--quiet`, `--silent`, `-q` | No | off | Suppress progress and text summary output. Errors still go to `stderr`. |
 | `--repository OWNER/REPO` | No | `OntoUML/ontouml-models` | GitHub repository used for generated `dcat:downloadURL` values. |
 | `--branch BRANCH` | No | `master` | Git branch used for generated `dcat:downloadURL` values. |
 | `--models-dir-name PATH` | No | `models` | Repository-relative models path used inside generated `dcat:downloadURL` values. |
+| `--model-iri-base IRI` | No | `https://w3id.org/ontouml-models/model` | Base IRI used for deterministic UUIDv5 model IRIs when no existing catalog model IRI is available. |
 | `--no-overwrite` | No | overwrite enabled | Fail if a target metadata file already exists. |
 | `--strict` | No | off | Fail if an expected diagram folder is missing or empty. |
-| `--dry-run` | No | off | Validate inputs and report files that would be generated without writing them. |
 | `--include-file-metadata` | No | off | Also add optional byte size, SHA-256 checksum, width, and height triples. |
-| `--metadata-timestamp VALUE` | No | current UTC timestamp | `xsd:dateTime` value used for `fdpo:metadataIssued` and `fdpo:metadataModified` on new files, or on existing files where those values are missing. |
-| `--require-license` | No | off | Fail if model-level `metadata.yaml` does not provide a usable license. By default, missing licenses are tolerated and `dct:license` is omitted unless an existing PNG metadata file already has one. |
+| `--metadata-timestamp VALUE` | Conditional | none | `xsd:dateTime` value used to initialize missing `fdpo:metadataIssued` values and update `fdpo:metadataModified` when existing metadata files change. Required when creating new metadata files, when existing metadata files lack `fdpo:metadataIssued`, or when existing files need regeneration changes. |
 
 ## Input assumptions
 
@@ -271,9 +327,9 @@ The model-level `metadata.yaml` must provide enough information for the script t
 
 - the model title;
 - the model issued date;
-- the model URI, or an identifier/slug from which the standard catalog model URI can be derived.
+- the model license, unless `--allow-missing-license` is used for a legacy dataset.
 
-A model-level license is recommended and is copied to generated PNG metadata when available. It is tolerated as missing by default so batch generation can still process catalog entries without model-level license metadata. Use `--require-license` to make a missing or unusable model-level license a fatal error.
+The model URI is preserved from existing catalog metadata when available. Otherwise, it is generated deterministically from the dataset folder name using the same UUIDv5 approach used by the model-level metadata converter.
 
 Each dataset must contain at least one PNG file in one of these folders:
 
@@ -286,20 +342,29 @@ In normal mode, a missing or empty `original-diagrams` or `new-diagrams` folder 
 
 Only direct PNG files inside these folders are processed. The `.png` extension is matched case-insensitively. Nested files are not scanned.
 
-## Error handling
+## Error handling and exit codes
 
-The script fails with a non-zero exit code for critical problems, including:
+The script uses these exit codes:
+
+| Exit code | Meaning |
+| --- | --- |
+| `0` | Generation completed successfully. In `--check` mode, no changes are needed. |
+| `1` | Generation failed for at least one dataset, or `--check` detected changes. |
+| `2` | Command-line parsing, target discovery, or setup prevented normal execution. |
+
+The script fails for critical problems, including:
 
 - missing dataset folder;
 - missing or unparsable `metadata.yaml`;
 - missing model title in `metadata.yaml`;
 - missing model issued date in `metadata.yaml`;
-- missing or unusable model license in `metadata.yaml`, only when `--require-license` is used;
+- missing or unusable model license in `metadata.yaml`, unless `--allow-missing-license` is used;
 - no PNG diagrams found;
 - unsupported PNG filenames with control characters;
 - unreadable, invalid, or truncated PNG files;
 - duplicate generated metadata paths;
 - duplicate generated distribution URIs;
+- missing `--metadata-timestamp` when `fdpo:metadataIssued` must be initialized or `fdpo:metadataModified` must be updated;
 - invalid `--metadata-timestamp` values;
 - malformed existing PNG metadata files;
 - existing target files when `--no-overwrite` is used.
@@ -307,18 +372,6 @@ The script fails with a non-zero exit code for critical problems, including:
 ## Atomicity
 
 For each processed dataset, the script completes input validation and builds all RDF graphs before writing any target file. This prevents partial generation when a later diagram is invalid, when `--strict` fails, when `--no-overwrite` detects an existing target, or when optional file-derived metadata cannot be computed.
-
-## Serialization notes
-
-RDFLib serializes Turtle using its own formatting. Regenerated files may therefore differ from older manually generated files in non-semantic ways, such as:
-
-- prefix order;
-- whitespace before `;` and `.`;
-- omission of unused prefixes;
-- predicate order;
-- compact boolean syntax, e.g., `ocmv:isComplete false`, which is Turtle shorthand for an `xsd:boolean` false literal.
-
-These are Turtle serialization differences and do not change the RDF graph.
 
 ## Terminal output
 
@@ -333,6 +386,15 @@ In dry-run mode, it prints:
 ```text
 would generate: <metadata-file> <- <png-file>
 ```
+
+In check mode, it prints either:
+
+```text
+needs update: <metadata-file> <- <png-file>
+up to date: <metadata-file> <- <png-file>
+```
+
+Use `--format json` for machine-readable output.
 
 ## Run tests
 

--- a/scripts/generate_png_metadata.py
+++ b/scripts/generate_png_metadata.py
@@ -10,48 +10,49 @@ Run from the repository root, for example:
 
     python scripts/generate_png_metadata.py models/amaral2019rot
     python scripts/generate_png_metadata.py --all --models-dir models
-
-The generated RDF follows the distribution metadata pattern already used in the
-catalog for JSON, Turtle, VPP, and PNG distributions:
-
-- the distribution is typed as dcat:Distribution;
-- the distribution points back to the model with dct:isPartOf;
-- model-level dct:issued is copied from metadata.yaml to the distribution;
-- model-level dct:license is copied from metadata.yaml when available;
-- the distribution receives dcat:mediaType, dcat:downloadURL, dct:title,
-  skos:editorialNote, ocmv:isComplete, fdpo:metadataIssued, and
-  fdpo:metadataModified.
+    python scripts/generate_png_metadata.py --all --models-dir models --allow-missing-license
 
 The model-level source of truth is metadata.yaml. Existing metadata-png-*.ttl
-files are read only to preserve stable distribution identifiers and curated
-PNG-level values during regeneration. The script does not read or update
-metadata.ttl.
-
-RDFLib is used for RDF graph creation and Turtle serialization. PyYAML is used
-for metadata.yaml parsing. PNG validation and dimension extraction are performed
-with the Python standard library so that no image-processing dependency is
-needed.
+files are read only to preserve stable distribution identifiers, existing model
+W3IDs used by dct:isPartOf, and curated PNG-level values during regeneration.
+The script does not update metadata.ttl; it only reads an existing metadata.ttl
+as a compatibility fallback when no existing PNG metadata file exposes the
+model W3ID.
 """
 
 from __future__ import annotations
 
 import argparse
+import difflib
 import hashlib
+import json
 import os
 import re
 import struct
 import sys
 import uuid
-from dataclasses import dataclass
-from datetime import datetime, timezone
+import zlib
+from dataclasses import asdict, dataclass
+from datetime import date, datetime, timezone
 from decimal import Decimal
 from pathlib import Path
-from typing import Any, List, Mapping, Optional, Sequence, Tuple
+from typing import Any, Iterable, Mapping, Optional, Sequence
 from urllib.parse import quote
 
-import yaml
-from rdflib import BNode, Graph, Literal, Namespace, URIRef
-from rdflib.namespace import DCTERMS as DCT, RDF, SKOS, XSD
+try:
+    import yaml
+except ImportError as exc:  # pragma: no cover - dependency failure only
+    raise SystemExit(
+        "PyYAML is required. Install it with: python -m pip install -r scripts/requirements.txt"
+    ) from exc
+
+try:
+    from rdflib import BNode, Graph, Literal, Namespace, URIRef
+    from rdflib.namespace import DCTERMS as DCT, RDF, SKOS, XSD
+except ImportError as exc:  # pragma: no cover - dependency failure only
+    raise SystemExit(
+        "RDFLib is required. Install it with: python -m pip install -r scripts/requirements.txt"
+    ) from exc
 
 DCAT = Namespace("http://www.w3.org/ns/dcat#")
 FDPO = Namespace("https://w3id.org/fdp/fdp-o#")
@@ -61,6 +62,10 @@ SCHEMA = Namespace("https://schema.org/")
 
 PNG_MEDIA_TYPE = URIRef("https://www.iana.org/assignments/media-types/image/png")
 DISTRIBUTION_BASE = "https://w3id.org/ontouml-models/distribution/"
+DEFAULT_REPOSITORY = "OntoUML/ontouml-models"
+DEFAULT_BRANCH = "master"
+DEFAULT_MODELS_DIR = "models"
+DEFAULT_MODEL_IRI_BASE = "https://w3id.org/ontouml-models/model"
 
 DIAGRAM_SOURCES = {
     "original-diagrams": "o",
@@ -77,10 +82,45 @@ EDITORIAL_NOTES = {
     "n": "This image depicts a version of the original diagram re-created in the Visual Paradigm editor.",
 }
 
+LICENSE_ALIASES = {
+    "ccby40": "https://creativecommons.org/licenses/by/4.0/",
+    "creativecommonsattribution40international": "https://creativecommons.org/licenses/by/4.0/",
+    "ccbysa40": "https://creativecommons.org/licenses/by-sa/4.0/",
+    "creativecommonsattributionsharealike40international": "https://creativecommons.org/licenses/by-sa/4.0/",
+    "ccbysa30": "https://creativecommons.org/licenses/by-sa/3.0/",
+    "creativecommonsattributionsharealike30unported": "https://creativecommons.org/licenses/by-sa/3.0/",
+    "cc010": "https://creativecommons.org/publicdomain/zero/1.0/",
+    "creativecommonszero10universaldomainpublicdedication": "https://creativecommons.org/publicdomain/zero/1.0/",
+    "mit": "http://spdx.org/licenses/MIT",
+}
+
 CONTROL_CHARS = re.compile(r"[\x00-\x1f\x7f]")
-XSD_DATETIME = re.compile(
+DATE_YEAR_RE = re.compile(r"^\d{4}$")
+DATE_YEAR_MONTH_RE = re.compile(r"^\d{4}-\d{2}$")
+DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+XSD_DATETIME_RE = re.compile(
     r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})?$"
 )
+HTTP_URI_RE = re.compile(r"^https?://", re.I)
+DISTRIBUTION_IRI_RE = re.compile(r"<([^>]+)>\s+a\s+[^.;]*\bdcat:Distribution\b", re.S)
+URI_RE = re.compile(r"<([^>]+)>")
+MODEL_IRI_RE = re.compile(
+    r"<(?P<iri>https://w3id\.org/ontouml-models/model/[^>]+/?)>\s+a\s+[^.;]*\bdcat:Dataset\b",
+    re.S,
+)
+IS_PART_OF_RE = re.compile(r"\bdct:isPartOf\s+<([^>]+)>", re.S)
+FULL_IS_PART_OF_RE = re.compile(
+    r"<http://purl\.org/dc/terms/isPartOf>\s+<([^>]+)>", re.S
+)
+PREFIXED_DATETIME_RE_TEMPLATE = r"\bfdpo:{name}\s+\"([^\"]+)\"\^\^xsd:dateTime"
+FULL_DATETIME_RE_TEMPLATE = (
+    r"<https://w3id\.org/fdp/fdp-o#{name}>\s+\"([^\"]+)\"\^\^"
+    r"<http://www\.w3\.org/2001/XMLSchema#dateTime>"
+)
+
+
+class MetadataSetupError(RuntimeError):
+    """Raised when command-line or discovery setup prevents execution."""
 
 
 class MetadataGenerationError(RuntimeError):
@@ -91,15 +131,21 @@ class MetadataGenerationError(RuntimeError):
 class Config:
     """Configuration for PNG metadata generation."""
 
-    repository: str = "OntoUML/ontouml-models"
-    branch: str = "master"
-    models_dir_name: str = "models"
+    repository: str = DEFAULT_REPOSITORY
+    branch: str = DEFAULT_BRANCH
+    models_dir_name: str = DEFAULT_MODELS_DIR
+    model_iri_base: str = DEFAULT_MODEL_IRI_BASE
     overwrite: bool = True
     strict: bool = False
     dry_run: bool = False
+    check: bool = False
     include_file_metadata: bool = False
     metadata_timestamp: Optional[str] = None
-    require_license: bool = False
+    allow_missing_license: bool = False
+    # Deprecated compatibility shim for older callers that used Config(require_license=True).
+    require_license: Optional[bool] = None
+    emit_diff: bool = False
+    quiet: bool = False
 
 
 @dataclass(frozen=True)
@@ -116,13 +162,14 @@ class ModelMetadata:
 class ExistingDistributionMetadata:
     """Reusable metadata found in an existing distribution metadata file."""
 
-    uri: Optional[URIRef]
-    title: Optional[Literal]
-    editorial_note: Optional[Literal]
-    download_url: Optional[URIRef]
-    license_uri: Optional[URIRef]
-    metadata_issued: Optional[Literal]
-    metadata_modified: Optional[Literal]
+    uri: Optional[URIRef] = None
+    model_uri: Optional[URIRef] = None
+    title: Optional[Literal] = None
+    editorial_note: Optional[Literal] = None
+    download_url: Optional[URIRef] = None
+    license_uri: Optional[URIRef] = None
+    metadata_issued: Optional[Literal] = None
+    metadata_modified: Optional[Literal] = None
 
 
 @dataclass(frozen=True)
@@ -141,11 +188,59 @@ class DiagramFile:
 
 @dataclass(frozen=True)
 class GeneratedFile:
-    """Result of generating one metadata file."""
+    """Result of generating or checking one metadata file."""
 
     diagram_path: Path
     metadata_path: Path
     distribution_uri: URIRef
+    changed: bool
+    written: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        data["diagram_path"] = str(self.diagram_path)
+        data["metadata_path"] = str(self.metadata_path)
+        data["distribution_uri"] = str(self.distribution_uri)
+        return data
+
+
+class MetadataYamlLoader(yaml.SafeLoader):
+    """Safe YAML loader preserving date-like scalar lexical forms."""
+
+
+MetadataYamlLoader.yaml_implicit_resolvers = {
+    key: [
+        resolver
+        for resolver in resolvers
+        if resolver[0] != "tag:yaml.org,2002:timestamp"
+    ]
+    for key, resolvers in yaml.SafeLoader.yaml_implicit_resolvers.items()
+}
+
+
+def _construct_mapping_no_duplicates(
+    loader: MetadataYamlLoader, node: yaml.MappingNode, deep: bool = False
+) -> dict[Any, Any]:
+    """Construct YAML mappings while rejecting duplicate keys."""
+
+    mapping: dict[Any, Any] = {}
+    for key_node, value_node in node.value:
+        key = loader.construct_object(key_node, deep=deep)
+        if key in mapping:
+            raise yaml.constructor.ConstructorError(
+                "while constructing a mapping",
+                node.start_mark,
+                f"found duplicate key {key!r}",
+                key_node.start_mark,
+            )
+        mapping[key] = loader.construct_object(value_node, deep=deep)
+    return mapping
+
+
+MetadataYamlLoader.add_constructor(
+    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+    _construct_mapping_no_duplicates,
+)
 
 
 def bind_prefixes(graph: Graph) -> None:
@@ -161,136 +256,42 @@ def bind_prefixes(graph: Graph) -> None:
     graph.bind("schema", SCHEMA)
 
 
-def validate_dataset_folder(dataset_folder: Path) -> Path:
-    """Return a normalized dataset folder path or raise a clear error."""
+def effective_allow_missing_license(config: Config) -> bool:
+    """Return the active missing-license policy."""
+
+    if config.require_license is True:
+        return False
+    return config.allow_missing_license
+
+
+def validate_dataset_folder(
+    dataset_folder: Path, *, require_metadata_yaml: bool = True
+) -> Path:
+    """Return a normalized dataset folder path or raise a setup error."""
 
     dataset_folder = dataset_folder.resolve()
     if not dataset_folder.exists():
-        raise MetadataGenerationError(
-            f"Dataset folder does not exist: {dataset_folder}"
-        )
+        raise MetadataSetupError(f"Dataset folder does not exist: {dataset_folder}")
     if not dataset_folder.is_dir():
-        raise MetadataGenerationError(
-            f"Dataset path is not a directory: {dataset_folder}"
+        raise MetadataSetupError(f"Dataset path is not a directory: {dataset_folder}")
+    if require_metadata_yaml and not (dataset_folder / "metadata.yaml").exists():
+        raise MetadataSetupError(
+            f"Missing metadata.yaml in dataset folder: {dataset_folder}"
         )
     return dataset_folder
 
 
 def normalize_model_uri(uri: URIRef) -> URIRef:
-    """Normalize model URIs for distribution metadata.
-
-    Some catalog metadata files contain the model subject with a trailing slash,
-    while existing distribution metadata files use dct:isPartOf with the same URI
-    without that trailing slash. Distribution files generated here follow the
-    existing distribution-file convention.
-    """
+    """Normalize model URIs for distribution metadata."""
 
     return URIRef(str(uri).rstrip("/"))
-
-
-def load_model_metadata(dataset_folder: Path, config: Config) -> ModelMetadata:
-    """Load model URI, title, issued date, and optional license from metadata.yaml."""
-
-    metadata_path = dataset_folder / "metadata.yaml"
-    if not metadata_path.exists():
-        raise MetadataGenerationError(
-            f"Missing required canonical metadata file: {metadata_path}"
-        )
-
-    data = load_yaml_mapping(metadata_path)
-
-    title_value = yaml_first_value(
-        data,
-        paths=(
-            ("title",),
-            ("model", "title"),
-            ("metadata", "title"),
-            ("resource", "title"),
-            ("ontology", "title"),
-            ("name",),
-        ),
-        recursive_keys=("title", "name"),
-    )
-    title = yaml_text(title_value)
-    if not title:
-        raise MetadataGenerationError(f"Missing required title in {metadata_path}")
-
-    issued_value = yaml_first_value(
-        data,
-        paths=(
-            ("issued",),
-            ("dateIssued",),
-            ("issuedDate",),
-            ("issued_date",),
-            ("date",),
-            ("metadata", "issued"),
-            ("metadata", "dateIssued"),
-            ("metadata", "date"),
-            ("model", "issued"),
-            ("model", "dateIssued"),
-            ("resource", "issued"),
-            ("resource", "dateIssued"),
-            ("publication", "issued"),
-            ("publication", "date"),
-            ("publicationDate",),
-        ),
-        recursive_keys=("issued", "dateIssued", "issuedDate", "publicationDate"),
-    )
-    issued_literal = yaml_issued_literal(issued_value)
-    if issued_literal is None:
-        raise MetadataGenerationError(
-            f"Missing required issued date in {metadata_path}"
-        )
-
-    uri_value = yaml_first_value(
-        data,
-        paths=(
-            ("uri",),
-            ("modelUri",),
-            ("model", "uri"),
-            ("model", "id"),
-            ("metadata", "uri"),
-            ("resource", "uri"),
-            ("id",),
-        ),
-        recursive_keys=("modelUri", "uri"),
-    )
-    model_uri = yaml_model_uri(uri_value, dataset_folder.name)
-
-    license_value = yaml_first_value(
-        data,
-        paths=(
-            ("license",),
-            ("licenseUrl",),
-            ("licenseUri",),
-            ("metadata", "license"),
-            ("metadata", "licenseUrl"),
-            ("metadata", "licenseUri"),
-            ("model", "license"),
-            ("resource", "license"),
-            ("rights", "license"),
-            ("rights", "licenseUrl"),
-            ("rights", "licenseUri"),
-        ),
-        recursive_keys=("license", "licenseUrl", "licenseUri"),
-    )
-    license_ref = yaml_license_uri(license_value)
-    if license_ref is None and config.require_license:
-        raise MetadataGenerationError(f"Missing required license in {metadata_path}")
-
-    return ModelMetadata(
-        uri=model_uri,
-        title=title,
-        license_uri=license_ref,
-        issued=issued_literal,
-    )
 
 
 def load_yaml_mapping(path: Path) -> Mapping[str, Any]:
     """Load a YAML file and ensure its root node is a mapping."""
 
     try:
-        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+        data = yaml.load(path.read_text(encoding="utf-8"), Loader=MetadataYamlLoader)
     except yaml.YAMLError as exc:
         raise MetadataGenerationError(f"Could not parse {path}: {exc}") from exc
     except OSError as exc:
@@ -305,25 +306,23 @@ def load_yaml_mapping(path: Path) -> Mapping[str, Any]:
     return data
 
 
-def canonical_yaml_key(value: object) -> str:
-    """Return a normalized key for permissive YAML field matching."""
+def canonical_key(value: object) -> str:
+    """Return a normalized key or identifier for permissive matching."""
 
     return re.sub(r"[^a-z0-9]", "", str(value).lower())
 
 
 def yaml_mapping_get(mapping: Mapping[str, Any], key: str) -> Any:
-    """Return a mapping value using case-insensitive, punctuation-insensitive key matching."""
+    """Return a mapping value using case-insensitive key matching."""
 
-    wanted = canonical_yaml_key(key)
+    wanted = canonical_key(key)
     for candidate, value in mapping.items():
-        if canonical_yaml_key(candidate) == wanted:
+        if canonical_key(candidate) == wanted:
             return value
     return None
 
 
 def yaml_value_at_path(data: Any, path: Sequence[str]) -> Any:
-    """Return a YAML value by a normalized key path, or None when absent."""
-
     current = data
     for key in path:
         if not isinstance(current, Mapping):
@@ -334,40 +333,11 @@ def yaml_value_at_path(data: Any, path: Sequence[str]) -> Any:
     return current
 
 
-def yaml_recursive_find(data: Any, keys: Sequence[str]) -> Any:
-    """Return the first scalar-like value found recursively for one of the given keys."""
-
-    wanted = {canonical_yaml_key(key) for key in keys}
-    if isinstance(data, Mapping):
-        for key, value in data.items():
-            if canonical_yaml_key(key) in wanted and value is not None:
-                return value
-        for value in data.values():
-            found = yaml_recursive_find(value, keys)
-            if found is not None:
-                return found
-    elif isinstance(data, list):
-        for value in data:
-            found = yaml_recursive_find(value, keys)
-            if found is not None:
-                return found
-    return None
-
-
-def yaml_first_value(
-    data: Mapping[str, Any],
-    *,
-    paths: Sequence[Sequence[str]],
-    recursive_keys: Sequence[str] = (),
-) -> Any:
-    """Return the first matching value from explicit paths, then from recursive key search."""
-
+def yaml_first_value(data: Mapping[str, Any], paths: Sequence[Sequence[str]]) -> Any:
     for path in paths:
         value = yaml_value_at_path(data, path)
         if value is not None:
             return value
-    if recursive_keys:
-        return yaml_recursive_find(data, recursive_keys)
     return None
 
 
@@ -378,8 +348,7 @@ def yaml_text(value: Any) -> Optional[str]:
         return None
     if isinstance(value, Mapping):
         for key in ("en", "eng", "english", "value", "label", "title", "name"):
-            nested = yaml_mapping_get(value, key)
-            text = yaml_text(nested)
+            text = yaml_text(yaml_mapping_get(value, key))
             if text:
                 return text
         for nested in value.values():
@@ -398,223 +367,455 @@ def yaml_text(value: Any) -> Optional[str]:
 
 
 def yaml_issued_literal(value: Any) -> Optional[Literal]:
-    """Convert a YAML issued-date value to the RDF literal used for dct:issued."""
+    """Return an RDF literal for a model issued value."""
 
-    text = yaml_text(value)
-    if not text:
+    if value is None:
         return None
-    if re.fullmatch(r"\d{4}", text):
-        return Literal(text, datatype=XSD.gYear)
-    if re.fullmatch(r"\d{4}-\d{2}-\d{2}", text):
-        return Literal(text, datatype=XSD.date)
-    if XSD_DATETIME.match(text):
+    if isinstance(value, datetime):
+        text = value.isoformat()
         return Literal(text, datatype=XSD.dateTime, normalize=False)
-    return Literal(text)
-
-
-def yaml_model_uri(value: Any, dataset_slug: str) -> URIRef:
-    """Return the model URI from YAML, falling back to the dataset folder name."""
+    if isinstance(value, date):
+        return Literal(value.isoformat(), datatype=XSD.date, normalize=False)
 
     text = yaml_text(value)
-    if text and re.match(r"https?://", text):
-        return normalize_model_uri(URIRef(text))
-    if text and "/ontouml-models/model/" in text:
-        return normalize_model_uri(URIRef(text))
-
-    # If the canonical YAML does not expose the full IRI, the catalog folder name
-    # is the stable model slug used in the standard model URI pattern.
-    slug = text or dataset_slug
-    slug = str(slug).strip().strip("/")
-    if not slug:
-        slug = dataset_slug
-    return normalize_model_uri(URIRef(f"https://w3id.org/ontouml-models/model/{slug}/"))
-
-
-def yaml_license_uri(value: Any) -> Optional[URIRef]:
-    """Extract a license URI from common YAML license forms."""
-
-    text = yaml_license_text(value)
     if not text:
         return None
-    text = text.strip()
-    if re.match(r"https?://", text):
-        return URIRef(text)
-
-    licenses = {
-        "ccby40": "https://creativecommons.org/licenses/by/4.0/",
-        "creativecommonsattribution40international": "https://creativecommons.org/licenses/by/4.0/",
-        "ccbysa40": "https://creativecommons.org/licenses/by-sa/4.0/",
-        "creativecommonsattributionsharealike40international": "https://creativecommons.org/licenses/by-sa/4.0/",
-        "ccbysa30": "https://creativecommons.org/licenses/by-sa/3.0/",
-        "creativecommonsattributionsharealike30unported": "https://creativecommons.org/licenses/by-sa/3.0/",
-        "cc010": "https://creativecommons.org/publicdomain/zero/1.0/",
-        "creativecommonszero10universaldomainpublicdedication": "https://creativecommons.org/publicdomain/zero/1.0/",
-        "mit": "http://spdx.org/licenses/MIT",
-    }
-    return (
-        URIRef(licenses[canonical_yaml_key(text)])
-        if canonical_yaml_key(text) in licenses
-        else None
+    if DATE_YEAR_RE.match(text):
+        return Literal(text, datatype=XSD.gYear, normalize=False)
+    if DATE_YEAR_MONTH_RE.match(text):
+        return Literal(text, datatype=XSD.gYearMonth, normalize=False)
+    if DATE_RE.match(text):
+        return Literal(text, datatype=XSD.date, normalize=False)
+    if XSD_DATETIME_RE.match(text):
+        return Literal(text, datatype=XSD.dateTime, normalize=False)
+    raise MetadataGenerationError(
+        f"Unsupported issued date value {text!r}; expected YYYY, YYYY-MM, YYYY-MM-DD, or xsd:dateTime."
     )
 
 
-def yaml_license_text(value: Any) -> Optional[str]:
-    """Extract a license string, preferring URI/URL fields over labels."""
+def uri_from_text(value: str, *, field_name: str) -> URIRef:
+    text = value.strip()
+    if not HTTP_URI_RE.match(text):
+        raise MetadataGenerationError(
+            f"Field '{field_name}' must be an HTTP(S) URI; got {text!r}."
+        )
+    return URIRef(text)
+
+
+def deterministic_model_uri(dataset_folder: Path, model_iri_base: str) -> URIRef:
+    """Return the converter-compatible deterministic model URI for a new dataset."""
+
+    slug = dataset_folder.name.strip().strip("/")
+    if not slug:
+        raise MetadataGenerationError(
+            "Could not infer model URI because the dataset folder has no name."
+        )
+    base = model_iri_base.rstrip("/")
+    generated_uuid = uuid.uuid5(uuid.NAMESPACE_URL, f"{base}|{slug}")
+    return URIRef(f"{base}/{generated_uuid}")
+
+
+def yaml_model_uri(value: Any, dataset_folder: Path, model_iri_base: str) -> URIRef:
+    """Return an explicit YAML model URI or the converter-compatible deterministic URI."""
+
+    text = yaml_text(value)
+    if text and HTTP_URI_RE.match(text):
+        return normalize_model_uri(URIRef(text))
+    return deterministic_model_uri(dataset_folder, model_iri_base)
+
+
+def yaml_license_uri(value: Any) -> Optional[URIRef]:
+    """Return a license URI from common scalar or mapping forms."""
 
     if value is None:
         return None
     if isinstance(value, Mapping):
-        for key in (
-            "uri",
-            "url",
-            "licenseUri",
-            "licenseUrl",
-            "id",
-            "identifier",
-            "spdx",
-            "value",
-        ):
-            text = yaml_license_text(yaml_mapping_get(value, key))
-            if text:
-                return text
-        for nested in value.values():
-            text = yaml_license_text(nested)
-            if text:
-                return text
+        for key in ("uri", "url", "id", "identifier", "license", "value"):
+            result = yaml_license_uri(yaml_mapping_get(value, key))
+            if result is not None:
+                return result
         return None
     if isinstance(value, list):
         for item in value:
-            text = yaml_license_text(item)
-            if text:
-                return text
+            result = yaml_license_uri(item)
+            if result is not None:
+                return result
         return None
+
     text = str(value).strip()
-    return text or None
+    if not text:
+        return None
+    if HTTP_URI_RE.match(text):
+        return URIRef(text)
+    alias = LICENSE_ALIASES.get(canonical_key(text))
+    if alias:
+        return URIRef(alias)
+    raise MetadataGenerationError(
+        f"Unsupported license value {text!r}; use a license URI or a supported alias such as CC-BY-4.0."
+    )
 
 
-def first_literal(
-    graph: Graph, subject: URIRef, predicate: URIRef
-) -> Optional[Literal]:
-    """Return the first literal object for subject/predicate, if present."""
+def load_model_metadata(dataset_folder: Path, config: Config) -> ModelMetadata:
+    """Load model URI, title, issued date, and optional license from metadata.yaml."""
 
-    for value in graph.objects(subject, predicate):
-        if isinstance(value, Literal):
-            return value
-    return None
-
-
-def first_uri(graph: Graph, subject: URIRef, predicate: URIRef) -> Optional[URIRef]:
-    """Return the first URIRef object for subject/predicate, if present."""
-
-    for value in graph.objects(subject, predicate):
-        if isinstance(value, URIRef):
-            return value
-    return None
-
-
-def validate_png_name(path: Path) -> str:
-    """Validate a PNG filename and return the stem used in metadata names."""
-
-    if path.suffix.lower() != ".png":
+    metadata_path = dataset_folder / "metadata.yaml"
+    if not metadata_path.exists():
         raise MetadataGenerationError(
-            f"Unsupported diagram file extension; expected .png: {path}"
+            f"Missing required canonical metadata file: {metadata_path}"
         )
 
-    name = path.name
-    stem = path.stem
-    if not stem:
-        raise MetadataGenerationError(
-            f"Unsupported PNG filename with empty stem: {path}"
+    data = load_yaml_mapping(metadata_path)
+    title = yaml_text(
+        yaml_first_value(
+            data,
+            (
+                ("title",),
+                ("model", "title"),
+                ("metadata", "title"),
+                ("resource", "title"),
+                ("ontology", "title"),
+                ("name",),
+            ),
         )
-    if CONTROL_CHARS.search(name):
-        raise MetadataGenerationError(
-            f"Unsupported PNG filename with control characters: {path}"
+    )
+    if not title:
+        raise MetadataGenerationError(f"Missing required title in {metadata_path}")
+
+    issued_literal = yaml_issued_literal(
+        yaml_first_value(
+            data,
+            (
+                ("issued",),
+                ("dateIssued",),
+                ("issuedDate",),
+                ("issued_date",),
+                ("date",),
+                ("metadata", "issued"),
+                ("metadata", "dateIssued"),
+                ("metadata", "date"),
+                ("model", "issued"),
+                ("model", "dateIssued"),
+                ("resource", "issued"),
+                ("resource", "dateIssued"),
+                ("publication", "issued"),
+                ("publication", "date"),
+                ("publicationDate",),
+            ),
         )
-    if name in {".", ".."} or stem in {".", ".."}:
-        raise MetadataGenerationError(f"Unsupported PNG filename: {path}")
-    return stem
+    )
+    if issued_literal is None:
+        raise MetadataGenerationError(
+            f"Missing required issued date in {metadata_path}"
+        )
+
+    model_uri = yaml_model_uri(
+        yaml_first_value(
+            data,
+            (
+                ("uri",),
+                ("modelUri",),
+                ("model", "uri"),
+                ("metadata", "uri"),
+                ("resource", "uri"),
+            ),
+        ),
+        dataset_folder,
+        config.model_iri_base,
+    )
+
+    license_ref = yaml_license_uri(
+        yaml_first_value(
+            data,
+            (
+                ("license",),
+                ("licenseUrl",),
+                ("licenseUri",),
+                ("metadata", "license"),
+                ("metadata", "licenseUrl"),
+                ("metadata", "licenseUri"),
+                ("model", "license"),
+                ("resource", "license"),
+                ("rights", "license"),
+                ("rights", "licenseUrl"),
+                ("rights", "licenseUri"),
+            ),
+        )
+    )
+    if license_ref is None and not effective_allow_missing_license(config):
+        raise MetadataGenerationError(
+            "Missing mandatory metadata field(s): license. "
+            "Use --allow-missing-license only for legacy datasets that intentionally lack license metadata."
+        )
+
+    return ModelMetadata(
+        uri=model_uri,
+        title=title,
+        license_uri=license_ref,
+        issued=issued_literal,
+    )
 
 
-def read_png_dimensions(path: Path) -> Tuple[int, int]:
-    """Return PNG width and height after validating PNG chunk structure.
+def is_part_of_uri_from_text(text: str) -> Optional[URIRef]:
+    """Extract a distribution dct:isPartOf URI from Turtle text without full parsing."""
 
-    The validator checks the PNG signature, IHDR chunk, chunk boundaries, chunk
-    CRC values, and the presence of the terminal IEND chunk. It does not decode
-    the compressed image payload; the goal is to reject unreadable or truncated
-    files without adding an image-processing dependency.
+    match = IS_PART_OF_RE.search(text) or FULL_IS_PART_OF_RE.search(text)
+    return normalize_model_uri(URIRef(match.group(1))) if match else None
+
+
+def model_uri_from_metadata_ttl(path: Path) -> Optional[URIRef]:
+    """Extract the model dataset URI from an existing model-level metadata.ttl file."""
+
+    if not path.exists():
+        return None
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise MetadataGenerationError(
+            f"Could not read existing metadata.ttl {path}: {exc}"
+        ) from exc
+    match = MODEL_IRI_RE.search(text)
+    return normalize_model_uri(URIRef(match.group("iri"))) if match else None
+
+
+def unique_existing_model_uri(
+    uris: Iterable[URIRef], source_description: str
+) -> Optional[URIRef]:
+    """Return one existing model URI or fail on conflicting preserved values."""
+
+    normalized = sorted(
+        {str(normalize_model_uri(uri)) for uri in uris if uri is not None}
+    )
+    if not normalized:
+        return None
+    if len(normalized) > 1:
+        raise MetadataGenerationError(
+            f"Conflicting model URIs found in {source_description}: "
+            + ", ".join(normalized)
+        )
+    return URIRef(normalized[0])
+
+
+def discover_existing_png_model_uri(dataset_folder: Path) -> Optional[URIRef]:
+    """Discover the preserved model URI from existing PNG metadata files, if any."""
+
+    model_uris: list[URIRef] = []
+    for path in sorted(dataset_folder.glob("metadata-png-*.ttl")):
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            raise MetadataGenerationError(
+                f"Could not read existing PNG metadata {path}: {exc}"
+            ) from exc
+        uri = is_part_of_uri_from_text(text)
+        if uri is not None:
+            model_uris.append(uri)
+    return unique_existing_model_uri(
+        model_uris, f"existing PNG metadata files in {dataset_folder}"
+    )
+
+
+def resolve_model_uri(dataset_folder: Path, yaml_uri: URIRef) -> URIRef:
+    """Return the model URI to use in PNG distribution metadata.
+
+    Existing catalog datasets historically use UUID-based model W3IDs. Because
+    metadata.yaml does not contain those identifiers, preserve them from existing
+    metadata.ttl when available. This also repairs accidental slug-based
+    dct:isPartOf values produced by earlier regeneration attempts. If metadata.ttl
+    is absent, preserve the URI from existing PNG distribution metadata when
+    possible. If neither exists, use the same deterministic UUIDv5 model URI
+    strategy as metadata_yaml_to_ttl.py for new datasets.
     """
 
-    signature = b"\x89PNG\r\n\x1a\n"
+    existing_model_ttl_uri = model_uri_from_metadata_ttl(
+        dataset_folder / "metadata.ttl"
+    )
+    if existing_model_ttl_uri is not None:
+        return existing_model_ttl_uri
+    existing_png_uri = discover_existing_png_model_uri(dataset_folder)
+    if existing_png_uri is not None:
+        return existing_png_uri
+    return yaml_uri
+
+
+def prefixed_datetime_literal_from_text(text: str, name: str) -> Optional[Literal]:
+    """Preserve exact xsd:dateTime lexical forms from existing Turtle text."""
+
+    patterns = (
+        PREFIXED_DATETIME_RE_TEMPLATE.format(name=name),
+        FULL_DATETIME_RE_TEMPLATE.format(name=name),
+    )
+    for pattern in patterns:
+        match = re.search(pattern, text, re.S)
+        if match:
+            return Literal(match.group(1), datatype=XSD.dateTime, normalize=False)
+    return None
+
+
+def first_object(graph: Graph, subject: URIRef, predicate: URIRef) -> Any:
+    for obj in graph.objects(subject, predicate):
+        return obj
+    return None
+
+
+def read_existing_metadata(path: Path) -> ExistingDistributionMetadata:
+    """Read reusable values from an existing PNG distribution metadata file."""
+
+    if not path.exists():
+        return ExistingDistributionMetadata()
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise MetadataGenerationError(
+            f"Could not read existing metadata file {path}: {exc}"
+        ) from exc
+
+    graph = Graph()
+    bind_prefixes(graph)
+    try:
+        graph.parse(data=text, format="turtle")
+    except Exception as exc:  # noqa: BLE001 - surface RDFLib parse errors clearly
+        raise MetadataGenerationError(
+            f"Could not parse existing PNG metadata {path}: {exc}"
+        ) from exc
+
+    subjects = list(graph.subjects(RDF.type, DCAT.Distribution))
+    if subjects:
+        subject = subjects[0]
+    else:
+        match = DISTRIBUTION_IRI_RE.search(text)
+        subject = URIRef(match.group(1)) if match else None
+
+    if subject is None:
+        raise MetadataGenerationError(
+            f"Existing PNG metadata has no dcat:Distribution subject: {path}"
+        )
+
+    download_url = first_object(graph, subject, DCAT.downloadURL)
+    license_uri = first_object(graph, subject, DCT.license)
+    model_uri = first_object(graph, subject, DCT.isPartOf) or is_part_of_uri_from_text(
+        text
+    )
+    return ExistingDistributionMetadata(
+        uri=URIRef(subject),
+        model_uri=normalize_model_uri(URIRef(model_uri))
+        if model_uri is not None
+        else None,
+        title=first_object(graph, subject, DCT.title),
+        editorial_note=first_object(graph, subject, SKOS.editorialNote),
+        download_url=URIRef(download_url) if download_url is not None else None,
+        license_uri=URIRef(license_uri) if license_uri is not None else None,
+        metadata_issued=prefixed_datetime_literal_from_text(text, "metadataIssued")
+        or first_object(graph, subject, FDPO.metadataIssued),
+        metadata_modified=prefixed_datetime_literal_from_text(text, "metadataModified")
+        or first_object(graph, subject, FDPO.metadataModified),
+    )
+
+
+def deterministic_distribution_uri(
+    model: ModelMetadata, source_dir: str, filename: str
+) -> URIRef:
+    """Return a deterministic distribution URI for a new PNG metadata file."""
+
+    seed = f"{model.uri}|{source_dir}/{filename}"
+    return URIRef(f"{DISTRIBUTION_BASE}{uuid.uuid5(uuid.NAMESPACE_URL, seed)}/")
+
+
+def quote_path_segment(segment: str) -> str:
+    """Quote a URL path segment while preserving commas for catalog compatibility."""
+
+    return quote(segment, safe=",-_.~()")
+
+
+def split_path_like(value: str) -> list[str]:
+    """Split a slash-separated path-like CLI value into non-empty segments."""
+
+    return [segment for segment in value.strip("/").split("/") if segment]
+
+
+def default_download_url(
+    dataset_folder: Path, source_dir: str, filename: str, config: Config
+) -> URIRef:
+    """Return the raw GitHub download URL for a PNG diagram."""
+
+    parts = (
+        ["https://raw.githubusercontent.com"]
+        + [quote_path_segment(part) for part in split_path_like(config.repository)]
+        + [quote_path_segment(config.branch.strip("/"))]
+        + [quote_path_segment(part) for part in split_path_like(config.models_dir_name)]
+        + [
+            quote_path_segment(dataset_folder.name),
+            quote_path_segment(source_dir),
+            quote_path_segment(filename),
+        ]
+    )
+    return URIRef("/".join(parts))
+
+
+def validate_png(path: Path) -> tuple[int, int]:
+    """Validate a PNG file and return its width and height."""
 
     try:
-        with path.open("rb") as stream:
-            if stream.read(8) != signature:
-                raise MetadataGenerationError(f"Unreadable or invalid PNG file: {path}")
-
-            chunk_type, chunk_data = read_png_chunk(stream, path)
-            if chunk_type != b"IHDR" or len(chunk_data) != 13:
-                raise MetadataGenerationError(
-                    f"PNG file does not contain a valid IHDR chunk: {path}"
-                )
-
-            width, height = struct.unpack(">II", chunk_data[:8])
-            if width <= 0 or height <= 0:
-                raise MetadataGenerationError(
-                    f"PNG file has invalid dimensions {width}x{height}: {path}"
-                )
-
-            while True:
-                chunk_type, _chunk_data = read_png_chunk(stream, path)
-                if chunk_type == b"IEND":
-                    break
-
+        data = path.read_bytes()
     except OSError as exc:
         raise MetadataGenerationError(f"Could not read PNG file {path}: {exc}") from exc
 
+    signature = b"\x89PNG\r\n\x1a\n"
+    if not data.startswith(signature):
+        raise MetadataGenerationError(f"File is not a valid PNG image: {path}")
+
+    offset = len(signature)
+    width: Optional[int] = None
+    height: Optional[int] = None
+    seen_ihdr = False
+    seen_iend = False
+
+    while offset < len(data):
+        if offset + 8 > len(data):
+            raise MetadataGenerationError(
+                f"File has a truncated PNG chunk header: {path}"
+            )
+        length = struct.unpack(">I", data[offset : offset + 4])[0]
+        chunk_type = data[offset + 4 : offset + 8]
+        offset += 8
+        if offset + length + 4 > len(data):
+            raise MetadataGenerationError(f"File has a truncated PNG chunk: {path}")
+        chunk_data = data[offset : offset + length]
+        crc_bytes = data[offset + length : offset + length + 4]
+        actual_crc = struct.unpack(">I", crc_bytes)[0]
+        expected_crc = zlib.crc32(chunk_type + chunk_data) & 0xFFFFFFFF
+        if actual_crc != expected_crc:
+            raise MetadataGenerationError(f"File has an invalid PNG CRC: {path}")
+        offset += length + 4
+
+        if chunk_type == b"IHDR":
+            if seen_ihdr:
+                raise MetadataGenerationError(
+                    f"File has more than one PNG IHDR chunk: {path}"
+                )
+            if length != 13:
+                raise MetadataGenerationError(
+                    f"File has an invalid PNG IHDR chunk: {path}"
+                )
+            width, height = struct.unpack(">II", chunk_data[:8])
+            if width <= 0 or height <= 0:
+                raise MetadataGenerationError(
+                    f"File has invalid PNG dimensions: {path}"
+                )
+            seen_ihdr = True
+        elif not seen_ihdr:
+            raise MetadataGenerationError(f"File has no leading PNG IHDR chunk: {path}")
+        elif chunk_type == b"IEND":
+            seen_iend = True
+            break
+
+    if not seen_ihdr or width is None or height is None:
+        raise MetadataGenerationError(f"File has no PNG IHDR chunk: {path}")
+    if not seen_iend:
+        raise MetadataGenerationError(f"File has no PNG IEND chunk: {path}")
     return width, height
 
 
-def read_png_chunk(stream, path: Path) -> Tuple[bytes, bytes]:
-    """Read one PNG chunk and validate its CRC."""
-
-    length_bytes = stream.read(4)
-    if len(length_bytes) != 4:
-        raise MetadataGenerationError(f"Unreadable or truncated PNG file: {path}")
-
-    length = struct.unpack(">I", length_bytes)[0]
-    chunk_type = stream.read(4)
-    if len(chunk_type) != 4:
-        raise MetadataGenerationError(
-            f"Unreadable or truncated PNG chunk header: {path}"
-        )
-
-    chunk_data = stream.read(length)
-    if len(chunk_data) != length:
-        raise MetadataGenerationError(f"Unreadable or truncated PNG chunk data: {path}")
-
-    crc_bytes = stream.read(4)
-    if len(crc_bytes) != 4:
-        raise MetadataGenerationError(f"Unreadable or truncated PNG chunk CRC: {path}")
-
-    stored_crc = struct.unpack(">I", crc_bytes)[0]
-    computed_crc = crc32(chunk_type + chunk_data)
-    if stored_crc != computed_crc:
-        raise MetadataGenerationError(f"Invalid PNG chunk CRC in {path}")
-
-    return chunk_type, chunk_data
-
-
-def crc32(data: bytes) -> int:
-    """Return an unsigned PNG CRC-32 value."""
-
-    import zlib
-
-    return zlib.crc32(data) & 0xFFFFFFFF
-
-
 def sha256_hex(path: Path) -> str:
-    """Compute a SHA-256 checksum for a file."""
-
     digest = hashlib.sha256()
     with path.open("rb") as stream:
         for chunk in iter(lambda: stream.read(1024 * 1024), b""):
@@ -622,232 +823,78 @@ def sha256_hex(path: Path) -> str:
     return digest.hexdigest()
 
 
-def quoted_path(*segments: str) -> str:
-    """Quote URL path segments while preserving path separators.
-
-    Commas are left unescaped because they are valid path characters and existing
-    catalog raw GitHub URLs use them unescaped in diagram filenames.
-    """
-
-    return "/".join(quote(segment, safe=",") for segment in segments)
-
-
-def split_repository_path(path: str) -> List[str]:
-    """Split a repository-relative path option into URL path segments."""
-
-    return [segment for segment in path.replace("\\", "/").split("/") if segment]
-
-
-def new_distribution_uri(model_uri: URIRef, source_dir: str, filename: str) -> URIRef:
-    """Create a deterministic distribution URI for a PNG diagram.
-
-    Existing catalog distribution URIs use UUIDs under
-    https://w3id.org/ontouml-models/distribution/. For new PNG metadata files,
-    a UUIDv5 value makes generation reproducible. If a target metadata file
-    already exists, its distribution URI is preserved instead.
-    """
-
-    name = f"{model_uri}|{source_dir}/{filename}"
-    return URIRef(f"{DISTRIBUTION_BASE}{uuid.uuid5(uuid.NAMESPACE_URL, name)}/")
-
-
-def download_url(
-    config: Config, dataset_folder: Path, source_dir: str, filename: str
-) -> URIRef:
-    """Create the raw GitHub download URL for a diagram file."""
-
-    model_slug = dataset_folder.name
-    path = quoted_path(
-        *split_repository_path(config.models_dir_name), model_slug, source_dir, filename
-    )
-    return URIRef(
-        f"https://raw.githubusercontent.com/{config.repository}/{config.branch}/{path}"
-    )
-
-
-def read_existing_distribution_metadata(path: Path) -> ExistingDistributionMetadata:
-    """Read reusable metadata from an existing target file, if present.
-
-    RDFLib normalizes xsd:dateTime values when parsing, which can shorten
-    nanosecond timestamps such as 2023-04-14T17:33:22.898648451Z. The catalog
-    already contains such lexical forms, so timestamp literals are extracted from
-    the original Turtle text and reinserted with normalize=False.
-    """
-
-    if not path.exists():
-        return ExistingDistributionMetadata(
-            uri=None,
-            title=None,
-            editorial_note=None,
-            download_url=None,
-            license_uri=None,
-            metadata_issued=None,
-            metadata_modified=None,
-        )
-
-    graph = Graph()
-    try:
-        graph.parse(path)
-    except Exception as exc:  # noqa: BLE001 - surface RDFLib parse errors clearly
-        raise MetadataGenerationError(
-            f"Could not parse existing metadata file {path}: {exc}"
-        ) from exc
-
-    subjects = [
-        subject
-        for subject in graph.subjects(RDF.type, DCAT.Distribution)
-        if isinstance(subject, URIRef)
-    ]
-    if len(subjects) > 1:
-        raise MetadataGenerationError(
-            f"Expected at most one dcat:Distribution in {path}, found {len(subjects)}"
-        )
-
-    distribution = subjects[0] if subjects else None
-    if distribution and not str(distribution).startswith(DISTRIBUTION_BASE):
-        raise MetadataGenerationError(
-            f"Existing distribution URI does not follow catalog distribution URI pattern in {path}: {distribution}"
-        )
-
-    text = path.read_text(encoding="utf-8")
-    title = first_literal(graph, distribution, DCT.title) if distribution else None
-    editorial = (
-        first_literal(graph, distribution, SKOS.editorialNote) if distribution else None
-    )
-    download = (
-        first_uri(graph, distribution, DCAT.downloadURL) if distribution else None
-    )
-    license_uri = first_uri(graph, distribution, DCT.license) if distribution else None
-    metadata_issued = existing_datetime_literal(text, "metadataIssued")
-    metadata_modified = existing_datetime_literal(text, "metadataModified")
-
-    return ExistingDistributionMetadata(
-        uri=distribution,
-        title=title,
-        editorial_note=editorial,
-        download_url=download,
-        license_uri=license_uri,
-        metadata_issued=metadata_issued,
-        metadata_modified=metadata_modified,
-    )
-
-
-def existing_datetime_literal(turtle_text: str, local_name: str) -> Optional[Literal]:
-    """Return an existing fdpo dateTime literal while preserving its lexical form."""
-
-    patterns = [
-        rf"\bfdpo:{re.escape(local_name)}\s+\"([^\"]+)\"\^\^xsd:dateTime",
-        rf"<https://w3id\.org/fdp/fdp-o#{re.escape(local_name)}>\s+\"([^\"]+)\"\^\^<http://www\.w3\.org/2001/XMLSchema#dateTime>",
-    ]
-    for pattern in patterns:
-        match = re.search(pattern, turtle_text)
-        if match:
-            return Literal(match.group(1), datatype=XSD.dateTime, normalize=False)
-    return None
-
-
 def collect_diagrams(
     dataset_folder: Path, model: ModelMetadata, config: Config
-) -> List[DiagramFile]:
-    """Collect diagram files in catalog-supported diagram folders.
+) -> list[DiagramFile]:
+    """Collect PNG diagrams and derive their output metadata paths."""
 
-    All diagram-level validation is completed before any output file is written.
-    This prevents partial generation when a later diagram is invalid, when strict
-    mode fails, or when duplicate metadata targets/URIs are detected.
-    """
-
-    seen_outputs: dict[Path, Path] = {}
-    seen_uris: dict[URIRef, Path] = {}
-    missing_or_empty: List[str] = []
-    diagrams: List[DiagramFile] = []
+    diagrams: list[DiagramFile] = []
+    missing_or_empty: list[str] = []
 
     for source_dir, prefix in DIAGRAM_SOURCES.items():
         folder = dataset_folder / source_dir
-        if not folder.exists():
-            missing_or_empty.append(f"missing folder: {folder}")
+        if not folder.exists() or not folder.is_dir():
+            missing_or_empty.append(source_dir)
             continue
-        if not folder.is_dir():
-            raise MetadataGenerationError(
-                f"Diagram path exists but is not a directory: {folder}"
-            )
-
-        png_files = sorted(
+        pngs = sorted(
             path
             for path in folder.iterdir()
             if path.is_file() and path.suffix.lower() == ".png"
         )
-        if not png_files:
-            missing_or_empty.append(f"empty folder: {folder}")
+        if not pngs:
+            missing_or_empty.append(source_dir)
             continue
-
-        for png_path in png_files:
-            stem = validate_png_name(png_path)
-            # Validate PNG before generating metadata; dimensions can optionally
-            # be emitted with --include-file-metadata.
-            read_png_dimensions(png_path)
-
-            output_path = dataset_folder / f"metadata-png-{prefix}-{stem}.ttl"
-            if output_path.exists() and not config.overwrite:
-                existing = ExistingDistributionMetadata(
-                    uri=None,
-                    title=None,
-                    editorial_note=None,
-                    download_url=None,
-                    license_uri=None,
-                    metadata_issued=None,
-                    metadata_modified=None,
-                )
-                dist_uri = new_distribution_uri(model.uri, source_dir, png_path.name)
-            else:
-                existing = read_existing_distribution_metadata(output_path)
-                dist_uri = existing.uri or new_distribution_uri(
-                    model.uri, source_dir, png_path.name
-                )
-            generated_download_url = download_url(
-                config, dataset_folder, source_dir, png_path.name
-            )
-            dload = existing.download_url or generated_download_url
-
-            existing_output = seen_outputs.get(output_path)
-            if existing_output is not None:
+        for path in pngs:
+            if CONTROL_CHARS.search(path.name):
                 raise MetadataGenerationError(
-                    f"Duplicate metadata target {output_path} for {existing_output} and {png_path}"
+                    f"PNG filename contains control characters: {path}"
                 )
-            seen_outputs[output_path] = png_path
-
-            existing_uri = seen_uris.get(dist_uri)
-            if existing_uri is not None:
-                raise MetadataGenerationError(
-                    f"Duplicate distribution URI {dist_uri} for {existing_uri} and {png_path}"
-                )
-            seen_uris[dist_uri] = png_path
-
+            validate_png(path)
+            output = dataset_folder / f"metadata-png-{prefix}-{path.stem}.ttl"
+            existing = read_existing_metadata(output)
             diagrams.append(
                 DiagramFile(
                     source_dir=source_dir,
                     prefix=prefix,
-                    path=png_path,
-                    stem=stem,
-                    output_path=output_path,
-                    distribution_uri=dist_uri,
-                    download_url=dload,
+                    path=path,
+                    stem=path.stem,
+                    output_path=output,
+                    distribution_uri=existing.uri
+                    or deterministic_distribution_uri(model, source_dir, path.name),
+                    download_url=existing.download_url
+                    or default_download_url(
+                        dataset_folder, source_dir, path.name, config
+                    ),
                     existing_metadata=existing,
                 )
             )
 
-    if not diagrams:
-        details = (
-            "; ".join(missing_or_empty) if missing_or_empty else "no PNG files found"
-        )
-        raise MetadataGenerationError(
-            f"No PNG diagrams found in {dataset_folder} ({details})"
-        )
-
     if config.strict and missing_or_empty:
         raise MetadataGenerationError(
-            f"Strict mode failed for {dataset_folder}: " + "; ".join(missing_or_empty)
+            "Missing or empty expected diagram folder(s): "
+            + ", ".join(missing_or_empty)
         )
+    if not diagrams:
+        raise MetadataGenerationError(f"No PNG diagrams found in {dataset_folder}")
 
+    output_paths = [diagram.output_path for diagram in diagrams]
+    duplicated_outputs = sorted(
+        {path for path in output_paths if output_paths.count(path) > 1}
+    )
+    if duplicated_outputs:
+        raise MetadataGenerationError(
+            "Duplicate generated metadata path(s): "
+            + ", ".join(str(path) for path in duplicated_outputs)
+        )
+    distribution_uris = [diagram.distribution_uri for diagram in diagrams]
+    duplicated_uris = sorted(
+        {uri for uri in distribution_uris if distribution_uris.count(uri) > 1}
+    )
+    if duplicated_uris:
+        raise MetadataGenerationError(
+            "Duplicate generated distribution URI(s): "
+            + ", ".join(str(uri) for uri in duplicated_uris)
+        )
     return diagrams
 
 
@@ -862,43 +909,86 @@ def current_metadata_timestamp() -> Literal:
     return Literal(value, datatype=XSD.dateTime, normalize=False)
 
 
-def configured_metadata_timestamp(config: Config) -> Literal:
-    """Return a configured or current fdpo metadata timestamp."""
+def configured_metadata_timestamp(config: Config, target: Path) -> Literal:
+    """Return the explicit run timestamp used for FDP timestamp changes."""
 
+    if config.metadata_timestamp == "now":
+        return current_metadata_timestamp()
     if config.metadata_timestamp:
-        if not XSD_DATETIME.match(config.metadata_timestamp):
+        if not XSD_DATETIME_RE.match(config.metadata_timestamp):
             raise MetadataGenerationError(
                 "--metadata-timestamp must be an xsd:dateTime lexical value, "
-                "for example 2024-01-02T03:04:05Z"
+                "for example 2024-01-02T03:04:05Z. Use 'now' only when a "
+                "non-deterministic current timestamp is intentionally desired."
             )
         return Literal(
             config.metadata_timestamp, datatype=XSD.dateTime, normalize=False
         )
-    return current_metadata_timestamp()
+    raise MetadataGenerationError(
+        f"No run timestamp is available to initialize fdpo:metadataIssued or update "
+        f"fdpo:metadataModified in {target}. Provide --metadata-timestamp, for example "
+        "--metadata-timestamp 2026-01-31T12:00:00Z. Use --metadata-timestamp now "
+        "only when a non-deterministic execution timestamp is acceptable."
+    )
+
+
+def diagram_label(stem: str) -> str:
+    """Return a human-readable diagram label derived from a filename stem."""
+
+    return re.sub(r"[\s_-]+", " ", stem).strip()
+
+
+def source_version_label(prefix: str) -> str:
+    return SOURCE_VERSION_LABELS.get(prefix, prefix)
+
+
+def editorial_note(prefix: str) -> str:
+    return EDITORIAL_NOTES.get(
+        prefix, "This image depicts a diagram distribution of the model."
+    )
+
+
+def diagram_title(model: ModelMetadata, diagram: DiagramFile) -> str:
+    """Return a catalog-style title for a PNG diagram distribution."""
+
+    return (
+        f"PNG distribution of diagram '{diagram_label(diagram.stem)}' from the "
+        f"{model.title} ({source_version_label(diagram.prefix)})"
+    )
 
 
 def build_distribution_graph(
-    model: ModelMetadata, diagram: DiagramFile, config: Config
+    model: ModelMetadata,
+    diagram: DiagramFile,
+    config: Config,
+    *,
+    update_metadata_modified: bool = False,
 ) -> Graph:
     """Build RDF metadata for one PNG diagram distribution."""
 
     graph = Graph()
     bind_prefixes(graph)
 
-    title = diagram_title(model, diagram)
-    metadata_timestamp = configured_metadata_timestamp(config)
-    metadata_issued = diagram.existing_metadata.metadata_issued or metadata_timestamp
-    # Preserve existing metadataModified by default to make regeneration stable.
-    # Pass --metadata-timestamp with a new value after intentional changes if a
-    # maintained modified timestamp is required.
-    metadata_modified = (
-        diagram.existing_metadata.metadata_modified or metadata_timestamp
-    )
+    run_timestamp: Optional[Literal] = None
+
+    def get_run_timestamp() -> Literal:
+        nonlocal run_timestamp
+        if run_timestamp is None:
+            run_timestamp = configured_metadata_timestamp(config, diagram.output_path)
+        return run_timestamp
+
+    metadata_issued = diagram.existing_metadata.metadata_issued or get_run_timestamp()
+    if update_metadata_modified:
+        metadata_modified = get_run_timestamp()
+    else:
+        metadata_modified = (
+            diagram.existing_metadata.metadata_modified or metadata_issued
+        )
+    license_uri = diagram.existing_metadata.license_uri or model.license_uri
 
     graph.add((diagram.distribution_uri, RDF.type, DCAT.Distribution))
     graph.add((diagram.distribution_uri, DCT.isPartOf, model.uri))
     graph.add((diagram.distribution_uri, DCT.issued, model.issued))
-    license_uri = diagram.existing_metadata.license_uri or model.license_uri
     if license_uri is not None:
         graph.add((diagram.distribution_uri, DCT.license, license_uri))
     graph.add((diagram.distribution_uri, DCAT.mediaType, PNG_MEDIA_TYPE))
@@ -913,7 +1003,8 @@ def build_distribution_graph(
         (
             diagram.distribution_uri,
             DCT.title,
-            diagram.existing_metadata.title or Literal(title, lang="en"),
+            diagram.existing_metadata.title
+            or Literal(diagram_title(model, diagram), lang="en"),
         )
     )
     graph.add((diagram.distribution_uri, DCAT.downloadURL, diagram.download_url))
@@ -929,7 +1020,7 @@ def build_distribution_graph(
     graph.add((diagram.distribution_uri, FDPO.metadataModified, metadata_modified))
 
     if config.include_file_metadata:
-        width, height = read_png_dimensions(diagram.path)
+        width, height = validate_png(diagram.path)
         graph.add(
             (
                 diagram.distribution_uri,
@@ -960,32 +1051,8 @@ def build_distribution_graph(
     return graph
 
 
-def diagram_title(model: ModelMetadata, diagram: DiagramFile) -> str:
-    """Return a catalog-style title for a PNG diagram distribution."""
-
-    label = diagram_label(diagram.stem)
-    version = source_version_label(diagram.prefix)
-    return f"PNG distribution of diagram '{label}' from the {model.title} ({version})"
-
-
-def diagram_label(stem: str) -> str:
-    """Return a human-readable diagram label derived from a filename stem."""
-
-    return re.sub(r"[\s_-]+", " ", stem).strip()
-
-
-def source_version_label(prefix: str) -> str:
-    """Return the catalog label used for the source diagram version."""
-
-    return SOURCE_VERSION_LABELS.get(prefix, prefix)
-
-
-def editorial_note(prefix: str) -> str:
-    """Return the catalog editorial note used for the source diagram version."""
-
-    return EDITORIAL_NOTES.get(
-        prefix, "This image depicts a diagram distribution of the model."
-    )
+def serialize_graph(graph: Graph) -> str:
+    return graph.serialize(format="turtle")
 
 
 def write_graph(graph: Graph, target: Path, config: Config) -> None:
@@ -995,63 +1062,124 @@ def write_graph(graph: Graph, target: Path, config: Config) -> None:
         raise MetadataGenerationError(
             f"Metadata file already exists and overwrite is disabled: {target}"
         )
-    if config.dry_run:
+    if config.dry_run or config.check:
         return
+    target.write_text(serialize_graph(graph), encoding="utf-8")
 
-    target.write_text(graph.serialize(format="turtle"), encoding="utf-8")
 
-
-def process_dataset(dataset_folder: Path, config: Config) -> List[GeneratedFile]:
-    """Generate PNG distribution metadata files for one dataset folder.
-
-    The function validates all inputs and builds all RDF graphs before writing any
-    target file. This keeps generation atomic at dataset level for validation
-    errors and for --no-overwrite failures.
-    """
+def process_dataset(dataset_folder: Path, config: Config) -> list[GeneratedFile]:
+    """Generate PNG distribution metadata files for one dataset folder."""
 
     dataset_folder = validate_dataset_folder(dataset_folder)
     model = load_model_metadata(dataset_folder, config)
+    resolved_uri = resolve_model_uri(dataset_folder, model.uri)
+    if resolved_uri != model.uri:
+        model = ModelMetadata(
+            uri=resolved_uri,
+            title=model.title,
+            license_uri=model.license_uri,
+            issued=model.issued,
+        )
     diagrams = collect_diagrams(dataset_folder, model, config)
 
     existing_targets = [
         diagram.output_path for diagram in diagrams if diagram.output_path.exists()
     ]
     if existing_targets and not config.overwrite:
-        joined = ", ".join(str(path) for path in existing_targets)
         raise MetadataGenerationError(
-            f"Metadata file already exists and overwrite is disabled: {joined}"
+            "Metadata file already exists and overwrite is disabled: "
+            + ", ".join(str(path) for path in existing_targets)
         )
 
-    planned = [
+    initial_plans = [
         (diagram, build_distribution_graph(model, diagram, config))
         for diagram in diagrams
     ]
 
-    generated: List[GeneratedFile] = []
-    for diagram, graph in planned:
-        write_graph(graph, diagram.output_path, config)
+    final_plans: list[tuple[DiagramFile, Graph, str | None, str, bool]] = []
+    for diagram, graph in initial_plans:
+        old_text = (
+            diagram.output_path.read_text(encoding="utf-8")
+            if diagram.output_path.exists()
+            else None
+        )
+        initial_text = serialize_graph(graph)
+        changed = old_text != initial_text
+        if changed:
+            graph = build_distribution_graph(
+                model,
+                diagram,
+                config,
+                update_metadata_modified=True,
+            )
+        final_text = serialize_graph(graph)
+        changed = old_text != final_text
+        final_plans.append((diagram, graph, old_text, final_text, changed))
+
+    generated: list[GeneratedFile] = []
+    for diagram, graph, old_text, new_text, changed in final_plans:
+        if config.check and changed and config.emit_diff:
+            if old_text is None:
+                print(f"Would create {diagram.output_path}")
+            else:
+                diff = difflib.unified_diff(
+                    old_text.splitlines(),
+                    new_text.splitlines(),
+                    fromfile=str(diagram.output_path),
+                    tofile=f"{diagram.output_path} (generated)",
+                    lineterm="",
+                )
+                for line in diff:
+                    print(line)
+        if changed:
+            write_graph(graph, diagram.output_path, config)
         generated.append(
             GeneratedFile(
                 diagram_path=diagram.path,
                 metadata_path=diagram.output_path,
                 distribution_uri=diagram.distribution_uri,
+                changed=changed,
+                written=changed and not config.dry_run and not config.check,
             )
         )
     return generated
 
 
-def discover_datasets(models_dir: Path) -> List[Path]:
+def discover_datasets(models_dir: Path) -> list[Path]:
     """Discover model dataset folders under models_dir by metadata.yaml presence."""
 
+    models_dir = models_dir.resolve()
     if not models_dir.exists():
-        raise MetadataGenerationError(f"Models directory does not exist: {models_dir}")
+        raise MetadataSetupError(f"Models directory does not exist: {models_dir}")
     if not models_dir.is_dir():
-        raise MetadataGenerationError(f"Models path is not a directory: {models_dir}")
+        raise MetadataSetupError(f"Models path is not a directory: {models_dir}")
     return sorted(
         path
         for path in models_dir.iterdir()
         if path.is_dir() and (path / "metadata.yaml").exists()
     )
+
+
+def resolve_targets(args: argparse.Namespace) -> list[Path]:
+    if args.all:
+        if args.datasets:
+            raise MetadataSetupError(
+                "Use either --all or explicit dataset folders, not both."
+            )
+        datasets = discover_datasets(args.models_dir)
+    elif args.datasets:
+        datasets = [validate_dataset_folder(path) for path in args.datasets]
+    else:
+        cwd = Path.cwd()
+        if (cwd / "metadata.yaml").exists():
+            datasets = [cwd]
+        else:
+            raise MetadataSetupError(
+                "No dataset folder provided. Pass one or more model folders, use --all, or run from a dataset folder."
+            )
+    if not datasets:
+        raise MetadataSetupError("No dataset folders with metadata.yaml were found.")
+    return datasets
 
 
 def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
@@ -1072,23 +1200,56 @@ def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
     parser.add_argument(
         "--models-dir",
         type=Path,
-        default=Path("models"),
-        help="Models directory used with --all. Default: models.",
+        default=Path(DEFAULT_MODELS_DIR),
+        help=f"Models directory used with --all. Default: {DEFAULT_MODELS_DIR}.",
+    )
+    parser.add_argument(
+        "--allow-missing-license",
+        action="store_true",
+        help="Allow generation for legacy datasets without license metadata; otherwise license is mandatory.",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Do not write files; exit 1 if any PNG metadata file would change.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Validate inputs and report files that would be generated without writing them.",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("text", "json"),
+        default="text",
+        help="Summary output format. Default: text.",
+    )
+    parser.add_argument(
+        "-q",
+        "--quiet",
+        "--silent",
+        action="store_true",
+        help="Suppress per-file progress logs and the final text summary. Errors are still printed to stderr.",
     )
     parser.add_argument(
         "--repository",
-        default="OntoUML/ontouml-models",
-        help="GitHub repository used for dcat:downloadURL. Default: OntoUML/ontouml-models.",
+        default=DEFAULT_REPOSITORY,
+        help=f"GitHub repository used for dcat:downloadURL. Default: {DEFAULT_REPOSITORY}.",
     )
     parser.add_argument(
         "--branch",
-        default="master",
-        help="Git branch used for dcat:downloadURL. Default: master.",
+        default=DEFAULT_BRANCH,
+        help=f"Git branch used for dcat:downloadURL. Default: {DEFAULT_BRANCH}.",
     )
     parser.add_argument(
         "--models-dir-name",
-        default="models",
-        help="Repository-relative models path used inside generated dcat:downloadURL values. Default: models.",
+        default=DEFAULT_MODELS_DIR,
+        help=f"Repository-relative models path used inside generated dcat:downloadURL values. Default: {DEFAULT_MODELS_DIR}.",
+    )
+    parser.add_argument(
+        "--model-iri-base",
+        default=DEFAULT_MODEL_IRI_BASE,
+        help=f"Base IRI used for deterministic UUIDv5 model IRIs when no existing catalog model IRI is available. Default: {DEFAULT_MODEL_IRI_BASE}.",
     )
     parser.add_argument(
         "--no-overwrite",
@@ -1101,45 +1262,65 @@ def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
         help="Fail if expected diagram folders are missing or empty.",
     )
     parser.add_argument(
-        "--dry-run",
-        action="store_true",
-        help="Validate inputs and report files that would be generated without writing them.",
-    )
-    parser.add_argument(
         "--include-file-metadata",
         action="store_true",
         help="Also add optional byte size, SHA-256 checksum, width, and height triples.",
     )
     parser.add_argument(
         "--metadata-timestamp",
-        help="xsd:dateTime value used for fdpo:metadataIssued and fdpo:metadataModified on new files.",
+        help=(
+            "xsd:dateTime value used to initialize missing fdpo:metadataIssued values and "
+            "update fdpo:metadataModified when an existing metadata file changes. Required when "
+            "creating new metadata files, when existing files lack fdpo:metadataIssued, or when "
+            "existing files need regeneration changes. Use 'now' only when a non-deterministic "
+            "current timestamp is intentionally desired."
+        ),
     )
     parser.add_argument(
         "--require-license",
         action="store_true",
-        help="Fail if metadata.yaml does not provide a usable license. By default, missing licenses are tolerated and dct:license is omitted unless an existing PNG metadata file already has one.",
+        help=argparse.SUPPRESS,
     )
-    return parser.parse_args(argv)
+    args = parser.parse_args(argv)
+    if args.check and args.dry_run:
+        parser.error("--check and --dry-run cannot be used together.")
+    if args.allow_missing_license and args.require_license:
+        parser.error(
+            "--allow-missing-license and --require-license cannot be used together."
+        )
+    return args
 
 
-def resolve_targets(args: argparse.Namespace) -> List[Path]:
-    if args.all:
-        if args.datasets:
-            raise MetadataGenerationError(
-                "Use either --all or explicit dataset folders, not both."
-            )
-        return discover_datasets(args.models_dir)
+def action_label(config: Config, item: GeneratedFile) -> str:
+    if config.dry_run:
+        return "would generate"
+    if config.check:
+        return "needs update" if item.changed else "up to date"
+    return "generated" if item.written else "unchanged"
 
-    if args.datasets:
-        return list(args.datasets)
 
-    cwd = Path.cwd()
-    if (cwd / "metadata.yaml").exists():
-        return [cwd]
+def print_progress(item: GeneratedFile, config: Config) -> None:
+    print(f"{action_label(config, item)}: {item.metadata_path} <- {item.diagram_path}")
 
-    raise MetadataGenerationError(
-        "No dataset folder provided. Pass one or more model folders, use --all, or run from a dataset folder."
-    )
+
+def print_summary(
+    results: Sequence[GeneratedFile], error_count: int, config: Config
+) -> None:
+    if config.dry_run:
+        return
+    changed = sum(1 for item in results if item.changed)
+    written = sum(1 for item in results if item.written)
+    total = len(results) + error_count
+    if config.check:
+        print(
+            f"Summary: {total} file(s) processed, {len(results)} succeeded, "
+            f"{error_count} error(s), {changed} file(s) need update."
+        )
+    else:
+        print(
+            f"Summary: {total} file(s) processed, {len(results)} succeeded, "
+            f"{error_count} error(s), {written} written, {changed} changed."
+        )
 
 
 def main(argv: Optional[Sequence[str]] = None) -> int:
@@ -1148,26 +1329,59 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         repository=args.repository,
         branch=args.branch,
         models_dir_name=args.models_dir_name,
+        model_iri_base=args.model_iri_base,
         overwrite=not args.no_overwrite,
         strict=args.strict,
         dry_run=args.dry_run,
+        check=args.check,
         include_file_metadata=args.include_file_metadata,
         metadata_timestamp=args.metadata_timestamp,
-        require_license=args.require_license,
+        allow_missing_license=args.allow_missing_license,
+        require_license=args.require_license or None,
+        emit_diff=args.format == "text" and not args.quiet,
+        quiet=args.quiet,
     )
 
     try:
         targets = resolve_targets(args)
-        generated_all: List[GeneratedFile] = []
-        for target in targets:
-            generated_all.extend(process_dataset(target, config))
-    except MetadataGenerationError as exc:
-        print(f"error: {exc}", file=sys.stderr)
-        return 1
+    except MetadataSetupError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
 
-    action = "would generate" if config.dry_run else "generated"
-    for item in generated_all:
-        print(f"{action}: {item.metadata_path} <- {item.diagram_path}")
+    results: list[GeneratedFile] = []
+    errors: list[dict[str, str]] = []
+    progress_enabled = args.format == "text" and not args.quiet
+    for target in targets:
+        try:
+            generated = process_dataset(target, config)
+            results.extend(generated)
+            if progress_enabled:
+                for item in generated:
+                    print_progress(item, config)
+        except MetadataGenerationError as exc:
+            errors.append({"dataset": str(target), "error": str(exc)})
+            print(f"ERROR {target}: {exc}", file=sys.stderr)
+
+    if args.format == "json":
+        print(
+            json.dumps(
+                {
+                    "ok": not errors
+                    and not (config.check and any(item.changed for item in results)),
+                    "results": [item.to_dict() for item in results],
+                    "errors": errors,
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+    elif not args.quiet:
+        print_summary(results, len(errors), config)
+
+    if errors:
+        return 1
+    if config.check and any(item.changed for item in results):
+        return 1
     return 0
 
 

--- a/scripts/tests/test_generate_png_metadata.py
+++ b/scripts/tests/test_generate_png_metadata.py
@@ -4,6 +4,7 @@ import importlib.util
 import struct
 import sys
 import zlib
+import uuid
 from pathlib import Path
 
 import pytest
@@ -71,6 +72,13 @@ issued: {issued}
     )
 
 
+def deterministic_model_uri(slug: str) -> str:
+    model_uuid = uuid.uuid5(
+        uuid.NAMESPACE_URL, f"https://w3id.org/ontouml-models/model|{slug}"
+    )
+    return f"https://w3id.org/ontouml-models/model/{model_uuid}"
+
+
 def write_dataset(tmp_path: Path) -> Path:
     dataset = tmp_path / "models" / "example-model"
     (dataset / "original-diagrams").mkdir(parents=True)
@@ -87,6 +95,7 @@ def write_dataset(tmp_path: Path) -> Path:
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
 
 <https://w3id.org/ontouml-models/distribution/original-existing> a dcat:Distribution;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/0647761f-976f-41c4-94c0-a907ae1ed577>;
     dct:title "Existing original PNG title"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/example-model/original-diagrams/petroleum-system.png>;
     skos:editorialNote "Existing original editorial note."@en;
@@ -102,33 +111,48 @@ def test_png_metadata_regeneration_preserves_existing_catalog_values(tmp_path: P
     module = load_module()
     dataset = write_dataset(tmp_path)
 
-    generated = module.process_dataset(dataset, module.Config())
+    generated = module.process_dataset(
+        dataset, module.Config(metadata_timestamp="2024-01-02T03:04:05Z")
+    )
 
     assert len(generated) == 2
     original = (dataset / "metadata-png-o-petroleum-system.ttl").read_text(
         encoding="utf-8"
     )
-
     assert "ocmv:isComplete false" in original
     assert "Existing original PNG title" in original
     assert "Existing original editorial note." in original
     assert "2023-04-14T17:33:24.802284319Z" in original
-    assert "2023-04-14T17:33:25.802284319Z" in original
+    assert "2023-04-14T17:33:25.802284319Z" not in original
+    assert "2024-01-02T03:04:05Z" in original
     assert "https://w3id.org/ontouml-models/distribution/original-existing" in original
     assert "original-diagrams/petroleum-system.png" in original
 
 
-def test_png_metadata_generation_uses_yaml_defaults_for_new_files(tmp_path: Path):
+def test_png_metadata_generation_uses_metadata_yaml_when_metadata_ttl_is_absent(
+    tmp_path: Path,
+):
     module = load_module()
     dataset = write_dataset(tmp_path)
 
-    module.process_dataset(dataset, module.Config())
+    assert not (dataset / "metadata.ttl").exists()
+    module.process_dataset(
+        dataset, module.Config(metadata_timestamp="2024-01-02T03:04:05Z")
+    )
 
     new = (dataset / "metadata-png-n-petroleum-system.ttl").read_text(encoding="utf-8")
-
     assert "ocmv:isComplete false" in new
-    assert "dct:isPartOf <https://w3id.org/ontouml-models/model/example>" in new
+    assert (
+        "dct:isPartOf <https://w3id.org/ontouml-models/model/0647761f-976f-41c4-94c0-a907ae1ed577>"
+        in new
+    )
+    assert "dct:isPartOf <https://w3id.org/ontouml-models/model/example>" not in new
     assert 'dct:issued "2015"^^xsd:gYear' in new
+    assert "https://creativecommons.org/licenses/by/4.0/" in new
+    assert (
+        "https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/example-model/new-diagrams/petroleum-system.png"
+        in new
+    )
     assert (
         'skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en'
         in new
@@ -139,22 +163,213 @@ def test_png_metadata_generation_uses_yaml_defaults_for_new_files(tmp_path: Path
     )
 
 
-def test_png_metadata_generation_does_not_require_metadata_ttl(tmp_path: Path):
+def test_new_dataset_uses_converter_compatible_deterministic_model_uri(tmp_path: Path):
     module = load_module()
-    dataset = write_dataset(tmp_path)
-
-    assert not (dataset / "metadata.ttl").exists()
+    dataset = tmp_path / "models" / "new-deterministic-model"
+    (dataset / "original-diagrams").mkdir(parents=True)
+    (dataset / "original-diagrams" / "diagram.png").write_bytes(minimal_png())
+    write_metadata_yaml(
+        dataset,
+        slug="ignored-yaml-id",
+        title="New Deterministic Model",
+        issued="2024",
+    )
 
     module.process_dataset(
         dataset, module.Config(metadata_timestamp="2024-01-02T03:04:05Z")
     )
 
-    assert (dataset / "metadata-png-n-petroleum-system.ttl").exists()
+    generated = (dataset / "metadata-png-o-diagram.ttl").read_text(encoding="utf-8")
+    assert (
+        f"dct:isPartOf <{deterministic_model_uri('new-deterministic-model')}>"
+        in generated
+    )
+    assert "ignored-yaml-id" not in generated
 
 
-def test_png_metadata_regeneration_preserves_existing_download_url_with_comma(
+def test_existing_metadata_ttl_model_uri_is_used_when_png_metadata_has_no_is_part_of(
     tmp_path: Path,
 ):
+    module = load_module()
+    dataset = tmp_path / "models" / "existing-model-uri"
+    (dataset / "original-diagrams").mkdir(parents=True)
+    (dataset / "original-diagrams" / "diagram.png").write_bytes(minimal_png())
+    write_metadata_yaml(
+        dataset, slug="existing-model-uri", title="Existing Model URI", issued="2024"
+    )
+    (dataset / "metadata.ttl").write_text(
+        """
+@prefix dcat: <http://www.w3.org/ns/dcat#>.
+@prefix mod: <https://w3id.org/mod#>.
+
+<https://w3id.org/ontouml-models/model/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource .
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    module.process_dataset(
+        dataset, module.Config(metadata_timestamp="2024-01-02T03:04:05Z")
+    )
+
+    generated = (dataset / "metadata-png-o-diagram.ttl").read_text(encoding="utf-8")
+    assert (
+        "dct:isPartOf <https://w3id.org/ontouml-models/model/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee>"
+        in generated
+    )
+
+
+def test_existing_metadata_ttl_takes_precedence_over_png_is_part_of(tmp_path: Path):
+    module = load_module()
+    dataset = tmp_path / "models" / "png-model-uri"
+    (dataset / "original-diagrams").mkdir(parents=True)
+    (dataset / "new-diagrams").mkdir()
+    (dataset / "original-diagrams" / "diagram.png").write_bytes(minimal_png())
+    (dataset / "new-diagrams" / "diagram.png").write_bytes(minimal_png())
+    write_metadata_yaml(
+        dataset, slug="png-model-uri", title="PNG Model URI", issued="2024"
+    )
+    (dataset / "metadata.ttl").write_text(
+        """
+@prefix dcat: <http://www.w3.org/ns/dcat#>.
+@prefix mod: <https://w3id.org/mod#>.
+
+<https://w3id.org/ontouml-models/model/from-metadata-ttl/> a dcat:Dataset, mod:SemanticArtefact, dcat:Resource .
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    (dataset / "metadata-png-o-diagram.ttl").write_text(
+        """
+@prefix dcat: <http://www.w3.org/ns/dcat#>.
+@prefix dct: <http://purl.org/dc/terms/>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+
+<https://w3id.org/ontouml-models/distribution/existing-png-model-uri> a dcat:Distribution;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/from-existing-png>;
+    fdpo:metadataIssued "2023-04-14T17:33:24.802284319Z"^^xsd:dateTime;
+    fdpo:metadataModified "2023-04-14T17:33:25.802284319Z"^^xsd:dateTime .
+""".strip(),
+        encoding="utf-8",
+    )
+
+    module.process_dataset(
+        dataset, module.Config(metadata_timestamp="2024-01-02T03:04:05Z")
+    )
+
+    new_generated = (dataset / "metadata-png-n-diagram.ttl").read_text(encoding="utf-8")
+    assert (
+        "dct:isPartOf <https://w3id.org/ontouml-models/model/from-metadata-ttl>"
+        in new_generated
+    )
+    assert "from-existing-png" not in new_generated
+
+
+def test_missing_license_fails_without_allow_missing_license(tmp_path: Path):
+    module = load_module()
+    dataset = tmp_path / "models" / "missing-license-model"
+    (dataset / "original-diagrams").mkdir(parents=True)
+    (dataset / "original-diagrams" / "diagram.png").write_bytes(minimal_png())
+    write_metadata_yaml(
+        dataset,
+        slug="missing-license",
+        title="Missing License Model",
+        issued="2024",
+        license_value=None,
+    )
+
+    with pytest.raises(module.MetadataGenerationError, match="license"):
+        module.process_dataset(
+            dataset, module.Config(metadata_timestamp="2024-01-02T03:04:05Z")
+        )
+
+    assert not (dataset / "metadata-png-o-diagram.ttl").exists()
+
+
+def test_missing_license_is_allowed_with_allow_missing_license(tmp_path: Path):
+    module = load_module()
+    dataset = tmp_path / "models" / "missing-license-model"
+    (dataset / "original-diagrams").mkdir(parents=True)
+    (dataset / "original-diagrams" / "diagram.png").write_bytes(minimal_png())
+    write_metadata_yaml(
+        dataset,
+        slug="missing-license",
+        title="Missing License Model",
+        issued="2024",
+        license_value=None,
+    )
+
+    module.process_dataset(
+        dataset,
+        module.Config(
+            metadata_timestamp="2024-01-02T03:04:05Z",
+            allow_missing_license=True,
+        ),
+    )
+
+    generated = (dataset / "metadata-png-o-diagram.ttl").read_text(encoding="utf-8")
+    assert "dct:license" not in generated
+    assert "Missing License Model" in generated
+
+
+def test_missing_metadata_timestamp_for_new_png_metadata_fails(tmp_path: Path):
+    module = load_module()
+    dataset = tmp_path / "models" / "timestamp-model"
+    (dataset / "original-diagrams").mkdir(parents=True)
+    (dataset / "original-diagrams" / "diagram.png").write_bytes(minimal_png())
+    write_metadata_yaml(
+        dataset, slug="timestamp-model", title="Timestamp Model", issued="2024"
+    )
+
+    with pytest.raises(module.MetadataGenerationError, match="No run timestamp"):
+        module.process_dataset(dataset, module.Config())
+
+    assert not (dataset / "metadata-png-o-diagram.ttl").exists()
+
+
+def test_existing_png_license_is_preserved_when_missing_license_is_allowed(
+    tmp_path: Path,
+):
+    module = load_module()
+    dataset = tmp_path / "models" / "existing-license-model"
+    (dataset / "original-diagrams").mkdir(parents=True)
+    (dataset / "original-diagrams" / "diagram.png").write_bytes(minimal_png())
+    write_metadata_yaml(
+        dataset,
+        slug="existing-license-model",
+        title="Existing License Model",
+        issued="2024",
+        license_value=None,
+    )
+    (dataset / "metadata-png-o-diagram.ttl").write_text(
+        """
+@prefix dcat: <http://www.w3.org/ns/dcat#>.
+@prefix dct: <http://purl.org/dc/terms/>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+
+<https://w3id.org/ontouml-models/distribution/existing-license> a dcat:Distribution;
+    dct:license <https://example.org/custom-license>;
+    fdpo:metadataIssued "2023-04-14T17:33:24.802284319Z"^^xsd:dateTime;
+    fdpo:metadataModified "2023-04-14T17:33:25.802284319Z"^^xsd:dateTime .
+""".strip(),
+        encoding="utf-8",
+    )
+
+    module.process_dataset(
+        dataset,
+        module.Config(
+            metadata_timestamp="2024-01-02T03:04:05Z",
+            allow_missing_license=True,
+        ),
+    )
+
+    generated = (dataset / "metadata-png-o-diagram.ttl").read_text(encoding="utf-8")
+    assert "https://example.org/custom-license" in generated
+
+
+def test_existing_supported_behavior_preserves_download_url_with_comma(tmp_path: Path):
     module = load_module()
     dataset = tmp_path / "models" / "alpinebits2022"
     (dataset / "original-diagrams").mkdir(parents=True)
@@ -186,7 +401,9 @@ def test_png_metadata_regeneration_preserves_existing_download_url_with_comma(
         encoding="utf-8",
     )
 
-    module.process_dataset(dataset, module.Config())
+    module.process_dataset(
+        dataset, module.Config(metadata_timestamp="2024-01-02T03:04:05Z")
+    )
 
     regenerated = (
         dataset / "metadata-png-o-lifts,-ski-slopes,-and-snowparks.ttl"
@@ -195,17 +412,14 @@ def test_png_metadata_regeneration_preserves_existing_download_url_with_comma(
     assert "lifts%2C-ski-slopes%2C-and-snowparks.png" not in regenerated
 
 
-def test_png_metadata_generation_keeps_commas_unescaped_in_new_download_urls(
-    tmp_path: Path,
-):
+def test_new_download_url_quotes_spaces_and_apostrophes_but_not_commas(tmp_path: Path):
     module = load_module()
-    dataset = tmp_path / "models" / "new-comma-model"
+    dataset = tmp_path / "models" / "special-name-model"
     (dataset / "original-diagrams").mkdir(parents=True)
-    (
-        dataset / "original-diagrams" / "lifts,-ski-slopes,-and-snowparks.png"
-    ).write_bytes(minimal_png())
+    filename = "AUX - Object at Risk's Vulnerability, Manifestation.png"
+    (dataset / "original-diagrams" / filename).write_bytes(minimal_png())
     write_metadata_yaml(
-        dataset, slug="new-comma", title="New Comma Model", issued="2024"
+        dataset, slug="special-name-model", title="Special Name Model", issued="2024"
     )
 
     module.process_dataset(
@@ -213,51 +427,14 @@ def test_png_metadata_generation_keeps_commas_unescaped_in_new_download_urls(
     )
 
     generated = (
-        dataset / "metadata-png-o-lifts,-ski-slopes,-and-snowparks.ttl"
+        dataset
+        / "metadata-png-o-AUX - Object at Risk's Vulnerability, Manifestation.ttl"
     ).read_text(encoding="utf-8")
-    assert "lifts,-ski-slopes,-and-snowparks.png" in generated
-    assert "lifts%2C-ski-slopes%2C-and-snowparks.png" not in generated
-
-
-def test_png_metadata_generation_tolerates_missing_model_license(tmp_path: Path):
-    module = load_module()
-    dataset = tmp_path / "models" / "missing-license-model"
-    (dataset / "original-diagrams").mkdir(parents=True)
-    (dataset / "original-diagrams" / "diagram.png").write_bytes(minimal_png())
-    write_metadata_yaml(
-        dataset,
-        slug="missing-license",
-        title="Missing License Model",
-        issued="2024",
-        license_value=None,
+    assert (
+        "AUX%20-%20Object%20at%20Risk%27s%20Vulnerability,%20Manifestation.png"
+        in generated
     )
-
-    module.process_dataset(
-        dataset, module.Config(metadata_timestamp="2024-01-02T03:04:05Z")
-    )
-
-    generated = (dataset / "metadata-png-o-diagram.ttl").read_text(encoding="utf-8")
-    assert "dct:license" not in generated
-    assert "Missing License Model" in generated
-
-
-def test_png_metadata_generation_can_require_model_license(tmp_path: Path):
-    module = load_module()
-    dataset = tmp_path / "models" / "missing-license-model"
-    (dataset / "original-diagrams").mkdir(parents=True)
-    (dataset / "original-diagrams" / "diagram.png").write_bytes(minimal_png())
-    write_metadata_yaml(
-        dataset,
-        slug="missing-license",
-        title="Missing License Model",
-        issued="2024",
-        license_value=None,
-    )
-
-    with pytest.raises(
-        module.MetadataGenerationError, match="Missing required license"
-    ):
-        module.process_dataset(dataset, module.Config(require_license=True))
+    assert "%2C" not in generated
 
 
 def test_discover_datasets_uses_metadata_yaml(tmp_path: Path):
@@ -306,7 +483,7 @@ rights:
     assert "https://creativecommons.org/licenses/by/4.0/" in generated
 
 
-def test_cli_all_dry_run_processes_metadata_yaml_datasets(
+def test_cli_all_dry_run_processes_metadata_yaml_datasets_with_allow_missing_license(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ):
     module = load_module()
@@ -319,9 +496,21 @@ def test_cli_all_dry_run_processes_metadata_yaml_datasets(
     ):
         (dataset / "original-diagrams").mkdir(parents=True)
         (dataset / "original-diagrams" / "diagram.png").write_bytes(minimal_png())
-        write_metadata_yaml(dataset, slug=slug, title=title, issued="2024")
+        write_metadata_yaml(
+            dataset, slug=slug, title=title, issued="2024", license_value=None
+        )
 
-    exit_code = module.main(["--all", "--models-dir", str(models), "--dry-run"])
+    exit_code = module.main(
+        [
+            "--all",
+            "--models-dir",
+            str(models),
+            "--dry-run",
+            "--allow-missing-license",
+            "--metadata-timestamp",
+            "2024-01-02T03:04:05Z",
+        ]
+    )
 
     captured = capsys.readouterr()
     assert exit_code == 0
@@ -332,69 +521,65 @@ def test_cli_all_dry_run_processes_metadata_yaml_datasets(
     assert not (second / "metadata-png-o-diagram.ttl").exists()
 
 
-def test_png_metadata_generation_url_quotes_spaces_and_apostrophes_but_not_commas(
-    tmp_path: Path,
+def test_cli_missing_license_without_allow_missing_license_returns_generation_error(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ):
     module = load_module()
-    dataset = tmp_path / "models" / "special-name-model"
-    (dataset / "original-diagrams").mkdir(parents=True)
-    filename = "AUX - Object at Risk's Vulnerability, Manifestation.png"
-    (dataset / "original-diagrams" / filename).write_bytes(minimal_png())
-    write_metadata_yaml(
-        dataset, slug="special-name-model", title="Special Name Model", issued="2024"
-    )
-
-    module.process_dataset(
-        dataset, module.Config(metadata_timestamp="2024-01-02T03:04:05Z")
-    )
-
-    generated = (
-        dataset
-        / "metadata-png-o-AUX - Object at Risk's Vulnerability, Manifestation.ttl"
-    ).read_text(encoding="utf-8")
-    assert (
-        "AUX%20-%20Object%20at%20Risk%27s%20Vulnerability,%20Manifestation.png"
-        in generated
-    )
-    assert "%2C" not in generated
-
-
-def test_existing_png_license_is_preserved_when_model_license_is_missing(
-    tmp_path: Path,
-):
-    module = load_module()
-    dataset = tmp_path / "models" / "existing-license-model"
+    dataset = tmp_path / "models" / "missing-license-model"
     (dataset / "original-diagrams").mkdir(parents=True)
     (dataset / "original-diagrams" / "diagram.png").write_bytes(minimal_png())
     write_metadata_yaml(
         dataset,
-        slug="existing-license-model",
-        title="Existing License Model",
+        slug="missing-license",
+        title="Missing License",
         issued="2024",
         license_value=None,
     )
-    (dataset / "metadata-png-o-diagram.ttl").write_text(
-        """
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
 
-<https://w3id.org/ontouml-models/distribution/existing-license> a dcat:Distribution;
-    dct:license <https://example.org/custom-license>;
-    fdpo:metadataIssued "2023-04-14T17:33:24.802284319Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:33:25.802284319Z"^^xsd:dateTime .
-""".strip(),
-        encoding="utf-8",
+    exit_code = module.main(
+        [str(dataset), "--metadata-timestamp", "2024-01-02T03:04:05Z"]
     )
 
-    module.process_dataset(dataset, module.Config())
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "license" in captured.err
 
-    generated = (dataset / "metadata-png-o-diagram.ttl").read_text(encoding="utf-8")
-    assert "https://example.org/custom-license" in generated
+
+def test_cli_check_returns_one_when_metadata_would_change(tmp_path: Path):
+    module = load_module()
+    dataset = tmp_path / "models" / "check-model"
+    (dataset / "original-diagrams").mkdir(parents=True)
+    (dataset / "original-diagrams" / "diagram.png").write_bytes(minimal_png())
+    write_metadata_yaml(dataset, slug="check-model", title="Check Model", issued="2024")
+
+    exit_code = module.main(
+        [
+            str(dataset),
+            "--check",
+            "--metadata-timestamp",
+            "2024-01-02T03:04:05Z",
+        ]
+    )
+
+    assert exit_code == 1
+    assert not (dataset / "metadata-png-o-diagram.ttl").exists()
 
 
-def test_existing_full_iri_timestamps_are_preserved(tmp_path: Path):
+def test_cli_setup_error_returns_two(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+):
+    module = load_module()
+
+    exit_code = module.main(["--all", "--models-dir", str(tmp_path / "missing")])
+
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert "Models directory does not exist" in captured.err
+
+
+def test_existing_full_iri_metadata_issued_is_preserved_and_modified_updates_when_changed(
+    tmp_path: Path,
+):
     module = load_module()
     dataset = tmp_path / "models" / "full-iri-timestamp-model"
     (dataset / "original-diagrams").mkdir(parents=True)
@@ -413,10 +598,72 @@ def test_existing_full_iri_timestamps_are_preserved(tmp_path: Path):
         encoding="utf-8",
     )
 
-    module.process_dataset(dataset, module.Config())
+    module.process_dataset(
+        dataset, module.Config(metadata_timestamp="2024-01-02T03:04:05Z")
+    )
 
     generated = (dataset / "metadata-png-o-diagram.ttl").read_text(encoding="utf-8")
     assert "2023-04-14T17:33:24.802284319Z" in generated
+    assert "2023-04-14T17:33:25.802284319Z" not in generated
+    assert "2024-01-02T03:04:05Z" in generated
+
+
+def test_unchanged_existing_timestamps_are_preserved_without_new_timestamp(
+    tmp_path: Path,
+):
+    module = load_module()
+    dataset = tmp_path / "models" / "unchanged-timestamp-model"
+    (dataset / "original-diagrams").mkdir(parents=True)
+    (dataset / "original-diagrams" / "diagram.png").write_bytes(minimal_png())
+    write_metadata_yaml(
+        dataset,
+        slug="unchanged-timestamp-model",
+        title="Timestamp Model",
+        issued="2024",
+    )
+
+    first_results = module.process_dataset(
+        dataset, module.Config(metadata_timestamp="2024-01-02T03:04:05Z")
+    )
+    assert any(item.written for item in first_results)
+    first_text = (dataset / "metadata-png-o-diagram.ttl").read_text(encoding="utf-8")
+
+    second_results = module.process_dataset(dataset, module.Config())
+
+    second_text = (dataset / "metadata-png-o-diagram.ttl").read_text(encoding="utf-8")
+    assert all(not item.changed for item in second_results)
+    assert first_text == second_text
+    assert "2024-01-02T03:04:05Z" in second_text
+
+
+def test_existing_changed_file_requires_metadata_timestamp(tmp_path: Path):
+    module = load_module()
+    dataset = tmp_path / "models" / "changed-existing-timestamp-model"
+    (dataset / "original-diagrams").mkdir(parents=True)
+    (dataset / "original-diagrams" / "diagram.png").write_bytes(minimal_png())
+    write_metadata_yaml(
+        dataset,
+        slug="changed-existing-timestamp-model",
+        title="Timestamp Model",
+        issued="2024",
+    )
+    (dataset / "metadata-png-o-diagram.ttl").write_text(
+        """
+@prefix dcat: <http://www.w3.org/ns/dcat#>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+
+<https://w3id.org/ontouml-models/distribution/changed-existing> a dcat:Distribution;
+    fdpo:metadataIssued "2023-04-14T17:33:24.802284319Z"^^xsd:dateTime;
+    fdpo:metadataModified "2023-04-14T17:33:25.802284319Z"^^xsd:dateTime .
+""".strip(),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(module.MetadataGenerationError, match="metadataModified"):
+        module.process_dataset(dataset, module.Config())
+
+    generated = (dataset / "metadata-png-o-diagram.ttl").read_text(encoding="utf-8")
     assert "2023-04-14T17:33:25.802284319Z" in generated
 
 
@@ -453,8 +700,10 @@ def test_invalid_png_fails_before_any_metadata_file_is_written(tmp_path: Path):
         dataset, slug="invalid-png-model", title="Invalid PNG Model", issued="2024"
     )
 
-    with pytest.raises(module.MetadataGenerationError, match="invalid PNG"):
-        module.process_dataset(dataset, module.Config())
+    with pytest.raises(module.MetadataGenerationError, match="valid PNG"):
+        module.process_dataset(
+            dataset, module.Config(metadata_timestamp="2024-01-02T03:04:05Z")
+        )
 
     assert not (dataset / "metadata-png-o-a-valid.ttl").exists()
     assert not (dataset / "metadata-png-o-z-invalid.ttl").exists()


### PR DESCRIPTION
## Summary

This PR updates the PNG diagram metadata generator so it can be used safely in the repository’s YAML-based metadata workflow.

The main goal is to make PNG distribution metadata generation independent from model-level `metadata.ttl` whenever the required information can be obtained from `metadata.yaml`, while still preserving existing catalog identifiers and curated distribution metadata for already published datasets.

This prepares the script for later workflow/CI integration, but **does not** add or modify any GitHub Actions workflow or CI configuration.

## Motivation

The repository is moving toward a generation order in which distribution-level metadata files are generated before the model-level `metadata.ttl` file.

A future workflow may eventually follow this general shape:

```bash
python scripts/validate_metadata_yaml.py --all --models-dir models --fix --allow-missing-license
python scripts/generate_png_metadata.py --all --models-dir models --allow-missing-license
python scripts/metadata_yaml_to_ttl.py --all --models-dir models --allow-missing-license --metadata-timestamp now
```

In that setup, PNG distribution metadata cannot depend on `metadata.ttl` being generated first. This PR updates the PNG metadata generator accordingly.

## Main changes

### Metadata source behavior

- Uses `metadata.yaml` as the preferred source for model-level information needed to generate PNG distribution metadata.
- Avoids requiring `metadata.ttl` as an input dependency for new datasets.
- Preserves compatibility with existing catalog datasets by reading existing `metadata.ttl` only when available to preserve the stable published model IRI.
- Falls back to existing PNG metadata `dct:isPartOf` when model-level `metadata.ttl` is absent.
- Uses deterministic UUIDv5 model IRIs for new datasets when no existing model IRI is available.

### Existing catalog preservation

For existing PNG metadata files, the script preserves catalog-managed or curated values where appropriate, including:

- existing PNG distribution IRI;
- existing `dct:title`;
- existing `skos:editorialNote`;
- existing `dcat:downloadURL`;
- existing PNG-level `dct:license`;
- existing `fdpo:metadataIssued`;
- existing `fdpo:metadataModified` when the regenerated file is unchanged.

This avoids changing already published identifiers and reduces unnecessary diffs during regeneration.

### Model IRI preservation

The script now resolves the model IRI in this order:

1. Existing model-level `metadata.ttl`, when present.
2. Existing PNG metadata `dct:isPartOf`, when model-level `metadata.ttl` is absent.
3. Explicit HTTP(S) model URI in `metadata.yaml`, if present.
4. Deterministic UUIDv5 model IRI for new datasets.

This prevents existing UUID-based catalog model IRIs from being replaced by folder-name-based IRIs.

### Missing-license behavior

The PNG metadata generator now aligns with the `metadata.yaml` to `metadata.ttl` converter:

- missing license metadata fails by default;
- `--allow-missing-license` allows legacy datasets without license metadata to be processed;
- available license metadata is still emitted;
- existing PNG-level license metadata can be preserved when missing model-level license is explicitly allowed.

Example:

```bash
python scripts/generate_png_metadata.py --all --models-dir models --allow-missing-license
```

### Timestamp behavior

The script now follows the same preservation/update strategy adopted for generated `metadata.ttl` files:

- preserve existing `fdpo:metadataIssued` when present;
- initialize missing `fdpo:metadataIssued` from `--metadata-timestamp`;
- preserve `fdpo:metadataModified` when the regenerated file is unchanged;
- update `fdpo:metadataModified` from `--metadata-timestamp` when an existing file changes;
- fail when a new or changed metadata file requires a timestamp and none is provided.

For deterministic regeneration, use a fixed timestamp:

```bash
python scripts/generate_png_metadata.py --all --models-dir models \
  --allow-missing-license \
  --metadata-timestamp 2026-06-23T12:00:00Z
```

For an intentional non-deterministic maintenance run, `now` is supported:

```bash
python scripts/generate_png_metadata.py --all --models-dir models \
  --allow-missing-license \
  --metadata-timestamp now
```

### CLI and automation-readiness improvements

The script is improved for later non-interactive use by supporting:

- selected dataset folders;
- `--all` with `--models-dir`;
- `--check`;
- `--dry-run`;
- `--format text`;
- `--format json`;
- `--quiet` / `--silent`;
- deterministic timestamp handling;
- clear exit codes;
- log-friendly output.

Exit-code behavior:

- `0`: generation/check completed successfully;
- `1`: dataset processing failed, or `--check` detected required updates;
- `2`: command-line, discovery, or setup error prevented normal execution.

## Documentation updates

Updates `scripts/generate-png-metadata.md` to document:

- the purpose of the PNG metadata generator;
- supported source PNG folders and generated metadata filenames;
- how model-level information is resolved;
- how existing metadata is preserved;
- how missing-license handling works;
- how timestamp preservation and updates work;
- how to run the script for one, multiple, or all datasets;
- how to use dry-run/check/json/quiet modes;
- how the script fits into the recommended future metadata workflow;
- that this PR does not create the workflow itself.

## Tests

Updates `scripts/tests/test_generate_png_metadata.py` to cover:

- generation using `metadata.yaml` when `metadata.ttl` is absent;
- preservation of existing catalog-managed PNG metadata values;
- preservation of existing UUID-based model IRIs;
- deterministic UUID fallback for new datasets;
- missing-license failure by default;
- missing-license success with `--allow-missing-license`;
- preservation of existing PNG-level license metadata;
- timestamp initialization and update behavior;
- CLI behavior for dry-run, check, json, and quiet usage;
- invalid PNG handling before any metadata file is written.

## Validation

The following commands were used to validate the changes:

```bash
python -m py_compile scripts/generate_png_metadata.py scripts/tests/test_generate_png_metadata.py
python -m pytest -q scripts/tests/test_generate_png_metadata.py
```

Expected result:

```text
22 passed
```

## Scope

This PR modifies only the PNG metadata generator, its documentation, and its tests:

- `scripts/generate_png_metadata.py`
- `scripts/generate-png-metadata.md`
- `scripts/tests/test_generate_png_metadata.py`

It does not modify model data files, generated metadata files, GitHub Actions workflows, or CI configuration.

## Notes

This PR prepares the PNG metadata generator for later workflow integration, but intentionally does not implement the workflow itself.