### PR TITLE
Prepare Turtle metadata generation for YAML workflow

### DIFF
--- a/scripts/generate-turtle-metadata.md
+++ b/scripts/generate-turtle-metadata.md
@@ -1,0 +1,367 @@
+# Generate Turtle distribution metadata
+
+This repository contains one RDF/Turtle metadata file for the Turtle linked-data distribution of each model.
+
+The generator implemented in `scripts/generate_turtle_metadata.py` scans one or more model dataset folders and creates this file:
+
+| Source file | Generated metadata file |
+| --- | --- |
+| `ontology.ttl` | `metadata-turtle.ttl` |
+
+For example:
+
+```text
+models/example/ontology.ttl
+models/example/metadata-turtle.ttl
+```
+
+## Purpose and pipeline role
+
+The script generates distribution-level metadata for the model's Turtle serialization. It is intended to run **before** model-level `metadata.ttl` is generated.
+
+The model-level source of truth is `metadata.yaml`. The Turtle generator does **not** update `metadata.ttl`, and it does **not** add model-level `dcat:distribution` triples. Instead, the generated `metadata-turtle.ttl` file points back to the model with `dct:isPartOf`.
+
+`metadata.ttl` is the final model-level aggregation product of the metadata workflow. The later `scripts/metadata_yaml_to_ttl.py` step should aggregate `metadata-turtle.ttl` and the other distribution metadata files into model-level `metadata.ttl`.
+
+Recommended future generation order:
+
+```text
+metadata.yaml + ontology.ttl
+  -> metadata-turtle.ttl
+
+metadata.yaml + metadata-turtle.ttl + other distribution metadata
+  -> metadata.ttl
+```
+
+This document only describes the Turtle metadata generator. No GitHub Actions workflow, CI configuration, or full automation pipeline is created by this script.
+
+## Generated RDF semantics
+
+For each `ontology.ttl` file, the script creates one `dcat:Distribution` metadata file following the RDF pattern used by existing Turtle distribution metadata files.
+
+The generated distribution includes:
+
+- `rdf:type dcat:Distribution`
+- `dct:isPartOf`, pointing to the preserved or generated model dataset URI
+- `dct:issued`, derived from model-level `metadata.yaml`
+- `dct:license`, copied from existing Turtle metadata or derived from model-level `metadata.yaml` when available
+- `dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>`
+- `dct:title`
+- `dcat:downloadURL`, pointing to the raw GitHub URL of `ontology.ttl`
+- `ocmv:isComplete true`, because `ontology.ttl` is the complete linked-data materialization of the model
+- `fdpo:metadataIssued`
+- `fdpo:metadataModified`
+
+If an existing `metadata-turtle.ttl` contains `skos:editorialNote`, the value is preserved. The generator does not add a new editorial note by default because existing Turtle distribution metadata does not require one.
+
+## Existing metadata preservation
+
+When regenerating an existing `metadata-turtle.ttl` file, the script preserves curated values that should not be changed accidentally:
+
+- the existing distribution URI;
+- the existing model URI used in `dct:isPartOf`;
+- `dct:title`;
+- `skos:editorialNote`, if present;
+- `dcat:downloadURL`;
+- `dct:license`;
+- the exact lexical value of `fdpo:metadataIssued`;
+- the exact lexical value of `fdpo:metadataModified` when the regenerated file is otherwise unchanged.
+
+Preserving exact timestamp lexical values avoids changes such as nanosecond truncation or conversion from `Z` to `+00:00` when existing `xsd:dateTime` literals are parsed.
+
+Timestamp handling follows the same maintenance strategy used by `scripts/metadata_yaml_to_ttl.py` and `scripts/generate_png_metadata.py`:
+
+- if an existing Turtle metadata file has `fdpo:metadataIssued`, that value is preserved;
+- if there is no existing Turtle metadata file, or the existing file has no `fdpo:metadataIssued`, the value is initialized from `--metadata-timestamp`;
+- if an existing Turtle metadata file changes during regeneration, `fdpo:metadataModified` is updated from `--metadata-timestamp`;
+- if an existing Turtle metadata file is already up to date, `fdpo:metadataModified` is preserved.
+
+For existing files, the script still regenerates the remaining triples from model metadata and script defaults, including `dct:issued`, `dcat:mediaType`, and `ocmv:isComplete`.
+
+## License handling
+
+By default, model-level `metadata.yaml` must contain a usable `license` value. This matches the policy of `scripts/metadata_yaml_to_ttl.py` and `scripts/generate_png_metadata.py`: license metadata is mandatory unless the legacy-compatibility option is explicitly used.
+
+Use `--allow-missing-license` only for legacy datasets that intentionally lack license metadata:
+
+```bash
+python scripts/generate_turtle_metadata.py models/<model-directory> --allow-missing-license \
+  --metadata-timestamp 2024-01-02T03:04:05Z
+```
+
+When `--allow-missing-license` is used and no model-level license is present:
+
+- an existing Turtle-level `dct:license` is preserved when regenerating an existing `metadata-turtle.ttl` file;
+- new Turtle metadata files omit `dct:license`;
+- generation continues so older catalog entries can be processed.
+
+When `--allow-missing-license` is not used, missing or unusable license metadata is a fatal error. This keeps license metadata enforceable for future datasets.
+
+When model-level license metadata is available, the generated metadata contains a `dct:license` triple even if `--allow-missing-license` is also used.
+
+## Defaults for new Turtle metadata files
+
+For new files, the script generates a catalog-style title:
+
+```text
+Turtle distribution of <model title>
+```
+
+The generated media type is:
+
+```text
+https://www.iana.org/assignments/media-types/text/turtle
+```
+
+The generated completeness value is:
+
+```text
+ocmv:isComplete true
+```
+
+This differs from PNG distribution metadata. PNG diagrams are incomplete diagrammatic views, whereas `ontology.ttl` is a complete machine-readable linked-data serialization of the model.
+
+## Distribution identifiers
+
+Existing `metadata-turtle.ttl` files keep their current distribution URI. This avoids changing already published W3IDs.
+
+For new Turtle metadata files, the script creates a deterministic UUIDv5 distribution URI under:
+
+```text
+https://w3id.org/ontouml-models/distribution/<uuid>/
+```
+
+The deterministic UUID input is:
+
+```text
+<model-uri>|ontology.ttl
+```
+
+This keeps new-file generation reproducible while preserving the catalog's established UUID-based distribution URI pattern.
+
+## Model identifiers used in `dct:isPartOf`
+
+The script resolves the model URI for Turtle distribution metadata in this order:
+
+1. an existing `dct:isPartOf` value in `metadata-turtle.ttl`, when present;
+2. an existing `dct:isPartOf` value in another distribution metadata file in the same dataset folder, when available and unambiguous;
+3. an explicit HTTP(S) model URI in `metadata.yaml`, if such a field is present;
+4. a deterministic UUIDv5 URI generated from the dataset folder name, using the same strategy as `scripts/metadata_yaml_to_ttl.py`.
+
+The script intentionally does **not** read model-level `metadata.ttl` for model URI preservation. This avoids making distribution metadata generation depend on a later aggregation product.
+
+If `metadata.ttl` exists but no existing distribution metadata file provides a usable `dct:isPartOf`, the script fails clearly instead of silently minting a new model URI. This protects existing catalog datasets from accidental replacement of UUID-based model W3IDs by newly generated identifiers.
+
+The same protection applies when an existing `metadata-turtle.ttl` file is present but does not contain a usable `dct:isPartOf`, unless another distribution metadata file or an explicit HTTP(S) URI in `metadata.yaml` provides the model URI.
+
+If multiple existing distribution metadata files provide conflicting `dct:isPartOf` values, including conflicts between `metadata-turtle.ttl` and another distribution metadata file, the script fails clearly and reports the conflict instead of guessing.
+
+## Download URLs
+
+For new metadata files, `dcat:downloadURL` values are generated as raw GitHub URLs using:
+
+- `--repository`
+- `--branch`
+- `--models-dir-name`
+- the dataset folder name
+- `ontology.ttl`
+
+By default, generated URLs point to:
+
+```text
+https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/<model-directory>/ontology.ttl
+```
+
+Existing `dcat:downloadURL` values are preserved when regenerating existing metadata files.
+
+When generating new URLs, path segments are URL-quoted where needed, but commas are left unescaped to match the existing catalog style.
+
+## Source validation
+
+Before writing metadata, the script validates that:
+
+- the dataset folder exists;
+- `metadata.yaml` exists and can be parsed as YAML;
+- `ontology.ttl` exists;
+- `ontology.ttl` can be parsed as Turtle by RDFLib;
+- existing distribution metadata files used for preservation can be read and parsed when needed;
+- no conflicting model IRIs are found;
+- a required timestamp is available.
+
+The script builds the complete output content before writing the file, preventing partial dataset updates when validation fails.
+
+## Requirements
+
+Install the script dependencies:
+
+```bash
+python -m pip install -r scripts/requirements.txt
+```
+
+The Turtle metadata generator requires `rdflib` and `PyYAML`. Tests require `pytest`. These dependencies are already used by the repository scripts.
+
+## Usage
+
+Run from the repository root.
+
+Commands that create new Turtle metadata files, initialize missing `fdpo:metadataIssued`, or update `fdpo:metadataModified` require `--metadata-timestamp`. Use a fixed timestamp for deterministic automation runs. Use `--metadata-timestamp now` only for manual, intentionally non-deterministic execution.
+
+Generate metadata for one dataset folder:
+
+```bash
+python scripts/generate_turtle_metadata.py models/<model-directory> \
+  --metadata-timestamp 2024-01-02T03:04:05Z
+```
+
+Generate metadata for multiple dataset folders:
+
+```bash
+python scripts/generate_turtle_metadata.py models/<model-1> models/<model-2> \
+  --metadata-timestamp 2024-01-02T03:04:05Z
+```
+
+Generate metadata for all dataset folders under `models/`:
+
+```bash
+python scripts/generate_turtle_metadata.py --all --models-dir models \
+  --metadata-timestamp 2024-01-02T03:04:05Z
+```
+
+Generate all Turtle metadata while allowing legacy datasets without license metadata:
+
+```bash
+python scripts/generate_turtle_metadata.py --all --models-dir models --allow-missing-license \
+  --metadata-timestamp 2024-01-02T03:04:05Z
+```
+
+Preview generation without writing files:
+
+```bash
+python scripts/generate_turtle_metadata.py models/<model-directory> --dry-run \
+  --metadata-timestamp 2024-01-02T03:04:05Z
+```
+
+Check whether files are up to date without writing them. The command exits with code `1` if `metadata-turtle.ttl` would change:
+
+```bash
+python scripts/generate_turtle_metadata.py models/<model-directory> --check \
+  --metadata-timestamp 2024-01-02T03:04:05Z
+```
+
+Fail when the generated file already exists. This check is atomic at dataset level: no metadata file is written if the target already exists:
+
+```bash
+python scripts/generate_turtle_metadata.py models/<model-directory> --no-overwrite \
+  --metadata-timestamp 2024-01-02T03:04:05Z
+```
+
+Use a different repository or branch in generated `dcat:downloadURL` values:
+
+```bash
+python scripts/generate_turtle_metadata.py models/<model-directory> \
+  --repository pedropaulofb/ontouml-models-dev \
+  --branch master \
+  --metadata-timestamp 2024-01-02T03:04:05Z
+```
+
+Use a different repository-relative models path in generated `dcat:downloadURL` values:
+
+```bash
+python scripts/generate_turtle_metadata.py models/<model-directory> \
+  --models-dir-name models \
+  --metadata-timestamp 2024-01-02T03:04:05Z
+```
+
+Use a fixed timestamp for new metadata files, for existing metadata files that do not already contain `fdpo:metadataIssued`, or for existing metadata files that will change and therefore need an updated `fdpo:metadataModified`. The value must use an `xsd:dateTime` lexical form such as `2024-01-02T03:04:05Z`:
+
+```bash
+python scripts/generate_turtle_metadata.py models/<model-directory> \
+  --metadata-timestamp 2024-01-02T03:04:05Z
+```
+
+Use `--metadata-timestamp now` only when a non-deterministic current execution timestamp is intentionally desired.
+
+Run from inside a dataset folder that contains `metadata.yaml`:
+
+```bash
+python ../../scripts/generate_turtle_metadata.py \
+  --metadata-timestamp 2024-01-02T03:04:05Z
+```
+
+## Command-line arguments
+
+| Argument | Required | Default | Meaning |
+| --- | --- | --- | --- |
+| `datasets` | No | current directory if it contains `metadata.yaml` | One or more model dataset folders to process. |
+| `--all` | No | off | Process all dataset folders below `--models-dir`. Cannot be combined with explicit dataset folders. |
+| `--models-dir PATH` | No | `models` | Models directory used with `--all`. |
+| `--allow-missing-license` | No | off | Allow legacy datasets without license metadata. Without it, license is mandatory. |
+| `--check` | No | off | Do not write files; exit `1` if `metadata-turtle.ttl` would change. |
+| `--dry-run` | No | off | Validate inputs and report files that would be generated without writing them. |
+| `--format {text,json}` | No | `text` | Summary output format for non-interactive use. |
+| `--quiet`, `--silent`, `-q` | No | off | Suppress progress and text summary output. Errors still go to `stderr`. |
+| `--repository OWNER/REPO` | No | `OntoUML/ontouml-models` | GitHub repository used for generated `dcat:downloadURL` values. |
+| `--branch BRANCH` | No | `master` | Git branch used for generated `dcat:downloadURL` values. |
+| `--models-dir-name PATH` | No | `models` | Repository-relative models path used inside generated `dcat:downloadURL` values. |
+| `--model-iri-base IRI` | No | `https://w3id.org/ontouml-models/model` | Base IRI used for deterministic UUIDv5 model IRIs when no existing catalog model IRI is available. |
+| `--no-overwrite` | No | overwrite enabled | Fail if `metadata-turtle.ttl` already exists. |
+| `--metadata-timestamp VALUE` | Conditional | none | `xsd:dateTime` value used to initialize missing `fdpo:metadataIssued` values and update `fdpo:metadataModified` when existing metadata files change. Required when creating new metadata files, when existing metadata files lack `fdpo:metadataIssued`, or when existing files need regeneration changes. |
+
+## Input assumptions
+
+Each dataset folder must contain:
+
+```text
+metadata.yaml
+ontology.ttl
+```
+
+The model-level `metadata.yaml` must provide enough information for the script to determine:
+
+- the model title;
+- the model issued date;
+- the model license, unless `--allow-missing-license` is used for a legacy dataset.
+
+The model URI is normally preserved from existing distribution metadata. For a genuinely new dataset, the script uses the same deterministic UUIDv5 fallback strategy as `scripts/metadata_yaml_to_ttl.py`.
+
+## Exit codes
+
+| Exit code | Meaning |
+| --- | --- |
+| `0` | Generation/check completed successfully. In `--check` mode, no changes are needed. |
+| `1` | Dataset processing failed, or `--check` detected required updates. |
+| `2` | Command-line, discovery, or setup error prevented normal execution. |
+
+## JSON and quiet output
+
+Use JSON output for automation-friendly reporting:
+
+```bash
+python scripts/generate_turtle_metadata.py models/<model-directory> \
+  --format json \
+  --metadata-timestamp 2024-01-02T03:04:05Z
+```
+
+Use quiet mode to suppress normal text progress and summary output:
+
+```bash
+python scripts/generate_turtle_metadata.py models/<model-directory> --quiet \
+  --metadata-timestamp 2024-01-02T03:04:05Z
+```
+
+Errors are still printed to `stderr`.
+
+## Future workflow context
+
+A future maintenance workflow may eventually run the distribution metadata generators before the final model-level converter, for example:
+
+```text
+python scripts/validate_metadata_yaml.py --all --models-dir models --fix --allow-missing-license
+python scripts/generate_png_metadata.py --all --models-dir models --allow-missing-license --metadata-timestamp now
+python scripts/generate_json_metadata.py --all --models-dir models --allow-missing-license --metadata-timestamp now
+python scripts/generate_turtle_metadata.py --all --models-dir models --allow-missing-license --metadata-timestamp now
+python scripts/generate_vpp_metadata.py --all --models-dir models --allow-missing-license --metadata-timestamp now
+python scripts/metadata_yaml_to_ttl.py --all --models-dir models --allow-missing-license --metadata-timestamp now
+```
+
+This workflow is only context. This script does not create or modify any workflow configuration.

--- a/scripts/generate_turtle_metadata.py
+++ b/scripts/generate_turtle_metadata.py
@@ -1,0 +1,1215 @@
+"""Generate RDF/Turtle metadata for OntoUML catalog Turtle distributions.
+
+The script scans one or more model dataset folders and creates one Turtle
+metadata file for the model's linked-data serialization:
+
+- ontology.ttl -> metadata-turtle.ttl
+
+Run from the repository root, for example:
+
+    python scripts/generate_turtle_metadata.py models/amaral2019rot \
+      --metadata-timestamp 2026-06-23T12:00:00Z
+    python scripts/generate_turtle_metadata.py --all --models-dir models \
+      --allow-missing-license --metadata-timestamp now
+
+The model-level source of truth is metadata.yaml. Existing distribution
+metadata files are read only to preserve stable distribution identifiers,
+existing model W3IDs used by dct:isPartOf, and curated distribution-level
+values during regeneration. This script does not read or update model-level
+metadata.ttl; metadata.ttl is generated later by scripts/metadata_yaml_to_ttl.py.
+"""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import json
+import re
+import sys
+import uuid
+from dataclasses import asdict, dataclass
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Optional, Sequence
+from urllib.parse import quote
+
+try:
+    import yaml
+except ImportError as exc:  # pragma: no cover - dependency failure only
+    raise SystemExit(
+        "PyYAML is required. Install it with: python -m pip install -r scripts/requirements.txt"
+    ) from exc
+
+try:
+    from rdflib import Graph, Literal, Namespace, URIRef
+    from rdflib.namespace import DCTERMS as DCT, RDF, RDFS, SKOS, XSD
+except ImportError as exc:  # pragma: no cover - dependency failure only
+    raise SystemExit(
+        "RDFLib is required. Install it with: python -m pip install -r scripts/requirements.txt"
+    ) from exc
+
+DCAT = Namespace("http://www.w3.org/ns/dcat#")
+FDPO = Namespace("https://w3id.org/fdp/fdp-o#")
+OCMV = Namespace("https://w3id.org/ontouml-models/vocabulary#")
+OWL = Namespace("http://www.w3.org/2002/07/owl#")
+
+TURTLE_SOURCE_FILE = "ontology.ttl"
+TURTLE_METADATA_FILE = "metadata-turtle.ttl"
+TURTLE_MEDIA_TYPE = URIRef("https://www.iana.org/assignments/media-types/text/turtle")
+DISTRIBUTION_BASE = "https://w3id.org/ontouml-models/distribution/"
+DEFAULT_REPOSITORY = "OntoUML/ontouml-models"
+DEFAULT_BRANCH = "master"
+DEFAULT_MODELS_DIR = "models"
+DEFAULT_MODEL_IRI_BASE = "https://w3id.org/ontouml-models/model"
+
+LICENSE_ALIASES = {
+    "ccby40": "https://creativecommons.org/licenses/by/4.0/",
+    "creativecommonsattribution40international": "https://creativecommons.org/licenses/by/4.0/",
+    "ccbysa40": "https://creativecommons.org/licenses/by-sa/4.0/",
+    "creativecommonsattributionsharealike40international": "https://creativecommons.org/licenses/by-sa/4.0/",
+    "ccbysa30": "https://creativecommons.org/licenses/by-sa/3.0/",
+    "creativecommonsattributionsharealike30unported": "https://creativecommons.org/licenses/by-sa/3.0/",
+    "cc010": "https://creativecommons.org/publicdomain/zero/1.0/",
+    "creativecommonszero10universaldomainpublicdedication": "https://creativecommons.org/publicdomain/zero/1.0/",
+    "mit": "http://spdx.org/licenses/MIT",
+}
+
+CONTROL_CHARS = re.compile(r"[\x00-\x1f\x7f]")
+DATE_YEAR_RE = re.compile(r"^\d{4}$")
+DATE_YEAR_MONTH_RE = re.compile(r"^\d{4}-\d{2}$")
+DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+XSD_DATETIME_RE = re.compile(
+    r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})?$"
+)
+HTTP_URI_RE = re.compile(r"^https?://", re.I)
+DISTRIBUTION_IRI_RE = re.compile(r"<([^>]+)>\s+a\s+[^.;]*\bdcat:Distribution\b", re.S)
+IS_PART_OF_RE = re.compile(r"\bdct:isPartOf\s+<([^>]+)>", re.S)
+FULL_IS_PART_OF_RE = re.compile(
+    r"<http://purl\.org/dc/terms/isPartOf>\s+<([^>]+)>", re.S
+)
+PREFIXED_DATETIME_RE_TEMPLATE = r"\bfdpo:{name}\s+\"([^\"]+)\"\^\^xsd:dateTime"
+FULL_DATETIME_RE_TEMPLATE = (
+    r"<https://w3id\.org/fdp/fdp-o#{name}>\s+\"([^\"]+)\"\^\^"
+    r"<http://www\.w3\.org/2001/XMLSchema#dateTime>"
+)
+
+
+class MetadataSetupError(RuntimeError):
+    """Raised when command-line or discovery setup prevents execution."""
+
+
+class MetadataGenerationError(RuntimeError):
+    """Raised when a dataset cannot be processed safely."""
+
+
+@dataclass(frozen=True)
+class Config:
+    """Configuration for Turtle distribution metadata generation."""
+
+    repository: str = DEFAULT_REPOSITORY
+    branch: str = DEFAULT_BRANCH
+    models_dir_name: str = DEFAULT_MODELS_DIR
+    model_iri_base: str = DEFAULT_MODEL_IRI_BASE
+    overwrite: bool = True
+    dry_run: bool = False
+    check: bool = False
+    metadata_timestamp: Optional[str] = None
+    allow_missing_license: bool = False
+    # Deprecated compatibility shim for older callers that used Config(require_license=True).
+    require_license: Optional[bool] = None
+    emit_diff: bool = False
+    quiet: bool = False
+
+
+@dataclass(frozen=True)
+class ModelMetadata:
+    """Minimum model metadata required to describe its Turtle distribution."""
+
+    uri: URIRef
+    title: str
+    license_uri: Optional[URIRef]
+    issued: Literal
+
+
+@dataclass(frozen=True)
+class ExistingDistributionMetadata:
+    """Reusable metadata found in an existing distribution metadata file."""
+
+    uri: Optional[URIRef] = None
+    model_uri: Optional[URIRef] = None
+    title: Optional[Literal] = None
+    editorial_note: Optional[Literal] = None
+    download_url: Optional[URIRef] = None
+    license_uri: Optional[URIRef] = None
+    metadata_issued: Optional[Literal] = None
+    metadata_modified: Optional[Literal] = None
+
+
+@dataclass(frozen=True)
+class TurtleDistribution:
+    """Discovered ontology.ttl source and derived output metadata information."""
+
+    source_path: Path
+    output_path: Path
+    distribution_uri: URIRef
+    download_url: URIRef
+    existing_metadata: ExistingDistributionMetadata
+
+
+@dataclass(frozen=True)
+class GeneratedFile:
+    """Result of generating or checking one metadata file."""
+
+    source_path: Path
+    metadata_path: Path
+    distribution_uri: URIRef
+    changed: bool
+    written: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        data["source_path"] = str(self.source_path)
+        data["metadata_path"] = str(self.metadata_path)
+        data["distribution_uri"] = str(self.distribution_uri)
+        return data
+
+
+class MetadataYamlLoader(yaml.SafeLoader):
+    """Safe YAML loader preserving date-like scalar lexical forms."""
+
+
+MetadataYamlLoader.yaml_implicit_resolvers = {
+    key: [
+        resolver
+        for resolver in resolvers
+        if resolver[0] != "tag:yaml.org,2002:timestamp"
+    ]
+    for key, resolvers in yaml.SafeLoader.yaml_implicit_resolvers.items()
+}
+
+
+def _construct_mapping_no_duplicates(
+    loader: MetadataYamlLoader, node: yaml.MappingNode, deep: bool = False
+) -> dict[Any, Any]:
+    """Construct YAML mappings while rejecting duplicate keys."""
+
+    mapping: dict[Any, Any] = {}
+    for key_node, value_node in node.value:
+        key = loader.construct_object(key_node, deep=deep)
+        if key in mapping:
+            raise yaml.constructor.ConstructorError(
+                "while constructing a mapping",
+                node.start_mark,
+                f"found duplicate key {key!r}",
+                key_node.start_mark,
+            )
+        mapping[key] = loader.construct_object(value_node, deep=deep)
+    return mapping
+
+
+MetadataYamlLoader.add_constructor(
+    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+    _construct_mapping_no_duplicates,
+)
+
+
+def bind_prefixes(graph: Graph) -> None:
+    """Bind prefixes used by catalog distribution metadata."""
+
+    graph.bind("fdpo", FDPO)
+    graph.bind("dcat", DCAT)
+    graph.bind("dct", DCT)
+    graph.bind("ocmv", OCMV)
+    graph.bind("owl", OWL)
+    graph.bind("rdf", RDF)
+    graph.bind("rdfs", RDFS)
+    graph.bind("skos", SKOS)
+    graph.bind("xsd", XSD)
+
+
+def effective_allow_missing_license(config: Config) -> bool:
+    """Return the active missing-license policy."""
+
+    if config.require_license is True:
+        return False
+    return config.allow_missing_license
+
+
+def validate_dataset_folder(
+    dataset_folder: Path, *, require_metadata_yaml: bool = True
+) -> Path:
+    """Return a normalized dataset folder path or raise a setup error."""
+
+    dataset_folder = dataset_folder.resolve()
+    if not dataset_folder.exists():
+        raise MetadataSetupError(f"Dataset folder does not exist: {dataset_folder}")
+    if not dataset_folder.is_dir():
+        raise MetadataSetupError(f"Dataset path is not a directory: {dataset_folder}")
+    if require_metadata_yaml and not (dataset_folder / "metadata.yaml").exists():
+        raise MetadataSetupError(
+            f"Missing metadata.yaml in dataset folder: {dataset_folder}"
+        )
+    return dataset_folder
+
+
+def normalize_model_uri(uri: URIRef) -> URIRef:
+    """Normalize model URIs for distribution metadata."""
+
+    return URIRef(str(uri).rstrip("/"))
+
+
+def load_yaml_mapping(path: Path) -> Mapping[str, Any]:
+    """Load a YAML file and ensure its root node is a mapping."""
+
+    try:
+        data = yaml.load(path.read_text(encoding="utf-8"), Loader=MetadataYamlLoader)
+    except yaml.YAMLError as exc:
+        raise MetadataGenerationError(f"Could not parse {path}: {exc}") from exc
+    except OSError as exc:
+        raise MetadataGenerationError(f"Could not read {path}: {exc}") from exc
+
+    if data is None:
+        raise MetadataGenerationError(f"Canonical metadata file is empty: {path}")
+    if not isinstance(data, Mapping):
+        raise MetadataGenerationError(
+            f"Canonical metadata file must contain a YAML mapping: {path}"
+        )
+    return data
+
+
+def canonical_key(value: object) -> str:
+    """Return a normalized key or identifier for permissive matching."""
+
+    return re.sub(r"[^a-z0-9]", "", str(value).lower())
+
+
+def yaml_mapping_get(mapping: Mapping[str, Any], key: str) -> Any:
+    """Return a mapping value using case-insensitive key matching."""
+
+    wanted = canonical_key(key)
+    for candidate, value in mapping.items():
+        if canonical_key(candidate) == wanted:
+            return value
+    return None
+
+
+def yaml_value_at_path(data: Any, path: Sequence[str]) -> Any:
+    current = data
+    for key in path:
+        if not isinstance(current, Mapping):
+            return None
+        current = yaml_mapping_get(current, key)
+        if current is None:
+            return None
+    return current
+
+
+def yaml_first_value(data: Mapping[str, Any], paths: Sequence[Sequence[str]]) -> Any:
+    for path in paths:
+        value = yaml_value_at_path(data, path)
+        if value is not None:
+            return value
+    return None
+
+
+def yaml_text(value: Any) -> Optional[str]:
+    """Extract human-readable text from common YAML scalar or language-map forms."""
+
+    if value is None:
+        return None
+    if isinstance(value, Mapping):
+        for key in ("en", "eng", "english", "value", "label", "title", "name"):
+            text = yaml_text(yaml_mapping_get(value, key))
+            if text:
+                return text
+        for nested in value.values():
+            text = yaml_text(nested)
+            if text:
+                return text
+        return None
+    if isinstance(value, list):
+        for item in value:
+            text = yaml_text(item)
+            if text:
+                return text
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def yaml_issued_literal(value: Any) -> Optional[Literal]:
+    """Return an RDF literal for a model issued value."""
+
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        text = value.isoformat()
+        return Literal(text, datatype=XSD.dateTime, normalize=False)
+    if isinstance(value, date):
+        return Literal(value.isoformat(), datatype=XSD.date, normalize=False)
+
+    text = yaml_text(value)
+    if not text:
+        return None
+    if DATE_YEAR_RE.match(text):
+        return Literal(text, datatype=XSD.gYear, normalize=False)
+    if DATE_YEAR_MONTH_RE.match(text):
+        return Literal(text, datatype=XSD.gYearMonth, normalize=False)
+    if DATE_RE.match(text):
+        return Literal(text, datatype=XSD.date, normalize=False)
+    if XSD_DATETIME_RE.match(text):
+        return Literal(text, datatype=XSD.dateTime, normalize=False)
+    raise MetadataGenerationError(
+        f"Unsupported issued date value {text!r}; expected YYYY, YYYY-MM, YYYY-MM-DD, or xsd:dateTime."
+    )
+
+
+def yaml_license_uri(value: Any) -> Optional[URIRef]:
+    """Return a license URI from common scalar or mapping forms."""
+
+    if value is None:
+        return None
+    if isinstance(value, Mapping):
+        for key in ("uri", "url", "id", "identifier", "license", "value"):
+            result = yaml_license_uri(yaml_mapping_get(value, key))
+            if result is not None:
+                return result
+        return None
+    if isinstance(value, list):
+        for item in value:
+            result = yaml_license_uri(item)
+            if result is not None:
+                return result
+        return None
+
+    text = str(value).strip()
+    if not text:
+        return None
+    if HTTP_URI_RE.match(text):
+        return URIRef(text)
+    alias = LICENSE_ALIASES.get(canonical_key(text))
+    if alias:
+        return URIRef(alias)
+    raise MetadataGenerationError(
+        f"Unsupported license value {text!r}; use a license URI or a supported alias such as CC-BY-4.0."
+    )
+
+
+def deterministic_model_uri(dataset_folder: Path, model_iri_base: str) -> URIRef:
+    """Return the converter-compatible deterministic model URI for a new dataset."""
+
+    slug = dataset_folder.name.strip().strip("/")
+    if not slug:
+        raise MetadataGenerationError(
+            "Could not infer model URI because the dataset folder has no name."
+        )
+    base = model_iri_base.rstrip("/")
+    generated_uuid = uuid.uuid5(uuid.NAMESPACE_URL, f"{base}|{slug}")
+    return URIRef(f"{base}/{generated_uuid}")
+
+
+def explicit_yaml_model_uri(data: Mapping[str, Any]) -> Optional[URIRef]:
+    """Return an explicit HTTP(S) model URI from YAML, if such a field is present."""
+
+    value = yaml_first_value(
+        data,
+        (
+            ("uri",),
+            ("modelUri",),
+            ("modelURI",),
+            ("model", "uri"),
+            ("metadata", "uri"),
+            ("resource", "uri"),
+        ),
+    )
+    text = yaml_text(value)
+    if not text:
+        return None
+    if HTTP_URI_RE.match(text):
+        return normalize_model_uri(URIRef(text))
+    raise MetadataGenerationError(
+        f"Explicit model URI in metadata.yaml must be an HTTP(S) URI; got {text!r}."
+    )
+
+
+def load_model_metadata(
+    dataset_folder: Path, config: Config
+) -> tuple[ModelMetadata, bool]:
+    """Load title, issued date, optional license, and optional URI from metadata.yaml."""
+
+    metadata_path = dataset_folder / "metadata.yaml"
+    if not metadata_path.exists():
+        raise MetadataGenerationError(
+            f"Missing required canonical metadata file: {metadata_path}"
+        )
+
+    data = load_yaml_mapping(metadata_path)
+    title = yaml_text(
+        yaml_first_value(
+            data,
+            (
+                ("title",),
+                ("model", "title"),
+                ("metadata", "title"),
+                ("resource", "title"),
+                ("ontology", "title"),
+                ("name",),
+            ),
+        )
+    )
+    if not title:
+        raise MetadataGenerationError(f"Missing required title in {metadata_path}")
+
+    issued_literal = yaml_issued_literal(
+        yaml_first_value(
+            data,
+            (
+                ("issued",),
+                ("dateIssued",),
+                ("issuedDate",),
+                ("issued_date",),
+                ("date",),
+                ("metadata", "issued"),
+                ("metadata", "dateIssued"),
+                ("metadata", "date"),
+                ("model", "issued"),
+                ("model", "dateIssued"),
+                ("resource", "issued"),
+                ("resource", "dateIssued"),
+                ("publication", "issued"),
+                ("publication", "date"),
+                ("publicationDate",),
+            ),
+        )
+    )
+    if issued_literal is None:
+        raise MetadataGenerationError(
+            f"Missing required issued date in {metadata_path}"
+        )
+
+    license_ref = yaml_license_uri(
+        yaml_first_value(
+            data,
+            (
+                ("license",),
+                ("licenseUrl",),
+                ("licenseUri",),
+                ("metadata", "license"),
+                ("metadata", "licenseUrl"),
+                ("metadata", "licenseUri"),
+                ("model", "license"),
+                ("resource", "license"),
+                ("rights", "license"),
+                ("rights", "licenseUrl"),
+                ("rights", "licenseUri"),
+            ),
+        )
+    )
+    if license_ref is None and not effective_allow_missing_license(config):
+        raise MetadataGenerationError(
+            "Missing mandatory metadata field(s): license. "
+            "Use --allow-missing-license only for legacy datasets that intentionally lack license metadata."
+        )
+
+    explicit_uri = explicit_yaml_model_uri(data)
+    model_uri = explicit_uri or deterministic_model_uri(
+        dataset_folder, config.model_iri_base
+    )
+    return (
+        ModelMetadata(
+            uri=model_uri,
+            title=title,
+            license_uri=license_ref,
+            issued=issued_literal,
+        ),
+        explicit_uri is not None,
+    )
+
+
+def is_part_of_uri_from_text(text: str) -> Optional[URIRef]:
+    """Extract a distribution dct:isPartOf URI from Turtle text without full parsing."""
+
+    match = IS_PART_OF_RE.search(text) or FULL_IS_PART_OF_RE.search(text)
+    return normalize_model_uri(URIRef(match.group(1))) if match else None
+
+
+def prefixed_datetime_literal_from_text(text: str, name: str) -> Optional[Literal]:
+    """Preserve exact xsd:dateTime lexical forms from existing Turtle text."""
+
+    patterns = (
+        PREFIXED_DATETIME_RE_TEMPLATE.format(name=name),
+        FULL_DATETIME_RE_TEMPLATE.format(name=name),
+    )
+    for pattern in patterns:
+        match = re.search(pattern, text, re.S)
+        if match:
+            return Literal(match.group(1), datatype=XSD.dateTime, normalize=False)
+    return None
+
+
+def first_object(graph: Graph, subject: URIRef, predicate: URIRef) -> Any:
+    for obj in graph.objects(subject, predicate):
+        return obj
+    return None
+
+
+def read_existing_metadata(path: Path) -> ExistingDistributionMetadata:
+    """Read reusable values from an existing distribution metadata file."""
+
+    if not path.exists():
+        return ExistingDistributionMetadata()
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise MetadataGenerationError(
+            f"Could not read existing metadata file {path}: {exc}"
+        ) from exc
+
+    graph = Graph()
+    bind_prefixes(graph)
+    try:
+        graph.parse(data=text, format="turtle")
+    except Exception as exc:  # noqa: BLE001 - surface RDFLib parse errors clearly
+        raise MetadataGenerationError(
+            f"Could not parse existing distribution metadata {path}: {exc}"
+        ) from exc
+
+    subjects = list(graph.subjects(RDF.type, DCAT.Distribution))
+    if subjects:
+        subject = subjects[0]
+    else:
+        match = DISTRIBUTION_IRI_RE.search(text)
+        subject = URIRef(match.group(1)) if match else None
+
+    if subject is None:
+        raise MetadataGenerationError(
+            f"Existing distribution metadata has no dcat:Distribution subject: {path}"
+        )
+
+    download_url = first_object(graph, subject, DCAT.downloadURL)
+    license_uri = first_object(graph, subject, DCT.license)
+    model_uri = first_object(graph, subject, DCT.isPartOf) or is_part_of_uri_from_text(
+        text
+    )
+    return ExistingDistributionMetadata(
+        uri=URIRef(subject),
+        model_uri=normalize_model_uri(URIRef(model_uri))
+        if model_uri is not None
+        else None,
+        title=first_object(graph, subject, DCT.title),
+        editorial_note=first_object(graph, subject, SKOS.editorialNote),
+        download_url=URIRef(download_url) if download_url is not None else None,
+        license_uri=URIRef(license_uri) if license_uri is not None else None,
+        metadata_issued=prefixed_datetime_literal_from_text(text, "metadataIssued")
+        or first_object(graph, subject, FDPO.metadataIssued),
+        metadata_modified=prefixed_datetime_literal_from_text(text, "metadataModified")
+        or first_object(graph, subject, FDPO.metadataModified),
+    )
+
+
+def existing_distribution_metadata_paths(dataset_folder: Path) -> list[Path]:
+    """Return existing distribution metadata files, excluding model-level metadata.ttl."""
+
+    return sorted(
+        path
+        for path in dataset_folder.glob("metadata-*.ttl")
+        if path.name != TURTLE_METADATA_FILE and path.name != "metadata.ttl"
+    )
+
+
+def unique_existing_model_uri(
+    uris: Iterable[URIRef], source_description: str
+) -> Optional[URIRef]:
+    """Return one existing model URI or fail on conflicting preserved values."""
+
+    normalized = sorted(
+        {str(normalize_model_uri(uri)) for uri in uris if uri is not None}
+    )
+    if not normalized:
+        return None
+    if len(normalized) > 1:
+        raise MetadataGenerationError(
+            f"Conflicting model URIs found in {source_description}: "
+            + ", ".join(normalized)
+        )
+    return URIRef(normalized[0])
+
+
+def discover_other_distribution_model_uri(dataset_folder: Path) -> Optional[URIRef]:
+    """Discover the preserved model URI from non-target distribution metadata files."""
+
+    model_uris: list[URIRef] = []
+    scanned_paths = existing_distribution_metadata_paths(dataset_folder)
+    for path in scanned_paths:
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            raise MetadataGenerationError(
+                f"Could not read existing distribution metadata {path}: {exc}"
+            ) from exc
+        uri = is_part_of_uri_from_text(text)
+        if uri is not None:
+            model_uris.append(uri)
+    return unique_existing_model_uri(
+        model_uris, f"existing distribution metadata files in {dataset_folder}"
+    )
+
+
+def resolve_model_uri(
+    dataset_folder: Path,
+    existing_target: ExistingDistributionMetadata,
+    yaml_uri: URIRef,
+    *,
+    yaml_uri_is_explicit: bool,
+) -> URIRef:
+    """Return the model URI to use in Turtle distribution metadata.
+
+    Resolution intentionally ignores model-level metadata.ttl so the distribution
+    generator can run before metadata.ttl is created. Existing target metadata has
+    priority, then other distribution metadata, then an explicit YAML URI, and
+    finally the converter-compatible deterministic UUIDv5 URI for genuinely new
+    datasets. Conflicting preserved ``dct:isPartOf`` values across existing
+    distribution metadata files are treated as an error.
+    """
+
+    existing_distribution_uri = discover_other_distribution_model_uri(dataset_folder)
+    if existing_target.model_uri is not None:
+        if existing_distribution_uri is not None and normalize_model_uri(
+            existing_distribution_uri
+        ) != normalize_model_uri(existing_target.model_uri):
+            raise MetadataGenerationError(
+                "Conflicting model URIs found in existing distribution metadata files in "
+                f"{dataset_folder}: {existing_target.model_uri}, {existing_distribution_uri}"
+            )
+        return existing_target.model_uri
+    if existing_distribution_uri is not None:
+        return existing_distribution_uri
+    if yaml_uri_is_explicit:
+        return yaml_uri
+    if existing_target.uri is not None:
+        raise MetadataGenerationError(
+            "Existing metadata-turtle.ttl was found, but it does not provide a usable "
+            "dct:isPartOf model IRI. Refusing to generate a new deterministic model IRI "
+            "for a dataset that appears to be an existing catalog dataset."
+        )
+    if (dataset_folder / "metadata.ttl").exists():
+        raise MetadataGenerationError(
+            "No existing distribution metadata file provides a stable dct:isPartOf model IRI, "
+            "but model-level metadata.ttl exists. This dataset appears to be an existing catalog "
+            "dataset. The Turtle distribution generator does not read metadata.ttl because it must "
+            "be able to run before metadata.ttl is generated. Preserve the model IRI in an existing "
+            "distribution metadata file or confirm that deterministic UUIDv5 generation is intended."
+        )
+    if existing_distribution_metadata_paths(dataset_folder):
+        raise MetadataGenerationError(
+            "Existing distribution metadata files were found, but none provides a usable dct:isPartOf "
+            "model IRI. Refusing to generate a new deterministic model IRI for a dataset that appears "
+            "to be an existing catalog dataset."
+        )
+    return yaml_uri
+
+
+def deterministic_distribution_uri(
+    model: ModelMetadata, source_filename: str
+) -> URIRef:
+    """Return a deterministic distribution URI for a new Turtle metadata file."""
+
+    seed = f"{model.uri}|{source_filename}"
+    return URIRef(f"{DISTRIBUTION_BASE}{uuid.uuid5(uuid.NAMESPACE_URL, seed)}/")
+
+
+def quote_path_segment(segment: str) -> str:
+    """Quote a URL path segment while preserving commas for catalog compatibility."""
+
+    return quote(segment, safe=",-_.~()")
+
+
+def split_path_like(value: str) -> list[str]:
+    """Split a slash-separated path-like CLI value into non-empty segments."""
+
+    return [segment for segment in value.strip("/").split("/") if segment]
+
+
+def default_download_url(dataset_folder: Path, config: Config) -> URIRef:
+    """Return the raw GitHub download URL for ontology.ttl."""
+
+    parts = (
+        ["https://raw.githubusercontent.com"]
+        + [quote_path_segment(part) for part in split_path_like(config.repository)]
+        + [quote_path_segment(config.branch.strip("/"))]
+        + [quote_path_segment(part) for part in split_path_like(config.models_dir_name)]
+        + [quote_path_segment(dataset_folder.name), TURTLE_SOURCE_FILE]
+    )
+    return URIRef("/".join(parts))
+
+
+def validate_source_turtle(path: Path) -> None:
+    """Validate the source ontology.ttl file before generating metadata."""
+
+    if not path.exists():
+        raise MetadataGenerationError(f"Missing required Turtle source file: {path}")
+    if not path.is_file():
+        raise MetadataGenerationError(f"Turtle source path is not a file: {path}")
+    if CONTROL_CHARS.search(path.name):
+        raise MetadataGenerationError(
+            f"Turtle filename contains control characters: {path}"
+        )
+    graph = Graph()
+    try:
+        graph.parse(path, format="turtle")
+    except Exception as exc:  # noqa: BLE001 - surface RDFLib parse errors clearly
+        raise MetadataGenerationError(
+            f"Could not parse Turtle source {path}: {exc}"
+        ) from exc
+
+
+def collect_turtle_distribution(
+    dataset_folder: Path, model: ModelMetadata, config: Config
+) -> TurtleDistribution:
+    """Validate ontology.ttl and derive its output metadata path."""
+
+    source_path = dataset_folder / TURTLE_SOURCE_FILE
+    output_path = dataset_folder / TURTLE_METADATA_FILE
+    validate_source_turtle(source_path)
+    existing = read_existing_metadata(output_path)
+    distribution_uri = existing.uri or deterministic_distribution_uri(
+        model, TURTLE_SOURCE_FILE
+    )
+    download_url = existing.download_url or default_download_url(dataset_folder, config)
+    return TurtleDistribution(
+        source_path=source_path,
+        output_path=output_path,
+        distribution_uri=distribution_uri,
+        download_url=download_url,
+        existing_metadata=existing,
+    )
+
+
+def current_metadata_timestamp() -> Literal:
+    """Return the current UTC timestamp as xsd:dateTime."""
+
+    value = (
+        datetime.now(timezone.utc)
+        .isoformat(timespec="microseconds")
+        .replace("+00:00", "Z")
+    )
+    return Literal(value, datatype=XSD.dateTime, normalize=False)
+
+
+def configured_metadata_timestamp(config: Config, target: Path) -> Literal:
+    """Return the explicit run timestamp used for FDP timestamp changes."""
+
+    if config.metadata_timestamp == "now":
+        return current_metadata_timestamp()
+    if config.metadata_timestamp:
+        if not XSD_DATETIME_RE.match(config.metadata_timestamp):
+            raise MetadataGenerationError(
+                "--metadata-timestamp must be an xsd:dateTime lexical value, "
+                "for example 2024-01-02T03:04:05Z. Use 'now' only when a "
+                "non-deterministic current timestamp is intentionally desired."
+            )
+        return Literal(
+            config.metadata_timestamp, datatype=XSD.dateTime, normalize=False
+        )
+    raise MetadataGenerationError(
+        f"No run timestamp is available to initialize fdpo:metadataIssued or update "
+        f"fdpo:metadataModified in {target}. Provide --metadata-timestamp, for example "
+        "--metadata-timestamp 2026-01-31T12:00:00Z. Use --metadata-timestamp now "
+        "only when a non-deterministic execution timestamp is acceptable."
+    )
+
+
+def turtle_title(model: ModelMetadata) -> str:
+    """Return a catalog-style title for a Turtle distribution."""
+
+    return f"Turtle distribution of {model.title}"
+
+
+def build_distribution_graph(
+    model: ModelMetadata,
+    distribution: TurtleDistribution,
+    config: Config,
+    *,
+    update_metadata_modified: bool = False,
+) -> Graph:
+    """Build RDF metadata for one Turtle distribution."""
+
+    graph = Graph()
+    bind_prefixes(graph)
+
+    run_timestamp: Optional[Literal] = None
+
+    def get_run_timestamp() -> Literal:
+        nonlocal run_timestamp
+        if run_timestamp is None:
+            run_timestamp = configured_metadata_timestamp(
+                config, distribution.output_path
+            )
+        return run_timestamp
+
+    metadata_issued = (
+        distribution.existing_metadata.metadata_issued or get_run_timestamp()
+    )
+    if update_metadata_modified:
+        metadata_modified = get_run_timestamp()
+    else:
+        metadata_modified = (
+            distribution.existing_metadata.metadata_modified or metadata_issued
+        )
+    license_uri = distribution.existing_metadata.license_uri or model.license_uri
+
+    graph.add((distribution.distribution_uri, RDF.type, DCAT.Distribution))
+    graph.add((distribution.distribution_uri, DCT.isPartOf, model.uri))
+    graph.add((distribution.distribution_uri, DCT.issued, model.issued))
+    if license_uri is not None:
+        graph.add((distribution.distribution_uri, DCT.license, license_uri))
+    graph.add((distribution.distribution_uri, DCAT.mediaType, TURTLE_MEDIA_TYPE))
+    graph.add(
+        (
+            distribution.distribution_uri,
+            DCT.title,
+            distribution.existing_metadata.title
+            or Literal(turtle_title(model), lang="en"),
+        )
+    )
+    graph.add(
+        (distribution.distribution_uri, DCAT.downloadURL, distribution.download_url)
+    )
+    graph.add(
+        (
+            distribution.distribution_uri,
+            OCMV.isComplete,
+            Literal(True, datatype=XSD.boolean),
+        )
+    )
+    if distribution.existing_metadata.editorial_note is not None:
+        graph.add(
+            (
+                distribution.distribution_uri,
+                SKOS.editorialNote,
+                distribution.existing_metadata.editorial_note,
+            )
+        )
+    graph.add((distribution.distribution_uri, FDPO.metadataIssued, metadata_issued))
+    graph.add((distribution.distribution_uri, FDPO.metadataModified, metadata_modified))
+    return graph
+
+
+def serialize_graph(graph: Graph) -> str:
+    """Serialize graph as Turtle."""
+
+    return graph.serialize(format="turtle")
+
+
+def write_graph(graph: Graph, target: Path, config: Config) -> None:
+    """Serialize a graph to Turtle."""
+
+    if target.exists() and not config.overwrite:
+        raise MetadataGenerationError(
+            f"Metadata file already exists and overwrite is disabled: {target}"
+        )
+    if config.dry_run or config.check:
+        return
+    target.write_text(serialize_graph(graph), encoding="utf-8")
+
+
+def process_dataset(dataset_folder: Path, config: Config) -> list[GeneratedFile]:
+    """Generate Turtle distribution metadata for one dataset folder."""
+
+    dataset_folder = validate_dataset_folder(dataset_folder)
+    model, yaml_uri_is_explicit = load_model_metadata(dataset_folder, config)
+    existing_target = read_existing_metadata(dataset_folder / TURTLE_METADATA_FILE)
+    resolved_uri = resolve_model_uri(
+        dataset_folder,
+        existing_target,
+        model.uri,
+        yaml_uri_is_explicit=yaml_uri_is_explicit,
+    )
+    if resolved_uri != model.uri:
+        model = ModelMetadata(
+            uri=resolved_uri,
+            title=model.title,
+            license_uri=model.license_uri,
+            issued=model.issued,
+        )
+    distribution = collect_turtle_distribution(dataset_folder, model, config)
+
+    if distribution.output_path.exists() and not config.overwrite:
+        raise MetadataGenerationError(
+            f"Metadata file already exists and overwrite is disabled: {distribution.output_path}"
+        )
+
+    graph = build_distribution_graph(model, distribution, config)
+    old_text = (
+        distribution.output_path.read_text(encoding="utf-8")
+        if distribution.output_path.exists()
+        else None
+    )
+    new_text = serialize_graph(graph)
+    changed = old_text != new_text
+    if changed:
+        graph = build_distribution_graph(
+            model,
+            distribution,
+            config,
+            update_metadata_modified=True,
+        )
+        new_text = serialize_graph(graph)
+        changed = old_text != new_text
+
+    if config.check and changed and config.emit_diff:
+        if old_text is None:
+            print(f"Would create {distribution.output_path}")
+        else:
+            diff = difflib.unified_diff(
+                old_text.splitlines(),
+                new_text.splitlines(),
+                fromfile=str(distribution.output_path),
+                tofile=f"{distribution.output_path} (generated)",
+                lineterm="",
+            )
+            for line in diff:
+                print(line)
+    if changed:
+        write_graph(graph, distribution.output_path, config)
+    return [
+        GeneratedFile(
+            source_path=distribution.source_path,
+            metadata_path=distribution.output_path,
+            distribution_uri=distribution.distribution_uri,
+            changed=changed,
+            written=changed and not config.dry_run and not config.check,
+        )
+    ]
+
+
+def discover_datasets(models_dir: Path) -> list[Path]:
+    """Discover model dataset folders under models_dir by metadata.yaml presence."""
+
+    models_dir = models_dir.resolve()
+    if not models_dir.exists():
+        raise MetadataSetupError(f"Models directory does not exist: {models_dir}")
+    if not models_dir.is_dir():
+        raise MetadataSetupError(f"Models path is not a directory: {models_dir}")
+    return sorted(
+        path
+        for path in models_dir.iterdir()
+        if path.is_dir() and (path / "metadata.yaml").exists()
+    )
+
+
+def resolve_targets(args: argparse.Namespace) -> list[Path]:
+    if args.all:
+        if args.datasets:
+            raise MetadataSetupError(
+                "Use either --all or explicit dataset folders, not both."
+            )
+        datasets = discover_datasets(args.models_dir)
+    elif args.datasets:
+        datasets = [validate_dataset_folder(path) for path in args.datasets]
+    else:
+        cwd = Path.cwd()
+        if (cwd / "metadata.yaml").exists():
+            datasets = [cwd]
+        else:
+            raise MetadataSetupError(
+                "No dataset folder provided. Pass one or more model folders, use --all, or run from a dataset folder."
+            )
+    if not datasets:
+        raise MetadataSetupError("No dataset folders with metadata.yaml were found.")
+    return datasets
+
+
+def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate metadata-turtle.ttl files from ontology.ttl files.",
+    )
+    parser.add_argument(
+        "datasets",
+        nargs="*",
+        type=Path,
+        help="Dataset folder(s) to process. If omitted, the current directory is used when it contains metadata.yaml.",
+    )
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Process all dataset folders below --models-dir.",
+    )
+    parser.add_argument(
+        "--models-dir",
+        type=Path,
+        default=Path(DEFAULT_MODELS_DIR),
+        help=f"Models directory used with --all. Default: {DEFAULT_MODELS_DIR}.",
+    )
+    parser.add_argument(
+        "--allow-missing-license",
+        action="store_true",
+        help="Allow generation for legacy datasets without license metadata; otherwise license is mandatory.",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Do not write files; exit 1 if metadata-turtle.ttl would change.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Validate inputs and report files that would be generated without writing them.",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("text", "json"),
+        default="text",
+        help="Summary output format. Default: text.",
+    )
+    parser.add_argument(
+        "-q",
+        "--quiet",
+        "--silent",
+        action="store_true",
+        help="Suppress per-file progress logs and the final text summary. Errors are still printed to stderr.",
+    )
+    parser.add_argument(
+        "--repository",
+        default=DEFAULT_REPOSITORY,
+        help=f"GitHub repository used for dcat:downloadURL. Default: {DEFAULT_REPOSITORY}.",
+    )
+    parser.add_argument(
+        "--branch",
+        default=DEFAULT_BRANCH,
+        help=f"Git branch used for dcat:downloadURL. Default: {DEFAULT_BRANCH}.",
+    )
+    parser.add_argument(
+        "--models-dir-name",
+        default=DEFAULT_MODELS_DIR,
+        help=f"Repository-relative models path used inside generated dcat:downloadURL values. Default: {DEFAULT_MODELS_DIR}.",
+    )
+    parser.add_argument(
+        "--model-iri-base",
+        default=DEFAULT_MODEL_IRI_BASE,
+        help=f"Base IRI used for deterministic UUIDv5 model IRIs when no existing catalog model IRI is available. Default: {DEFAULT_MODEL_IRI_BASE}.",
+    )
+    parser.add_argument(
+        "--no-overwrite",
+        action="store_true",
+        help="Fail if metadata-turtle.ttl already exists.",
+    )
+    parser.add_argument(
+        "--metadata-timestamp",
+        help=(
+            "xsd:dateTime value used to initialize missing fdpo:metadataIssued values and "
+            "update fdpo:metadataModified when an existing metadata file changes. Required when "
+            "creating new metadata files, when existing files lack fdpo:metadataIssued, or when "
+            "existing files need regeneration changes. Use 'now' only when a non-deterministic "
+            "current timestamp is intentionally desired."
+        ),
+    )
+    parser.add_argument(
+        "--require-license",
+        action="store_true",
+        help=argparse.SUPPRESS,
+    )
+    args = parser.parse_args(argv)
+    if args.check and args.dry_run:
+        parser.error("--check and --dry-run cannot be used together.")
+    if args.allow_missing_license and args.require_license:
+        parser.error(
+            "--allow-missing-license and --require-license cannot be used together."
+        )
+    return args
+
+
+def action_label(config: Config, item: GeneratedFile) -> str:
+    if config.dry_run:
+        return "would generate"
+    if config.check:
+        return "needs update" if item.changed else "up to date"
+    return "generated" if item.written else "unchanged"
+
+
+def print_progress(item: GeneratedFile, config: Config) -> None:
+    print(f"{action_label(config, item)}: {item.metadata_path} <- {item.source_path}")
+
+
+def print_summary(
+    results: Sequence[GeneratedFile], error_count: int, config: Config
+) -> None:
+    if config.dry_run:
+        return
+    changed = sum(1 for item in results if item.changed)
+    written = sum(1 for item in results if item.written)
+    total = len(results) + error_count
+    if config.check:
+        print(
+            f"Summary: {total} file(s) processed, {len(results)} succeeded, "
+            f"{error_count} error(s), {changed} file(s) need update."
+        )
+    else:
+        print(
+            f"Summary: {total} file(s) processed, {len(results)} succeeded, "
+            f"{error_count} error(s), {written} written, {changed} changed."
+        )
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    args = parse_args(argv)
+    config = Config(
+        repository=args.repository,
+        branch=args.branch,
+        models_dir_name=args.models_dir_name,
+        model_iri_base=args.model_iri_base,
+        overwrite=not args.no_overwrite,
+        dry_run=args.dry_run,
+        check=args.check,
+        metadata_timestamp=args.metadata_timestamp,
+        allow_missing_license=args.allow_missing_license,
+        require_license=args.require_license or None,
+        emit_diff=args.format == "text" and not args.quiet,
+        quiet=args.quiet,
+    )
+
+    try:
+        targets = resolve_targets(args)
+    except MetadataSetupError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    results: list[GeneratedFile] = []
+    errors: list[dict[str, str]] = []
+    progress_enabled = args.format == "text" and not args.quiet
+    for target in targets:
+        try:
+            generated = process_dataset(target, config)
+            results.extend(generated)
+            if progress_enabled:
+                for item in generated:
+                    print_progress(item, config)
+        except MetadataGenerationError as exc:
+            errors.append({"dataset": str(target), "error": str(exc)})
+            print(f"ERROR {target}: {exc}", file=sys.stderr)
+
+    if args.format == "json":
+        print(
+            json.dumps(
+                {
+                    "ok": not errors
+                    and not (config.check and any(item.changed for item in results)),
+                    "results": [item.to_dict() for item in results],
+                    "errors": errors,
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+    elif not args.quiet:
+        print_summary(results, len(errors), config)
+
+    if errors:
+        return 1
+    if config.check and any(item.changed for item in results):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_generate_turtle_metadata.py
+++ b/scripts/tests/test_generate_turtle_metadata.py
@@ -1,0 +1,896 @@
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import sys
+import uuid
+from contextlib import redirect_stdout
+from pathlib import Path
+
+import pytest
+
+
+def load_module():
+    script = None
+    for parent in Path(__file__).resolve().parents:
+        for candidate in (
+            parent / "generate_turtle_metadata.py",
+            parent / "scripts" / "generate_turtle_metadata.py",
+        ):
+            if candidate.exists():
+                script = candidate
+                break
+        if script is not None:
+            break
+    assert script is not None
+    spec = importlib.util.spec_from_file_location("generate_turtle_metadata", script)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def write_metadata_yaml(
+    dataset: Path,
+    *,
+    title: str = "Aviation Safety Ontology",
+    issued: str = "2018",
+    license_value: str | None = "https://creativecommons.org/licenses/by/4.0/",
+    uri: str | None = None,
+) -> None:
+    lines = [f"title: {title}", f"issued: {issued}"]
+    if license_value is not None:
+        lines.append(f"license: {license_value}")
+    if uri is not None:
+        lines.append(f"uri: {uri}")
+    (dataset / "metadata.yaml").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def write_ontology(dataset: Path, *, valid: bool = True) -> None:
+    if valid:
+        text = "@prefix ex: <https://example.org/> .\nex:s ex:p ex:o .\n"
+    else:
+        text = "@prefix ex: <https://example.org/> .\nex:s ex:p .\n"
+    (dataset / "ontology.ttl").write_text(text, encoding="utf-8")
+
+
+def make_dataset(tmp_path: Path, name: str = "example-model") -> Path:
+    dataset = tmp_path / "models" / name
+    dataset.mkdir(parents=True)
+    write_metadata_yaml(dataset)
+    write_ontology(dataset)
+    return dataset
+
+
+def deterministic_model_uri(slug: str) -> str:
+    model_uuid = uuid.uuid5(
+        uuid.NAMESPACE_URL, f"https://w3id.org/ontouml-models/model|{slug}"
+    )
+    return f"https://w3id.org/ontouml-models/model/{model_uuid}"
+
+
+def existing_turtle_metadata(
+    *,
+    distribution_uri: str = "https://w3id.org/ontouml-models/distribution/existing-turtle/",
+    model_uri: str | None = "https://w3id.org/ontouml-models/model/existing-model",
+    title: str = "Existing Turtle title",
+    license_uri: str = "https://example.org/existing-license",
+    download_url: str = "https://example.org/existing/ontology.ttl",
+    issued_ts: str = "2023-04-14T17:34:20.99131566Z",
+    modified_ts: str = "2023-04-14T17:34:21.99131566Z",
+    editorial_note: str | None = "Existing Turtle editorial note.",
+) -> str:
+    is_part_of = f"    dct:isPartOf <{model_uri}>;\n" if model_uri else ""
+    editorial = (
+        f'    skos:editorialNote "{editorial_note}"@en;\n'
+        if editorial_note is not None
+        else ""
+    )
+    return (
+        f"""
+@prefix dcat: <http://www.w3.org/ns/dcat#>.
+@prefix dct: <http://purl.org/dc/terms/>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
+@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+
+<{distribution_uri}> a dcat:Distribution;
+{is_part_of}    dct:title "{title}"@en;
+    dct:license <{license_uri}>;
+    dcat:downloadURL <{download_url}>;
+{editorial}    fdpo:metadataIssued "{issued_ts}"^^xsd:dateTime;
+    fdpo:metadataModified "{modified_ts}"^^xsd:dateTime .
+""".strip()
+        + "\n"
+    )
+
+
+def existing_other_distribution(model_uri: str) -> str:
+    return (
+        f"""
+@prefix dcat: <http://www.w3.org/ns/dcat#>.
+@prefix dct: <http://purl.org/dc/terms/>.
+
+<https://w3id.org/ontouml-models/distribution/json-existing/> a dcat:Distribution;
+    dct:isPartOf <{model_uri}> .
+""".strip()
+        + "\n"
+    )
+
+
+def test_turtle_metadata_generation_uses_metadata_yaml_when_metadata_ttl_is_absent(
+    tmp_path: Path,
+):
+    module = load_module()
+    dataset = make_dataset(tmp_path, "new-turtle-model")
+
+    assert not (dataset / "metadata.ttl").exists()
+    generated = module.process_dataset(
+        dataset, module.Config(metadata_timestamp="2024-01-02T03:04:05Z")
+    )
+
+    assert len(generated) == 1
+    output = (dataset / "metadata-turtle.ttl").read_text(encoding="utf-8")
+    assert "https://www.iana.org/assignments/media-types/text/turtle" in output
+    assert "ocmv:isComplete true" in output
+    assert f"dct:isPartOf <{deterministic_model_uri('new-turtle-model')}>" in output
+    assert 'dct:issued "2018"^^xsd:gYear' in output
+    assert "https://creativecommons.org/licenses/by/4.0/" in output
+    assert "Turtle distribution of Aviation Safety Ontology" in output
+    assert "models/new-turtle-model/ontology.ttl" in output
+
+
+def test_generator_has_no_hard_dependency_on_model_level_metadata_ttl(tmp_path: Path):
+    module = load_module()
+    dataset = make_dataset(tmp_path, "no-metadata-ttl")
+
+    module.process_dataset(
+        dataset, module.Config(metadata_timestamp="2024-01-02T03:04:05Z")
+    )
+
+    assert (dataset / "metadata-turtle.ttl").exists()
+    assert not (dataset / "metadata.ttl").exists()
+
+
+def test_existing_turtle_is_part_of_is_preserved(tmp_path: Path):
+    module = load_module()
+    dataset = make_dataset(tmp_path, "existing-target")
+    (dataset / "metadata-turtle.ttl").write_text(
+        existing_turtle_metadata(
+            model_uri="https://w3id.org/ontouml-models/model/preserved-target"
+        ),
+        encoding="utf-8",
+    )
+
+    module.process_dataset(
+        dataset, module.Config(metadata_timestamp="2024-01-02T03:04:05Z")
+    )
+
+    output = (dataset / "metadata-turtle.ttl").read_text(encoding="utf-8")
+    assert "https://w3id.org/ontouml-models/model/preserved-target" in output
+    assert deterministic_model_uri("existing-target") not in output
+
+
+def test_other_distribution_is_part_of_is_used_when_target_metadata_is_absent(
+    tmp_path: Path,
+):
+    module = load_module()
+    dataset = make_dataset(tmp_path, "fallback-other")
+    (dataset / "metadata-json.ttl").write_text(
+        existing_other_distribution("https://w3id.org/ontouml-models/model/from-json"),
+        encoding="utf-8",
+    )
+
+    module.process_dataset(
+        dataset, module.Config(metadata_timestamp="2024-01-02T03:04:05Z")
+    )
+
+    output = (dataset / "metadata-turtle.ttl").read_text(encoding="utf-8")
+    assert "dct:isPartOf <https://w3id.org/ontouml-models/model/from-json>" in output
+
+
+def test_conflicting_other_distribution_model_iris_fail(tmp_path: Path):
+    module = load_module()
+    dataset = make_dataset(tmp_path, "conflict")
+    (dataset / "metadata-json.ttl").write_text(
+        existing_other_distribution("https://w3id.org/ontouml-models/model/a"),
+        encoding="utf-8",
+    )
+    (dataset / "metadata-vpp.ttl").write_text(
+        existing_other_distribution("https://w3id.org/ontouml-models/model/b"),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(module.MetadataGenerationError, match="Conflicting model URIs"):
+        module.process_dataset(
+            dataset, module.Config(metadata_timestamp="2024-01-02T03:04:05Z")
+        )
+
+    assert not (dataset / "metadata-turtle.ttl").exists()
+
+
+def test_conflict_between_target_and_other_distribution_model_iri_fails(
+    tmp_path: Path,
+):
+    module = load_module()
+    dataset = make_dataset(tmp_path, "target-other-conflict")
+    (dataset / "metadata-turtle.ttl").write_text(
+        existing_turtle_metadata(
+            model_uri="https://w3id.org/ontouml-models/model/from-turtle"
+        ),
+        encoding="utf-8",
+    )
+    (dataset / "metadata-json.ttl").write_text(
+        existing_other_distribution("https://w3id.org/ontouml-models/model/from-json"),
+        encoding="utf-8",
+    )
+    original_target = (dataset / "metadata-turtle.ttl").read_text(encoding="utf-8")
+
+    with pytest.raises(module.MetadataGenerationError, match="Conflicting model URIs"):
+        module.process_dataset(
+            dataset, module.Config(metadata_timestamp="2024-01-02T03:04:05Z")
+        )
+
+    assert (dataset / "metadata-turtle.ttl").read_text(
+        encoding="utf-8"
+    ) == original_target
+
+
+def test_existing_target_without_model_iri_fails_without_explicit_or_preserved_source(
+    tmp_path: Path,
+):
+    module = load_module()
+    dataset = make_dataset(tmp_path, "target-no-model-uri")
+    (dataset / "metadata-turtle.ttl").write_text(
+        existing_turtle_metadata(model_uri=None),
+        encoding="utf-8",
+    )
+    original_target = (dataset / "metadata-turtle.ttl").read_text(encoding="utf-8")
+
+    with pytest.raises(module.MetadataGenerationError, match="metadata-turtle.ttl"):
+        module.process_dataset(
+            dataset, module.Config(metadata_timestamp="2024-01-02T03:04:05Z")
+        )
+
+    assert (dataset / "metadata-turtle.ttl").read_text(
+        encoding="utf-8"
+    ) == original_target
+
+
+def test_new_dataset_uses_converter_compatible_deterministic_model_uri(tmp_path: Path):
+    module = load_module()
+    dataset = make_dataset(tmp_path, "new-deterministic-model")
+
+    module.process_dataset(
+        dataset, module.Config(metadata_timestamp="2024-01-02T03:04:05Z")
+    )
+
+    output = (dataset / "metadata-turtle.ttl").read_text(encoding="utf-8")
+    assert (
+        f"dct:isPartOf <{deterministic_model_uri('new-deterministic-model')}>" in output
+    )
+
+
+def test_existing_catalog_dataset_without_distribution_model_iri_fails(tmp_path: Path):
+    module = load_module()
+    dataset = make_dataset(tmp_path, "existing-catalog")
+    (dataset / "metadata.ttl").write_text(
+        "@prefix dcat: <http://www.w3.org/ns/dcat#>.\n"
+        "<https://w3id.org/ontouml-models/model/legacy> a dcat:Dataset .\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        module.MetadataGenerationError,
+        match="appears to be an existing catalog dataset",
+    ):
+        module.process_dataset(
+            dataset, module.Config(metadata_timestamp="2024-01-02T03:04:05Z")
+        )
+
+    assert not (dataset / "metadata-turtle.ttl").exists()
+
+
+def test_existing_distribution_iri_and_curated_values_are_preserved(tmp_path: Path):
+    module = load_module()
+    dataset = make_dataset(tmp_path, "curated")
+    (dataset / "metadata-turtle.ttl").write_text(
+        existing_turtle_metadata(),
+        encoding="utf-8",
+    )
+
+    module.process_dataset(
+        dataset, module.Config(metadata_timestamp="2024-01-02T03:04:05Z")
+    )
+
+    output = (dataset / "metadata-turtle.ttl").read_text(encoding="utf-8")
+    assert "https://w3id.org/ontouml-models/distribution/existing-turtle/" in output
+    assert "Existing Turtle title" in output
+    assert "Existing Turtle editorial note." in output
+    assert "https://example.org/existing/ontology.ttl" in output
+    assert "https://example.org/existing-license" in output
+    assert "2023-04-14T17:34:20.99131566Z" in output
+    assert "2023-04-14T17:34:21.99131566Z" not in output
+    assert "2024-01-02T03:04:05Z" in output
+
+
+def test_missing_license_fails_without_allow_missing_license(tmp_path: Path):
+    module = load_module()
+    dataset = make_dataset(tmp_path, "missing-license")
+    write_metadata_yaml(dataset, license_value=None)
+
+    with pytest.raises(module.MetadataGenerationError, match="license"):
+        module.process_dataset(
+            dataset, module.Config(metadata_timestamp="2024-01-02T03:04:05Z")
+        )
+
+    assert not (dataset / "metadata-turtle.ttl").exists()
+
+
+def test_missing_license_is_allowed_with_allow_missing_license(tmp_path: Path):
+    module = load_module()
+    dataset = make_dataset(tmp_path, "missing-license-allowed")
+    write_metadata_yaml(dataset, license_value=None)
+
+    module.process_dataset(
+        dataset,
+        module.Config(
+            metadata_timestamp="2024-01-02T03:04:05Z",
+            allow_missing_license=True,
+        ),
+    )
+
+    output = (dataset / "metadata-turtle.ttl").read_text(encoding="utf-8")
+    assert "dct:license" not in output
+    assert "Turtle distribution of Aviation Safety Ontology" in output
+
+
+def test_available_license_is_emitted_when_allow_missing_license_is_used(
+    tmp_path: Path,
+):
+    module = load_module()
+    dataset = make_dataset(tmp_path, "available-license")
+
+    module.process_dataset(
+        dataset,
+        module.Config(
+            metadata_timestamp="2024-01-02T03:04:05Z",
+            allow_missing_license=True,
+        ),
+    )
+
+    output = (dataset / "metadata-turtle.ttl").read_text(encoding="utf-8")
+    assert "dct:license <https://creativecommons.org/licenses/by/4.0/>" in output
+
+
+def test_missing_metadata_timestamp_for_new_file_fails(tmp_path: Path):
+    module = load_module()
+    dataset = make_dataset(tmp_path, "timestamp-required")
+
+    with pytest.raises(module.MetadataGenerationError, match="No run timestamp"):
+        module.process_dataset(dataset, module.Config())
+
+    assert not (dataset / "metadata-turtle.ttl").exists()
+
+
+def test_metadata_modified_is_preserved_when_generated_file_is_unchanged(
+    tmp_path: Path,
+):
+    module = load_module()
+    dataset = make_dataset(tmp_path, "unchanged")
+    first = module.process_dataset(
+        dataset, module.Config(metadata_timestamp="2024-01-02T03:04:05Z")
+    )
+    assert first[0].changed is True
+    original_text = (dataset / "metadata-turtle.ttl").read_text(encoding="utf-8")
+
+    second = module.process_dataset(dataset, module.Config())
+    second_text = (dataset / "metadata-turtle.ttl").read_text(encoding="utf-8")
+
+    assert second[0].changed is False
+    assert second[0].written is False
+    assert second_text == original_text
+    assert "2024-01-02T03:04:05Z" in second_text
+
+
+def test_check_detects_required_update_without_writing(tmp_path: Path):
+    module = load_module()
+    dataset = make_dataset(tmp_path, "check-mode")
+
+    result = module.process_dataset(
+        dataset,
+        module.Config(
+            metadata_timestamp="2024-01-02T03:04:05Z",
+            check=True,
+        ),
+    )
+
+    assert result[0].changed is True
+    assert result[0].written is False
+    assert not (dataset / "metadata-turtle.ttl").exists()
+
+
+def test_dry_run_detects_generation_without_writing(tmp_path: Path):
+    module = load_module()
+    dataset = make_dataset(tmp_path, "dry-run")
+
+    result = module.process_dataset(
+        dataset,
+        module.Config(
+            metadata_timestamp="2024-01-02T03:04:05Z",
+            dry_run=True,
+        ),
+    )
+
+    assert result[0].changed is True
+    assert result[0].written is False
+    assert not (dataset / "metadata-turtle.ttl").exists()
+
+
+def test_json_output_from_cli(tmp_path: Path):
+    module = load_module()
+    dataset = make_dataset(tmp_path, "json-cli")
+
+    stdout = io.StringIO()
+    with redirect_stdout(stdout):
+        code = module.main(
+            [
+                str(dataset),
+                "--format",
+                "json",
+                "--metadata-timestamp",
+                "2024-01-02T03:04:05Z",
+            ]
+        )
+
+    assert code == 0
+    data = json.loads(stdout.getvalue())
+    assert data["ok"] is True
+    assert data["errors"] == []
+    assert data["results"][0]["metadata_path"].endswith("metadata-turtle.ttl")
+
+
+def test_no_partial_write_when_source_turtle_is_invalid(tmp_path: Path):
+    module = load_module()
+    dataset = make_dataset(tmp_path, "invalid-source")
+    write_ontology(dataset, valid=False)
+
+    with pytest.raises(
+        module.MetadataGenerationError, match="Could not parse Turtle source"
+    ):
+        module.process_dataset(
+            dataset, module.Config(metadata_timestamp="2024-01-02T03:04:05Z")
+        )
+
+    assert not (dataset / "metadata-turtle.ttl").exists()
+
+
+def test_generated_download_url_uses_repository_relative_source_path(tmp_path: Path):
+    module = load_module()
+    dataset = make_dataset(tmp_path, "path-model")
+
+    module.process_dataset(
+        dataset,
+        module.Config(
+            repository="pedropaulofb/ontouml-models-dev",
+            branch="feature-branch",
+            models_dir_name="models",
+            metadata_timestamp="2024-01-02T03:04:05Z",
+        ),
+    )
+
+    output = (dataset / "metadata-turtle.ttl").read_text(encoding="utf-8")
+    assert (
+        "https://raw.githubusercontent.com/pedropaulofb/ontouml-models-dev/feature-branch/models/path-model/ontology.ttl"
+        in output
+    )
+    assert str(tmp_path) not in output
+
+
+def write_ahmad_catalog_like_dataset(tmp_path: Path) -> Path:
+    dataset = tmp_path / "models" / "ahmad2018aviation"
+    dataset.mkdir(parents=True)
+    (dataset / "metadata.yaml").write_text(
+        """
+title: Aviation Safety Ontology
+acronym:
+issued: 2018
+modified:
+contributor:
+ - https://dblp.org/pid/185/3559
+ - https://dblp.org/pid/77/5702
+ - https://dblp.org/pid/166/2116
+keyword:
+ - safety
+ - aviation
+theme: Class T - Technology
+editorialNote:
+ontologyType:
+ - domain
+language: en
+designedForTask:
+ - information retrieval
+context:
+ - research
+source:
+ - https://doi.org/10.1007/978-3-030-02671-4_22
+representationStyle:
+ - ufo
+landingPage:
+license:
+""".lstrip(),
+        encoding="utf-8",
+    )
+    write_ontology(dataset)
+    (dataset / "metadata-turtle.ttl").write_text(
+        """
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#>.
+@prefix dct: <http://purl.org/dc/terms/>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
+@prefix owl: <http://www.w3.org/2002/07/owl#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+
+<https://w3id.org/ontouml-models/distribution/69cd521b-671c-49f2-a176-e31910dec404/> a dcat:Distribution;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/660ad6c4-dbc1-43e7-b582-d7eb9ec43739>;
+    dct:issued "2018"^^xsd:gYear;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
+    dct:title "Turtle distribution of Aviation Safety Ontology"@en;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/ahmad2018aviation/ontology.ttl>;
+    ocmv:isComplete "true"^^xsd:boolean;
+    fdpo:metadataIssued "2023-04-14T17:34:20.99131566Z"^^xsd:dateTime;
+    fdpo:metadataModified "2023-04-14T17:34:20.99131566Z"^^xsd:dateTime .
+""".lstrip(),
+        encoding="utf-8",
+    )
+    return dataset
+
+
+def write_qam_catalog_like_dataset(tmp_path: Path) -> Path:
+    dataset = tmp_path / "models" / "qam"
+    dataset.mkdir(parents=True)
+    (dataset / "metadata.yaml").write_text(
+        """
+title: Quality Assurance Model
+acronym:
+issued: 2013
+modified:
+contributor:
+keyword:
+ - quality assurance process
+theme: Class H - Social Sciences
+editorialNote: Ontology build in classroom for learning purposes. The author is anonymous.
+ontologyType:
+ - application
+language: en
+designedForTask:
+ - learning
+context:
+ - classroom
+source:
+representationStyle:
+ - ontouml
+landingPage:
+license: https://creativecommons.org/licenses/by/4.0
+""".lstrip(),
+        encoding="utf-8",
+    )
+    write_ontology(dataset)
+    (dataset / "metadata-turtle.ttl").write_text(
+        """
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#>.
+@prefix dct: <http://purl.org/dc/terms/>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
+@prefix owl: <http://www.w3.org/2002/07/owl#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+
+<https://w3id.org/ontouml-models/distribution/f39081f9-416d-4d2f-832f-1b82d4a7d4cf/> a dcat:Distribution;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/0b6d6128-81e6-4985-8f0e-bd5af9a295f3>;
+    dct:issued "2013"^^xsd:gYear;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
+    dct:license <https://creativecommons.org/licenses/by/4.0>;
+    dct:title "Turtle distribution of Quality Assurance Model"@en;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/qam/ontology.ttl>;
+    ocmv:isComplete "true"^^xsd:boolean;
+    fdpo:metadataIssued "2023-04-14T18:10:47.674011631Z"^^xsd:dateTime;
+    fdpo:metadataModified "2023-04-14T18:10:47.674011631Z"^^xsd:dateTime .
+""".lstrip(),
+        encoding="utf-8",
+    )
+    return dataset
+
+
+def test_catalog_like_ahmad_regeneration_preserves_existing_catalog_identifiers(
+    tmp_path: Path,
+):
+    module = load_module()
+    dataset = write_ahmad_catalog_like_dataset(tmp_path)
+
+    assert not (dataset / "metadata.ttl").exists()
+    module.process_dataset(
+        dataset,
+        module.Config(
+            allow_missing_license=True,
+            metadata_timestamp="2024-01-02T03:04:05Z",
+        ),
+    )
+
+    output = (dataset / "metadata-turtle.ttl").read_text(encoding="utf-8")
+    assert (
+        "https://w3id.org/ontouml-models/distribution/69cd521b-671c-49f2-a176-e31910dec404/"
+        in output
+    )
+    assert (
+        "dct:isPartOf <https://w3id.org/ontouml-models/model/660ad6c4-dbc1-43e7-b582-d7eb9ec43739>"
+        in output
+    )
+    assert deterministic_model_uri("ahmad2018aviation") not in output
+    assert "Turtle distribution of Aviation Safety Ontology" in output
+    assert "https://creativecommons.org/licenses/by/4.0/" in output
+    assert "models/ahmad2018aviation/ontology.ttl" in output
+
+
+def test_catalog_like_qam_regeneration_preserves_existing_turtle_distribution(
+    tmp_path: Path,
+):
+    module = load_module()
+    dataset = write_qam_catalog_like_dataset(tmp_path)
+
+    module.process_dataset(
+        dataset, module.Config(metadata_timestamp="2024-01-02T03:04:05Z")
+    )
+
+    output = (dataset / "metadata-turtle.ttl").read_text(encoding="utf-8")
+    assert (
+        "https://w3id.org/ontouml-models/distribution/f39081f9-416d-4d2f-832f-1b82d4a7d4cf/"
+        in output
+    )
+    assert (
+        "dct:isPartOf <https://w3id.org/ontouml-models/model/0b6d6128-81e6-4985-8f0e-bd5af9a295f3>"
+        in output
+    )
+    assert "https://creativecommons.org/licenses/by/4.0" in output
+    assert "Turtle distribution of Quality Assurance Model" in output
+
+
+def test_explicit_yaml_model_uri_is_used_for_new_dataset(tmp_path: Path):
+    module = load_module()
+    dataset = make_dataset(tmp_path, "explicit-yaml-uri")
+    explicit_uri = "https://w3id.org/ontouml-models/model/explicit-from-yaml"
+    write_metadata_yaml(dataset, uri=explicit_uri)
+
+    module.process_dataset(
+        dataset, module.Config(metadata_timestamp="2024-01-02T03:04:05Z")
+    )
+
+    output = (dataset / "metadata-turtle.ttl").read_text(encoding="utf-8")
+    assert f"dct:isPartOf <{explicit_uri}>" in output
+    assert deterministic_model_uri("explicit-yaml-uri") not in output
+
+
+def test_existing_target_without_is_part_of_can_use_explicit_yaml_model_uri(
+    tmp_path: Path,
+):
+    module = load_module()
+    dataset = make_dataset(tmp_path, "target-explicit-yaml-uri")
+    explicit_uri = "https://w3id.org/ontouml-models/model/explicit-existing-target"
+    write_metadata_yaml(dataset, uri=explicit_uri)
+    (dataset / "metadata-turtle.ttl").write_text(
+        existing_turtle_metadata(model_uri=None),
+        encoding="utf-8",
+    )
+
+    module.process_dataset(
+        dataset, module.Config(metadata_timestamp="2024-01-02T03:04:05Z")
+    )
+
+    output = (dataset / "metadata-turtle.ttl").read_text(encoding="utf-8")
+    assert f"dct:isPartOf <{explicit_uri}>" in output
+    assert "https://w3id.org/ontouml-models/distribution/existing-turtle/" in output
+
+
+def test_full_uri_is_part_of_predicate_in_other_distribution_is_supported(
+    tmp_path: Path,
+):
+    module = load_module()
+    dataset = make_dataset(tmp_path, "full-predicate")
+    model_uri = "https://w3id.org/ontouml-models/model/from-full-predicate"
+    (dataset / "metadata-json.ttl").write_text(
+        f"""
+@prefix dcat: <http://www.w3.org/ns/dcat#>.
+
+<https://w3id.org/ontouml-models/distribution/json-existing/> a dcat:Distribution;
+    <http://purl.org/dc/terms/isPartOf> <{model_uri}> .
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    module.process_dataset(
+        dataset, module.Config(metadata_timestamp="2024-01-02T03:04:05Z")
+    )
+
+    output = (dataset / "metadata-turtle.ttl").read_text(encoding="utf-8")
+    assert f"dct:isPartOf <{model_uri}>" in output
+
+
+def test_malformed_existing_target_metadata_fails_without_overwriting(tmp_path: Path):
+    module = load_module()
+    dataset = make_dataset(tmp_path, "malformed-existing-target")
+    bad_text = (
+        "@prefix dcat: <http://www.w3.org/ns/dcat#>.\n<broken> a dcat:Distribution ;\n"
+    )
+    (dataset / "metadata-turtle.ttl").write_text(bad_text, encoding="utf-8")
+
+    with pytest.raises(
+        module.MetadataGenerationError,
+        match="Could not parse existing distribution metadata",
+    ):
+        module.process_dataset(
+            dataset, module.Config(metadata_timestamp="2024-01-02T03:04:05Z")
+        )
+
+    assert (dataset / "metadata-turtle.ttl").read_text(encoding="utf-8") == bad_text
+
+
+def test_missing_source_turtle_fails_without_writing(tmp_path: Path):
+    module = load_module()
+    dataset = make_dataset(tmp_path, "missing-source")
+    (dataset / "ontology.ttl").unlink()
+
+    with pytest.raises(
+        module.MetadataGenerationError, match="Missing required Turtle source file"
+    ):
+        module.process_dataset(
+            dataset, module.Config(metadata_timestamp="2024-01-02T03:04:05Z")
+        )
+
+    assert not (dataset / "metadata-turtle.ttl").exists()
+
+
+def test_no_overwrite_fails_for_existing_target_without_modifying_it(tmp_path: Path):
+    module = load_module()
+    dataset = make_dataset(tmp_path, "no-overwrite")
+    original = existing_turtle_metadata()
+    (dataset / "metadata-turtle.ttl").write_text(original, encoding="utf-8")
+
+    with pytest.raises(module.MetadataGenerationError, match="overwrite is disabled"):
+        module.process_dataset(
+            dataset,
+            module.Config(
+                overwrite=False,
+                metadata_timestamp="2024-01-02T03:04:05Z",
+            ),
+        )
+
+    assert (dataset / "metadata-turtle.ttl").read_text(encoding="utf-8") == original
+
+
+def test_main_check_returns_one_and_json_marks_not_ok_when_update_is_needed(
+    tmp_path: Path,
+):
+    module = load_module()
+    dataset = make_dataset(tmp_path, "check-cli-json")
+
+    stdout = io.StringIO()
+    with redirect_stdout(stdout):
+        code = module.main(
+            [
+                str(dataset),
+                "--check",
+                "--format",
+                "json",
+                "--metadata-timestamp",
+                "2024-01-02T03:04:05Z",
+            ]
+        )
+
+    assert code == 1
+    data = json.loads(stdout.getvalue())
+    assert data["ok"] is False
+    assert data["results"][0]["changed"] is True
+    assert not (dataset / "metadata-turtle.ttl").exists()
+
+
+def test_all_discovers_dataset_folders_below_models_dir(tmp_path: Path):
+    module = load_module()
+    models_dir = tmp_path / "models"
+    first = make_dataset(tmp_path, "all-first")
+    second = make_dataset(tmp_path, "all-second")
+    (models_dir / "not-a-dataset").mkdir()
+
+    stdout = io.StringIO()
+    with redirect_stdout(stdout):
+        code = module.main(
+            [
+                "--all",
+                "--models-dir",
+                str(models_dir),
+                "--format",
+                "json",
+                "--metadata-timestamp",
+                "2024-01-02T03:04:05Z",
+            ]
+        )
+
+    assert code == 0
+    data = json.loads(stdout.getvalue())
+    assert len(data["results"]) == 2
+    assert (first / "metadata-turtle.ttl").exists()
+    assert (second / "metadata-turtle.ttl").exists()
+    assert not (models_dir / "not-a-dataset" / "metadata-turtle.ttl").exists()
+
+
+def test_invalid_metadata_timestamp_fails_without_writing(tmp_path: Path):
+    module = load_module()
+    dataset = make_dataset(tmp_path, "invalid-timestamp")
+
+    with pytest.raises(module.MetadataGenerationError, match="--metadata-timestamp"):
+        module.process_dataset(
+            dataset, module.Config(metadata_timestamp="2024-01-02 03:04:05")
+        )
+
+    assert not (dataset / "metadata-turtle.ttl").exists()
+
+
+def test_generated_metadata_parses_and_has_one_distribution_subject(tmp_path: Path):
+    module = load_module()
+    dataset = make_dataset(tmp_path, "parse-generated")
+
+    module.process_dataset(
+        dataset, module.Config(metadata_timestamp="2024-01-02T03:04:05Z")
+    )
+
+    graph = module.Graph()
+    graph.parse(dataset / "metadata-turtle.ttl", format="turtle")
+    subjects = list(graph.subjects(module.RDF.type, module.DCAT.Distribution))
+    assert len(subjects) == 1
+    assert (subjects[0], module.DCAT.mediaType, module.TURTLE_MEDIA_TYPE) in graph
+    assert (
+        subjects[0],
+        module.OCMV.isComplete,
+        module.Literal(True, datatype=module.XSD.boolean),
+    ) in graph
+
+
+def test_owned_distribution_semantics_are_regenerated_from_script_defaults(
+    tmp_path: Path,
+):
+    module = load_module()
+    dataset = make_dataset(tmp_path, "wrong-owned-values")
+    (dataset / "metadata-turtle.ttl").write_text(
+        """
+@prefix dcat: <http://www.w3.org/ns/dcat#>.
+@prefix dct: <http://purl.org/dc/terms/>.
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+
+<https://w3id.org/ontouml-models/distribution/wrong-owned-values/> a dcat:Distribution;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/wrong-owned-values>;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    ocmv:isComplete "false"^^xsd:boolean;
+    fdpo:metadataIssued "2023-04-14T17:34:20Z"^^xsd:dateTime;
+    fdpo:metadataModified "2023-04-14T17:34:20Z"^^xsd:dateTime .
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    module.process_dataset(
+        dataset, module.Config(metadata_timestamp="2024-01-02T03:04:05Z")
+    )
+
+    output = (dataset / "metadata-turtle.ttl").read_text(encoding="utf-8")
+    assert "https://www.iana.org/assignments/media-types/text/turtle" in output
+    assert "https://www.iana.org/assignments/media-types/application/json" not in output
+    assert "ocmv:isComplete true" in output
+    assert "ocmv:isComplete false" not in output


### PR DESCRIPTION
## Summary

This PR adds a YAML-first generator for Turtle distribution metadata files.

It introduces:

- `scripts/generate_turtle_metadata.py`
- `scripts/generate-turtle-metadata.md`
- `scripts/tests/test_generate_turtle_metadata.py`

The generator creates or checks `metadata-turtle.ttl` files for existing `ontology.ttl` distributions while avoiding a dependency on model-level `metadata.ttl`.

## Motivation

The catalog metadata tooling is being reorganized so distribution-level metadata can be generated before the model-level `metadata.ttl` aggregation step.

In the intended future order, distribution metadata files such as `metadata-png-*.ttl`, `metadata-json.ttl`, `metadata-turtle.ttl`, and `metadata-vpp.ttl` should be generated first. Then `metadata_yaml_to_ttl.py` can aggregate model-level metadata and distribution references into `metadata.ttl`.

This PR only adds the Turtle metadata generator, documentation, and tests. It does not add or modify any GitHub Actions workflow.

## Scope

This PR is intentionally limited to the Turtle distribution metadata generator.

It does not modify:

- generated metadata files under `models/`;
- GitHub Actions workflows;
- CI configuration;
- JSON, PNG, or VPP generators;
- unrelated documentation;
- unrelated tests.

## Behavior

The new generator:

- scans one or more dataset folders;
- validates the presence and Turtle syntax of `ontology.ttl`;
- creates or checks `metadata-turtle.ttl`;
- uses `metadata.yaml` as the canonical editable source for model-level values such as title, issued date, and license;
- does not require model-level `metadata.ttl`;
- preserves existing Turtle distribution identifiers when regenerating existing metadata;
- preserves existing `dct:isPartOf` values from existing distribution metadata;
- can fall back to other existing distribution metadata files in the same dataset folder when `metadata-turtle.ttl` is absent;
- generates deterministic UUIDv5 IRIs for genuinely new datasets;
- preserves curated distribution-level values when applicable;
- supports deterministic timestamp handling through `--metadata-timestamp`;
- supports `--allow-missing-license` for legacy datasets;
- supports `--check`, `--dry-run`, text output, JSON output, and quiet mode.

## Model IRI strategy

The generator resolves the model IRI without using `metadata.ttl`.

The resolution order is:

1. existing `metadata-turtle.ttl`, using its `dct:isPartOf`;
2. other existing distribution metadata files in the same dataset folder, when unambiguous;
3. an explicit HTTP(S) model URI in `metadata.yaml`, if available;
4. deterministic UUIDv5 model IRI for genuinely new datasets.

If an existing catalog dataset appears to need preservation of a stable catalog model IRI but no usable distribution metadata exists, the generator fails clearly instead of silently replacing the model IRI with a folder-name-based IRI.

## Distribution IRI strategy

Existing `metadata-turtle.ttl` files keep their current distribution URI.

For new `metadata-turtle.ttl` files, the generator creates a deterministic UUIDv5 distribution IRI based on stable repository/catalog information, namely the model IRI and the repository-relative source path:

```text
<model-uri>|ontology.ttl
```

This keeps generated identifiers reproducible while preserving existing catalog identifiers.

## Timestamp strategy

The generator follows the same maintenance pattern used by the updated distribution metadata tooling:

- existing `fdpo:metadataIssued` values are preserved;
- new files initialize `fdpo:metadataIssued` from `--metadata-timestamp`;
- changed files update `fdpo:metadataModified` from `--metadata-timestamp`;
- unchanged files preserve existing `fdpo:metadataModified`;
- missing timestamps fail clearly when a new or changed file requires one.

A fixed timestamp can be used for deterministic maintenance runs:

```bash
python scripts/generate_turtle_metadata.py models/<model-directory> \
  --metadata-timestamp 2026-06-23T12:00:00Z
```

The value `--metadata-timestamp now` is supported only for intentionally non-deterministic manual runs.

## License handling

By default, missing model-level license metadata is a fatal error.

The option `--allow-missing-license` allows legacy datasets without license metadata to be processed. When this option is used:

- existing distribution-level `dct:license` values are preserved when available;
- model-level licenses from `metadata.yaml` are still emitted when available;
- new files without any license source omit `dct:license`.

This option is intended for legacy catalog maintenance, not for new submissions.

## Usage examples

Generate Turtle metadata for one dataset:

```bash
python scripts/generate_turtle_metadata.py models/<model-directory> \
  --metadata-timestamp 2026-06-23T12:00:00Z
```

Check whether one dataset is up to date:

```bash
python scripts/generate_turtle_metadata.py models/<model-directory> \
  --check \
  --metadata-timestamp 2026-06-23T12:00:00Z
```

Generate Turtle metadata for all datasets:

```bash
python scripts/generate_turtle_metadata.py --all --models-dir models \
  --metadata-timestamp 2026-06-23T12:00:00Z
```

Allow legacy datasets without license metadata:

```bash
python scripts/generate_turtle_metadata.py --all --models-dir models \
  --allow-missing-license \
  --metadata-timestamp 2026-06-23T12:00:00Z
```

Produce JSON output for automation:

```bash
python scripts/generate_turtle_metadata.py models/<model-directory> \
  --check \
  --format json \
  --metadata-timestamp 2026-06-23T12:00:00Z
```

## Tests

The test suite covers:

- generation using `metadata.yaml` when `metadata.ttl` is absent;
- absence of a hard dependency on model-level `metadata.ttl`;
- preservation of existing `dct:isPartOf`;
- fallback to other existing distribution metadata;
- deterministic model and distribution IRI generation;
- failure on ambiguous or missing preservation sources for existing catalog datasets;
- preservation of existing distribution URI;
- preservation of curated distribution metadata values;
- missing-license failure by default;
- missing-license success with `--allow-missing-license`;
- timestamp initialization and preservation;
- `fdpo:metadataModified` update when files change;
- unchanged-file behavior;
- `--check`, `--dry-run`, JSON output, and `--all`;
- atomicity when validation fails;
- repository-relative paths in deterministic identifiers and download URLs;
- catalog-like cases based on existing Turtle metadata patterns.

Verification performed:

```bash
python -m pytest scripts/tests/test_generate_turtle_metadata.py
python -m py_compile scripts/generate_turtle_metadata.py scripts/tests/test_generate_turtle_metadata.py
python scripts/generate_turtle_metadata.py --help
```

The dedicated test suite passes locally.

## Notes

This PR prepares the Turtle distribution metadata generator for a future workflow, but it does not create that workflow.

The expected future order is conceptually:

```text
metadata.yaml + ontology.ttl
  -> metadata-turtle.ttl

metadata.yaml + distribution metadata files
  -> metadata.ttl
```