### PR TITLE
Prepare JSON metadata generation for YAML workflow

### DIFF
--- a/scripts/generate-json-metadata.md
+++ b/scripts/generate-json-metadata.md
@@ -1,0 +1,248 @@
+# JSON distribution metadata generator
+
+`scripts/generate_json_metadata.py` generates RDF/Turtle metadata for the OntoUML JSON distribution of a model dataset.
+
+For each processed dataset folder, it reads:
+
+- `metadata.yaml`
+- `ontology.json`
+- existing distribution metadata files, when needed to preserve stable identifiers and curated values
+
+It writes:
+
+- `metadata-json.ttl`
+
+The script is intended for repository maintenance and for a future metadata-generation workflow. It does **not** create or modify a GitHub Actions workflow.
+
+## Purpose
+
+The generator describes the `ontology.json` distribution of an OntoUML/UFO Catalog model as a `dcat:Distribution`.
+
+The generated metadata follows the repository’s established JSON distribution pattern:
+
+- source file: `ontology.json`
+- output file: `metadata-json.ttl`
+- media type: `https://www.iana.org/assignments/media-types/application/json`
+- schema: `https://w3id.org/ontouml/schema`
+- completeness: `ocmv:isComplete true`
+- default title pattern: `JSON distribution of {model title}`
+- default download URL pattern: `https://raw.githubusercontent.com/{repository}/{branch}/models/{dataset}/ontology.json`
+
+## Relationship to `metadata.ttl`
+
+`metadata.ttl` is the final model-level aggregation product of the metadata workflow.
+
+This generator does not read `metadata.ttl` and does not require it to exist. It generates distribution-level metadata first. Later, `scripts/metadata_yaml_to_ttl.py` can aggregate `metadata-json.ttl` and the other generated distribution metadata files into model-level `metadata.ttl`.
+
+A future generation order may therefore be:
+
+```text
+python scripts/validate_metadata_yaml.py --all --models-dir models --fix --allow-missing-license
+python scripts/generate_png_metadata.py --all --models-dir models --allow-missing-license --metadata-timestamp now
+python scripts/generate_json_metadata.py --all --models-dir models --allow-missing-license --metadata-timestamp now
+python scripts/generate_turtle_metadata.py --all --models-dir models --allow-missing-license --metadata-timestamp now
+python scripts/generate_vpp_metadata.py --all --models-dir models --allow-missing-license --metadata-timestamp now
+python scripts/metadata_yaml_to_ttl.py --all --models-dir models --allow-missing-license --metadata-timestamp now
+```
+
+This document describes the JSON generator only; no workflow is created by this task.
+
+## Inputs
+
+### `metadata.yaml`
+
+`metadata.yaml` is the canonical editable source for model-level values used in `metadata-json.ttl`, especially:
+
+- model title;
+- issued date;
+- license;
+- optional explicit model URI, when such a field is present in a compatible YAML variant.
+
+The current standard repository-facing `metadata.yaml` template does not need to expose a model URI. For existing catalog datasets, the generator should preserve the model URI from existing distribution metadata files instead.
+
+### `ontology.json`
+
+By default, the script requires `ontology.json` to exist and be parseable JSON with a JSON object at the top level. This prevents creating metadata for a missing or invalid source distribution.
+
+Use `--no-check-ontology-json` only for exceptional compatibility cases where the metadata record must be generated before the source file is available.
+
+### Existing distribution metadata
+
+The script reads existing distribution metadata files only to preserve stable catalog identifiers and curated distribution-level values. It does not treat model-level `metadata.ttl` as an input.
+
+## Model IRI resolution
+
+The generated `dct:isPartOf` value is resolved without reading `metadata.ttl`.
+
+Resolution order:
+
+1. Existing `metadata-json.ttl`, when present, by reading its `dct:isPartOf`.
+2. Other existing distribution metadata files in the same dataset folder, when available and unambiguous, by reading their `dct:isPartOf`.
+3. Explicit HTTP(S) model URI in `metadata.yaml`, if present in a compatible YAML form.
+4. Deterministic UUIDv5 model IRI for genuinely new datasets.
+
+The deterministic model IRI uses the same strategy as `metadata_yaml_to_ttl.py`:
+
+```text
+uuid5(NAMESPACE_URL, "https://w3id.org/ontouml-models/model|{dataset-folder-name}")
+```
+
+The generator does not replace existing UUID-based model IRIs with folder-name-based IRIs.
+
+If the folder appears to be an existing catalog dataset, but no existing distribution metadata file provides a stable `dct:isPartOf`, the generator fails instead of silently creating a new model IRI. A folder is treated as likely existing when it already contains `metadata.ttl` or another `metadata-*.ttl` file.
+
+If multiple distribution metadata files provide conflicting `dct:isPartOf` values, generation fails and reports the conflict.
+
+## Distribution IRI strategy
+
+For existing `metadata-json.ttl`, the existing distribution IRI is preserved.
+
+For new `metadata-json.ttl`, the script generates a deterministic UUIDv5 distribution IRI from stable repository/catalog information:
+
+```text
+{model IRI}|models/{dataset-folder-name}/ontology.json
+```
+
+The seed uses the repository-relative source path, not a local absolute filesystem path.
+
+## Preserved values
+
+When regenerating an existing `metadata-json.ttl`, the script preserves these values when present and applicable:
+
+- existing distribution IRI;
+- existing `dct:isPartOf`;
+- existing `dct:title`;
+- existing `skos:editorialNote`;
+- existing `dcat:downloadURL`;
+- existing distribution-level `dct:license`, when `metadata.yaml` lacks a license and `--allow-missing-license` is used;
+- existing `ocmv:conformsToSchema`;
+- existing `fdpo:metadataIssued`;
+- existing `fdpo:metadataModified` when the regenerated file is unchanged.
+
+When `metadata.yaml` provides a license, that license is emitted regardless of `--allow-missing-license`.
+
+## Timestamp behavior
+
+`--metadata-timestamp` controls `fdpo:metadataIssued` and `fdpo:metadataModified`.
+
+Use a fixed value for deterministic runs:
+
+```bash
+python scripts/generate_json_metadata.py models/amaral2019rot --metadata-timestamp 2026-06-23T12:00:00Z
+```
+
+Use `now` only for intentionally non-deterministic maintenance runs:
+
+```bash
+python scripts/generate_json_metadata.py models/amaral2019rot --metadata-timestamp now
+```
+
+Rules:
+
+- existing `fdpo:metadataIssued` is preserved;
+- missing `fdpo:metadataIssued` is initialized from `--metadata-timestamp`;
+- existing `fdpo:metadataModified` is preserved when the regenerated file is unchanged;
+- `fdpo:metadataModified` is updated from `--metadata-timestamp` when the regenerated file changes;
+- new files initialize both timestamps from the same supplied timestamp;
+- if a new or changed file needs a timestamp and none is supplied, generation fails clearly.
+
+The script does not silently use the current time by default.
+
+## Missing-license behavior
+
+By default, missing license metadata is an error.
+
+Use `--allow-missing-license` only for legacy datasets that intentionally lack license metadata:
+
+```bash
+python scripts/generate_json_metadata.py models/legacy-model --allow-missing-license --metadata-timestamp 2026-06-23T12:00:00Z
+```
+
+Behavior:
+
+- if `metadata.yaml` has a license, the generated metadata includes it;
+- if `metadata.yaml` has no license and `--allow-missing-license` is not used, generation fails;
+- if `metadata.yaml` has no license and `--allow-missing-license` is used, the script preserves an existing distribution-level `dct:license` when available;
+- if no license is available and `--allow-missing-license` is used, `dct:license` is omitted.
+
+Do not use `--allow-missing-license` for new submissions.
+
+## Usage
+
+### One dataset
+
+```bash
+python scripts/generate_json_metadata.py models/amaral2019rot --metadata-timestamp 2026-06-23T12:00:00Z
+```
+
+### Multiple datasets
+
+```bash
+python scripts/generate_json_metadata.py models/amaral2019rot models/albuquerque2011ontobio --metadata-timestamp 2026-06-23T12:00:00Z
+```
+
+### All datasets
+
+```bash
+python scripts/generate_json_metadata.py --all --models-dir models --metadata-timestamp 2026-06-23T12:00:00Z
+```
+
+### Check mode
+
+Use `--check` to verify whether files are up to date without writing changes:
+
+```bash
+python scripts/generate_json_metadata.py --all --models-dir models --check --metadata-timestamp 2026-06-23T12:00:00Z
+```
+
+Exit code `1` means at least one file would change or at least one dataset failed.
+
+### Dry run
+
+Use `--dry-run` to validate inputs and report intended outputs without writing files:
+
+```bash
+python scripts/generate_json_metadata.py --all --models-dir models --dry-run --metadata-timestamp 2026-06-23T12:00:00Z
+```
+
+### JSON output
+
+```bash
+python scripts/generate_json_metadata.py --all --models-dir models --format json --metadata-timestamp 2026-06-23T12:00:00Z
+```
+
+### Quiet mode
+
+```bash
+python scripts/generate_json_metadata.py --all --models-dir models --quiet --metadata-timestamp 2026-06-23T12:00:00Z
+```
+
+`--silent` is accepted as an alias for `--quiet`.
+
+### Download URL options
+
+By default, the script creates raw GitHub URLs using:
+
+```text
+repository: OntoUML/ontouml-models
+branch: master
+models path: models
+```
+
+Override them when testing a branch or fork:
+
+```bash
+python scripts/generate_json_metadata.py models/example \
+  --repository pedropaulofb/ontouml-models-dev \
+  --branch regenerate-json-metadata \
+  --models-dir-name models \
+  --metadata-timestamp 2026-06-23T12:00:00Z
+```
+
+## Exit codes
+
+| Code | Meaning |
+|---:|---|
+| `0` | Generation/check completed successfully. In `--check` mode, no updates are needed. |
+| `1` | Dataset processing failed, or `--check` detected required updates. |
+| `2` | Command-line, discovery, or setup error prevented normal execution. |

--- a/scripts/generate_json_metadata.py
+++ b/scripts/generate_json_metadata.py
@@ -1,0 +1,1263 @@
+"""Generate RDF/Turtle metadata for OntoUML catalog JSON distributions.
+
+The script scans one or more model dataset folders and creates or updates the
+metadata file for the OntoUML JSON serialization:
+
+- ontology.json -> metadata-json.ttl
+
+Run from the repository root, for example:
+
+    python scripts/generate_json_metadata.py models/amaral2019rot
+    python scripts/generate_json_metadata.py --all --models-dir models
+    python scripts/generate_json_metadata.py --all --models-dir models --allow-missing-license
+
+The model-level source of truth is metadata.yaml. Existing distribution metadata
+files are read only to preserve stable distribution identifiers, existing model
+W3IDs used by dct:isPartOf, and curated distribution-level values during
+regeneration. The script does not read metadata.ttl and does not generate
+metadata.ttl; metadata_yaml_to_ttl.py remains the final model-level aggregation
+step.
+"""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import json
+import re
+import sys
+import uuid
+from dataclasses import asdict, dataclass
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable, Mapping, Optional, Sequence
+from urllib.parse import quote
+
+try:
+    import yaml
+except ImportError as exc:  # pragma: no cover - dependency failure only
+    raise SystemExit(
+        "PyYAML is required. Install it with: python -m pip install -r scripts/requirements.txt"
+    ) from exc
+
+try:
+    from rdflib import Graph, Literal, Namespace, URIRef
+    from rdflib.namespace import DCTERMS as DCT, RDF, SKOS, XSD
+except ImportError as exc:  # pragma: no cover - dependency failure only
+    raise SystemExit(
+        "RDFLib is required. Install it with: python -m pip install -r scripts/requirements.txt"
+    ) from exc
+
+DCAT = Namespace("http://www.w3.org/ns/dcat#")
+FDPO = Namespace("https://w3id.org/fdp/fdp-o#")
+OCMV = Namespace("https://w3id.org/ontouml-models/vocabulary#")
+OWL = Namespace("http://www.w3.org/2002/07/owl#")
+RDFS = Namespace("http://www.w3.org/2000/01/rdf-schema#")
+
+JSON_MEDIA_TYPE = URIRef(
+    "https://www.iana.org/assignments/media-types/application/json"
+)
+JSON_SCHEMA_URI = URIRef("https://w3id.org/ontouml/schema")
+DISTRIBUTION_BASE = "https://w3id.org/ontouml-models/distribution/"
+DEFAULT_REPOSITORY = "OntoUML/ontouml-models"
+DEFAULT_BRANCH = "master"
+DEFAULT_MODELS_DIR = "models"
+DEFAULT_MODEL_IRI_BASE = "https://w3id.org/ontouml-models/model"
+SOURCE_FILE_NAME = "ontology.json"
+OUTPUT_FILE_NAME = "metadata-json.ttl"
+
+LICENSE_ALIASES = {
+    "ccby40": "https://creativecommons.org/licenses/by/4.0/",
+    "creativecommonsattribution40international": "https://creativecommons.org/licenses/by/4.0/",
+    "ccbysa40": "https://creativecommons.org/licenses/by-sa/4.0/",
+    "creativecommonsattributionsharealike40international": "https://creativecommons.org/licenses/by-sa/4.0/",
+    "ccbysa30": "https://creativecommons.org/licenses/by-sa/3.0/",
+    "creativecommonsattributionsharealike30unported": "https://creativecommons.org/licenses/by-sa/3.0/",
+    "cc010": "https://creativecommons.org/publicdomain/zero/1.0/",
+    "creativecommonszero10universaldomainpublicdedication": "https://creativecommons.org/publicdomain/zero/1.0/",
+    "mit": "http://spdx.org/licenses/MIT",
+}
+
+DATE_YEAR_RE = re.compile(r"^\d{4}$")
+DATE_YEAR_MONTH_RE = re.compile(r"^\d{4}-\d{2}$")
+DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+XSD_DATETIME_RE = re.compile(
+    r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})?$"
+)
+HTTP_URI_RE = re.compile(r"^https?://", re.I)
+DISTRIBUTION_IRI_RE = re.compile(r"<([^>]+)>\s+a\s+[^.;]*\bdcat:Distribution\b", re.S)
+IS_PART_OF_RE = re.compile(r"\bdct:isPartOf\s+<([^>]+)>", re.S)
+FULL_IS_PART_OF_RE = re.compile(
+    r"<http://purl\.org/dc/terms/isPartOf>\s+<([^>]+)>", re.S
+)
+PREFIXED_DATETIME_RE_TEMPLATE = r"\bfdpo:{name}\s+\"([^\"]+)\"\^\^xsd:dateTime"
+FULL_DATETIME_RE_TEMPLATE = (
+    r"<https://w3id\.org/fdp/fdp-o#{name}>\s+\"([^\"]+)\"\^\^"
+    r"<http://www\.w3\.org/2001/XMLSchema#dateTime>"
+)
+
+
+class MetadataSetupError(RuntimeError):
+    """Raised when command-line or discovery setup prevents execution."""
+
+
+class MetadataGenerationError(RuntimeError):
+    """Raised when a dataset cannot be processed safely."""
+
+
+@dataclass(frozen=True)
+class Config:
+    """Configuration for JSON distribution metadata generation."""
+
+    repository: str = DEFAULT_REPOSITORY
+    branch: str = DEFAULT_BRANCH
+    models_dir_name: str = DEFAULT_MODELS_DIR
+    model_iri_base: str = DEFAULT_MODEL_IRI_BASE
+    overwrite: bool = True
+    dry_run: bool = False
+    check: bool = False
+    check_source_file: bool = True
+    metadata_timestamp: Optional[str] = None
+    allow_missing_license: bool = False
+    # Deprecated compatibility shim for older callers that used Config(require_license=True).
+    require_license: Optional[bool] = None
+    emit_diff: bool = False
+    quiet: bool = False
+
+
+@dataclass(frozen=True)
+class ModelMetadata:
+    """Minimum model metadata required to describe its JSON distribution."""
+
+    uri: URIRef
+    title: str
+    license_uri: Optional[URIRef]
+    issued: Literal
+
+
+@dataclass(frozen=True)
+class ExistingDistributionMetadata:
+    """Reusable metadata found in an existing JSON distribution metadata file."""
+
+    uri: Optional[URIRef] = None
+    model_uri: Optional[URIRef] = None
+    title: Optional[Literal] = None
+    editorial_note: Optional[Literal] = None
+    download_url: Optional[URIRef] = None
+    license_uri: Optional[URIRef] = None
+    schema_uri: Optional[URIRef] = None
+    metadata_issued: Optional[Literal] = None
+    metadata_modified: Optional[Literal] = None
+
+
+@dataclass(frozen=True)
+class GeneratedFile:
+    """Result of generating or checking one metadata file."""
+
+    source_path: Path
+    metadata_path: Path
+    distribution_uri: URIRef
+    model_uri: URIRef
+    changed: bool
+    written: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        data["source_path"] = str(self.source_path)
+        data["metadata_path"] = str(self.metadata_path)
+        data["distribution_uri"] = str(self.distribution_uri)
+        data["model_uri"] = str(self.model_uri)
+        return data
+
+
+class MetadataYamlLoader(yaml.SafeLoader):
+    """Safe YAML loader preserving date-like scalar lexical forms."""
+
+
+MetadataYamlLoader.yaml_implicit_resolvers = {
+    key: [
+        resolver
+        for resolver in resolvers
+        if resolver[0] != "tag:yaml.org,2002:timestamp"
+    ]
+    for key, resolvers in yaml.SafeLoader.yaml_implicit_resolvers.items()
+}
+
+
+def _construct_mapping_no_duplicates(
+    loader: MetadataYamlLoader, node: yaml.MappingNode, deep: bool = False
+) -> dict[Any, Any]:
+    mapping: dict[Any, Any] = {}
+    for key_node, value_node in node.value:
+        key = loader.construct_object(key_node, deep=deep)
+        if key in mapping:
+            raise yaml.constructor.ConstructorError(
+                "while constructing a mapping",
+                node.start_mark,
+                f"found duplicate key {key!r}",
+                key_node.start_mark,
+            )
+        mapping[key] = loader.construct_object(value_node, deep=deep)
+    return mapping
+
+
+MetadataYamlLoader.add_constructor(
+    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+    _construct_mapping_no_duplicates,
+)
+
+
+def bind_prefixes(graph: Graph) -> None:
+    """Bind prefixes used by catalog distribution metadata."""
+
+    graph.bind("fdpo", FDPO)
+    graph.bind("dcat", DCAT)
+    graph.bind("dct", DCT)
+    graph.bind("ocmv", OCMV)
+    graph.bind("owl", OWL)
+    graph.bind("rdf", RDF)
+    graph.bind("rdfs", RDFS)
+    graph.bind("skos", SKOS)
+    graph.bind("xsd", XSD)
+
+
+def namespace_manager():
+    graph = Graph()
+    bind_prefixes(graph)
+    return graph.namespace_manager
+
+
+NS_MANAGER = namespace_manager()
+
+
+def effective_allow_missing_license(config: Config) -> bool:
+    """Return the active missing-license policy."""
+
+    if config.require_license is True:
+        return False
+    return config.allow_missing_license
+
+
+def validate_dataset_folder(
+    dataset_folder: Path, *, require_metadata_yaml: bool = True
+) -> Path:
+    """Return a normalized dataset folder path or raise a setup error."""
+
+    dataset_folder = dataset_folder.resolve()
+    if not dataset_folder.exists():
+        raise MetadataSetupError(f"Dataset folder does not exist: {dataset_folder}")
+    if not dataset_folder.is_dir():
+        raise MetadataSetupError(f"Dataset path is not a directory: {dataset_folder}")
+    if require_metadata_yaml and not (dataset_folder / "metadata.yaml").exists():
+        raise MetadataSetupError(
+            f"Missing metadata.yaml in dataset folder: {dataset_folder}"
+        )
+    return dataset_folder
+
+
+def load_yaml_mapping(path: Path) -> Mapping[str, Any]:
+    """Load a YAML file and ensure its root node is a mapping."""
+
+    try:
+        data = yaml.load(path.read_text(encoding="utf-8"), Loader=MetadataYamlLoader)
+    except yaml.YAMLError as exc:
+        raise MetadataGenerationError(f"Could not parse {path}: {exc}") from exc
+    except OSError as exc:
+        raise MetadataGenerationError(f"Could not read {path}: {exc}") from exc
+
+    if data is None:
+        raise MetadataGenerationError(f"Canonical metadata file is empty: {path}")
+    if not isinstance(data, Mapping):
+        raise MetadataGenerationError(
+            f"Canonical metadata file must contain a YAML mapping: {path}"
+        )
+    return data
+
+
+def canonical_key(value: object) -> str:
+    """Return a normalized key or identifier for permissive matching."""
+
+    return re.sub(r"[^a-z0-9]", "", str(value).lower())
+
+
+def yaml_mapping_get(mapping: Mapping[str, Any], key: str) -> Any:
+    """Return a mapping value using case-insensitive key matching."""
+
+    wanted = canonical_key(key)
+    for candidate, value in mapping.items():
+        if canonical_key(candidate) == wanted:
+            return value
+    return None
+
+
+def yaml_value_at_path(data: Any, path: Sequence[str]) -> Any:
+    current = data
+    for key in path:
+        if not isinstance(current, Mapping):
+            return None
+        current = yaml_mapping_get(current, key)
+        if current is None:
+            return None
+    return current
+
+
+def yaml_first_value(data: Mapping[str, Any], paths: Sequence[Sequence[str]]) -> Any:
+    for path in paths:
+        value = yaml_value_at_path(data, path)
+        if value is not None:
+            return value
+    return None
+
+
+def yaml_text(value: Any) -> Optional[str]:
+    """Extract human-readable text from common YAML scalar or language-map forms."""
+
+    if value is None:
+        return None
+    if isinstance(value, Mapping):
+        for key in ("en", "eng", "english", "value", "label", "title", "name"):
+            text = yaml_text(yaml_mapping_get(value, key))
+            if text:
+                return text
+        for nested in value.values():
+            text = yaml_text(nested)
+            if text:
+                return text
+        return None
+    if isinstance(value, list):
+        for item in value:
+            text = yaml_text(item)
+            if text:
+                return text
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def yaml_issued_literal(value: Any) -> Optional[Literal]:
+    """Return an RDF literal for a model issued value."""
+
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        text = value.isoformat()
+        return Literal(text, datatype=XSD.dateTime, normalize=False)
+    if isinstance(value, date):
+        return Literal(value.isoformat(), datatype=XSD.date, normalize=False)
+
+    text = yaml_text(value)
+    if not text:
+        return None
+    if DATE_YEAR_RE.match(text):
+        return Literal(text, datatype=XSD.gYear, normalize=False)
+    if DATE_YEAR_MONTH_RE.match(text):
+        return Literal(text, datatype=XSD.gYearMonth, normalize=False)
+    if DATE_RE.match(text):
+        return Literal(text, datatype=XSD.date, normalize=False)
+    if XSD_DATETIME_RE.match(text):
+        return Literal(text, datatype=XSD.dateTime, normalize=False)
+    raise MetadataGenerationError(
+        f"Unsupported issued date value {text!r}; expected YYYY, YYYY-MM, YYYY-MM-DD, or xsd:dateTime."
+    )
+
+
+def normalize_model_uri(uri: URIRef) -> URIRef:
+    """Normalize model URIs for distribution metadata."""
+
+    return URIRef(str(uri).rstrip("/"))
+
+
+def uri_from_text(
+    value: str, *, field_name: str, trailing_slash: Optional[bool] = None
+) -> URIRef:
+    text = value.strip()
+    if not HTTP_URI_RE.match(text):
+        raise MetadataGenerationError(
+            f"Field '{field_name}' must be an HTTP(S) URI; got {text!r}."
+        )
+    if trailing_slash is True and not text.endswith("/"):
+        text = f"{text}/"
+    elif trailing_slash is False:
+        text = text.rstrip("/")
+    return URIRef(text)
+
+
+def yaml_license_uri(value: Any) -> Optional[URIRef]:
+    """Return a license URI from common scalar or mapping forms."""
+
+    if value is None:
+        return None
+    if isinstance(value, Mapping):
+        for key in ("uri", "url", "id", "identifier", "license", "value"):
+            result = yaml_license_uri(yaml_mapping_get(value, key))
+            if result is not None:
+                return result
+        return None
+    if isinstance(value, list):
+        for item in value:
+            result = yaml_license_uri(item)
+            if result is not None:
+                return result
+        return None
+
+    text = str(value).strip()
+    if not text:
+        return None
+    if HTTP_URI_RE.match(text):
+        return URIRef(text)
+    alias = LICENSE_ALIASES.get(canonical_key(text))
+    if alias:
+        return URIRef(alias)
+    raise MetadataGenerationError(
+        f"Unsupported license value {text!r}; use a license URI or a supported alias such as CC-BY-4.0."
+    )
+
+
+def explicit_yaml_model_uri(data: Mapping[str, Any]) -> Optional[URIRef]:
+    """Return an explicit YAML model URI when a compatible field is present."""
+
+    raw_uri = yaml_first_value(
+        data,
+        (
+            ("uri",),
+            ("iri",),
+            ("modelUri",),
+            ("modelIri",),
+            ("model", "uri"),
+            ("model", "iri"),
+            ("metadata", "uri"),
+            ("resource", "uri"),
+        ),
+    )
+    text = yaml_text(raw_uri)
+    if text:
+        return normalize_model_uri(
+            uri_from_text(text, field_name="model URI", trailing_slash=False)
+        )
+    return None
+
+
+def deterministic_model_uri(dataset_folder: Path, model_iri_base: str) -> URIRef:
+    """Return the converter-compatible deterministic model URI for a new dataset."""
+
+    slug = dataset_folder.name.strip().strip("/")
+    if not slug:
+        raise MetadataGenerationError(
+            "Could not infer model URI because the dataset folder has no name."
+        )
+    base = model_iri_base.rstrip("/")
+    generated_uuid = uuid.uuid5(uuid.NAMESPACE_URL, f"{base}|{slug}")
+    return URIRef(f"{base}/{generated_uuid}")
+
+
+def load_model_metadata(
+    dataset_folder: Path, config: Config
+) -> tuple[str, Literal, Optional[URIRef], Optional[URIRef]]:
+    """Load title, issued date, license, and optional explicit URI from metadata.yaml."""
+
+    metadata_path = dataset_folder / "metadata.yaml"
+    if not metadata_path.exists():
+        raise MetadataGenerationError(
+            f"Missing required canonical metadata file: {metadata_path}"
+        )
+
+    data = load_yaml_mapping(metadata_path)
+    title = yaml_text(
+        yaml_first_value(
+            data,
+            (
+                ("title",),
+                ("model", "title"),
+                ("metadata", "title"),
+                ("resource", "title"),
+                ("ontology", "title"),
+                ("name",),
+            ),
+        )
+    )
+    if not title:
+        raise MetadataGenerationError(f"Missing required title in {metadata_path}")
+
+    issued_literal = yaml_issued_literal(
+        yaml_first_value(
+            data,
+            (
+                ("issued",),
+                ("dateIssued",),
+                ("issuedDate",),
+                ("issued_date",),
+                ("date",),
+                ("metadata", "issued"),
+                ("metadata", "dateIssued"),
+                ("metadata", "date"),
+                ("model", "issued"),
+                ("model", "dateIssued"),
+                ("resource", "issued"),
+                ("resource", "dateIssued"),
+                ("publication", "issued"),
+                ("publication", "date"),
+                ("publicationDate",),
+            ),
+        )
+    )
+    if issued_literal is None:
+        raise MetadataGenerationError(
+            f"Missing required issued date in {metadata_path}"
+        )
+
+    license_ref = yaml_license_uri(
+        yaml_first_value(
+            data,
+            (
+                ("license",),
+                ("licenseUrl",),
+                ("licenseUri",),
+                ("metadata", "license"),
+                ("metadata", "licenseUrl"),
+                ("metadata", "licenseUri"),
+                ("model", "license"),
+                ("resource", "license"),
+                ("rights", "license"),
+                ("rights", "licenseUrl"),
+                ("rights", "licenseUri"),
+            ),
+        )
+    )
+    if license_ref is None and not effective_allow_missing_license(config):
+        raise MetadataGenerationError(
+            "Missing mandatory metadata field(s): license. "
+            "Use --allow-missing-license only for legacy datasets that intentionally lack license metadata."
+        )
+
+    return title, issued_literal, license_ref, explicit_yaml_model_uri(data)
+
+
+def is_part_of_uri_from_text(text: str) -> Optional[URIRef]:
+    """Extract a distribution dct:isPartOf URI from Turtle text without full parsing."""
+
+    match = IS_PART_OF_RE.search(text) or FULL_IS_PART_OF_RE.search(text)
+    return normalize_model_uri(URIRef(match.group(1))) if match else None
+
+
+def unique_existing_model_uri(
+    uris: Iterable[URIRef], source_description: str
+) -> Optional[URIRef]:
+    """Return one existing model URI or fail on conflicting preserved values."""
+
+    normalized = sorted(
+        {str(normalize_model_uri(uri)) for uri in uris if uri is not None}
+    )
+    if not normalized:
+        return None
+    if len(normalized) > 1:
+        raise MetadataGenerationError(
+            f"Conflicting model URIs found in {source_description}: "
+            + ", ".join(normalized)
+        )
+    return URIRef(normalized[0])
+
+
+def discover_other_distribution_model_uri(
+    dataset_folder: Path, target_path: Path
+) -> Optional[URIRef]:
+    """Return a unique model URI from non-target distribution metadata files."""
+
+    model_uris: list[URIRef] = []
+    for path in sorted(dataset_folder.glob("metadata-*.ttl")):
+        if path == target_path or path.name == OUTPUT_FILE_NAME:
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except OSError as exc:
+            raise MetadataGenerationError(
+                f"Could not read existing distribution metadata {path}: {exc}"
+            ) from exc
+        uri = is_part_of_uri_from_text(text)
+        if uri is not None:
+            model_uris.append(uri)
+    return unique_existing_model_uri(
+        model_uris, f"existing distribution metadata files in {dataset_folder}"
+    )
+
+
+def dataset_appears_existing_catalog_dataset(dataset_folder: Path) -> bool:
+    """Return whether the folder has signs of an existing catalog metadata record."""
+
+    if (dataset_folder / "metadata.ttl").exists():
+        return True
+    return any(dataset_folder.glob("metadata-*.ttl"))
+
+
+def resolve_model_uri(
+    dataset_folder: Path,
+    target_path: Path,
+    existing_target_uri: Optional[URIRef],
+    yaml_uri: Optional[URIRef],
+    config: Config,
+) -> URIRef:
+    """Resolve the model URI without reading model-level metadata.ttl."""
+
+    other_uri = discover_other_distribution_model_uri(dataset_folder, target_path)
+    if existing_target_uri is not None and other_uri is not None:
+        target = normalize_model_uri(existing_target_uri)
+        other = normalize_model_uri(other_uri)
+        if target != other:
+            raise MetadataGenerationError(
+                "Conflicting model URIs found between existing JSON metadata and other distribution metadata files: "
+                f"{target}, {other}"
+            )
+    if existing_target_uri is not None:
+        return normalize_model_uri(existing_target_uri)
+    if other_uri is not None:
+        return normalize_model_uri(other_uri)
+    if yaml_uri is not None:
+        return normalize_model_uri(yaml_uri)
+    if dataset_appears_existing_catalog_dataset(dataset_folder):
+        raise MetadataGenerationError(
+            "No stable catalog model IRI could be preserved from existing distribution metadata. "
+            "This folder appears to be an existing catalog dataset, so the script will not silently generate a new deterministic model IRI. "
+            "Regenerate from a distribution metadata file containing dct:isPartOf or provide an explicit model URI only after confirming the intended catalog identifier."
+        )
+    return deterministic_model_uri(dataset_folder, config.model_iri_base)
+
+
+def prefixed_datetime_literal_from_text(text: str, name: str) -> Optional[Literal]:
+    """Preserve exact xsd:dateTime lexical forms from existing Turtle text."""
+
+    patterns = (
+        PREFIXED_DATETIME_RE_TEMPLATE.format(name=name),
+        FULL_DATETIME_RE_TEMPLATE.format(name=name),
+    )
+    for pattern in patterns:
+        match = re.search(pattern, text, re.S)
+        if match:
+            return Literal(match.group(1), datatype=XSD.dateTime, normalize=False)
+    return None
+
+
+def first_object(graph: Graph, subject: URIRef, predicate: URIRef) -> Any:
+    for obj in graph.objects(subject, predicate):
+        return obj
+    return None
+
+
+def read_existing_metadata(path: Path) -> ExistingDistributionMetadata:
+    """Read reusable values from an existing JSON distribution metadata file."""
+
+    if not path.exists():
+        return ExistingDistributionMetadata()
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise MetadataGenerationError(
+            f"Could not read existing metadata file {path}: {exc}"
+        ) from exc
+
+    graph = Graph()
+    bind_prefixes(graph)
+    try:
+        graph.parse(data=text, format="turtle")
+    except Exception as exc:  # noqa: BLE001 - surface RDFLib parse errors clearly
+        raise MetadataGenerationError(
+            f"Could not parse existing JSON metadata {path}: {exc}"
+        ) from exc
+
+    subjects = list(graph.subjects(RDF.type, DCAT.Distribution))
+    if len(subjects) > 1:
+        raise MetadataGenerationError(
+            f"Existing JSON metadata has multiple dcat:Distribution subjects: {path}"
+        )
+    if subjects:
+        subject = subjects[0]
+    else:
+        match = DISTRIBUTION_IRI_RE.search(text)
+        subject = URIRef(match.group(1)) if match else None
+
+    if subject is None:
+        raise MetadataGenerationError(
+            f"Existing JSON metadata has no dcat:Distribution subject: {path}"
+        )
+
+    download_url = first_object(graph, subject, DCAT.downloadURL)
+    license_uri = first_object(graph, subject, DCT.license)
+    schema_uri = first_object(graph, subject, OCMV.conformsToSchema)
+    model_uri = first_object(graph, subject, DCT.isPartOf) or is_part_of_uri_from_text(
+        text
+    )
+    return ExistingDistributionMetadata(
+        uri=URIRef(subject),
+        model_uri=normalize_model_uri(URIRef(model_uri))
+        if model_uri is not None
+        else None,
+        title=first_object(graph, subject, DCT.title),
+        editorial_note=first_object(graph, subject, SKOS.editorialNote),
+        download_url=URIRef(download_url) if download_url is not None else None,
+        license_uri=URIRef(license_uri) if license_uri is not None else None,
+        schema_uri=URIRef(schema_uri) if schema_uri is not None else None,
+        metadata_issued=prefixed_datetime_literal_from_text(text, "metadataIssued")
+        or first_object(graph, subject, FDPO.metadataIssued),
+        metadata_modified=prefixed_datetime_literal_from_text(text, "metadataModified")
+        or first_object(graph, subject, FDPO.metadataModified),
+    )
+
+
+def deterministic_distribution_uri(model_uri: URIRef, source_repo_path: str) -> URIRef:
+    """Return a deterministic distribution URI for a new JSON metadata file."""
+
+    seed = f"{normalize_model_uri(model_uri)}|{source_repo_path.strip('/')}"
+    return URIRef(f"{DISTRIBUTION_BASE}{uuid.uuid5(uuid.NAMESPACE_URL, seed)}/")
+
+
+def quote_path_segment(segment: str) -> str:
+    """Quote a URL path segment while preserving commas for catalog compatibility."""
+
+    return quote(segment, safe=",-_.~()")
+
+
+def split_path_like(value: str) -> list[str]:
+    """Split a slash-separated path-like CLI value into non-empty segments."""
+
+    return [segment for segment in value.strip("/").split("/") if segment]
+
+
+def repository_relative_source_path(dataset_folder: Path, config: Config) -> str:
+    """Return the repository-relative ontology.json path used in stable identifiers."""
+
+    return "/".join(
+        [
+            *split_path_like(config.models_dir_name),
+            dataset_folder.name,
+            SOURCE_FILE_NAME,
+        ]
+    )
+
+
+def default_download_url(dataset_folder: Path, config: Config) -> URIRef:
+    """Return the raw GitHub download URL for ontology.json."""
+
+    parts = (
+        ["https://raw.githubusercontent.com"]
+        + [quote_path_segment(part) for part in split_path_like(config.repository)]
+        + [quote_path_segment(config.branch.strip("/"))]
+        + [quote_path_segment(part) for part in split_path_like(config.models_dir_name)]
+        + [
+            quote_path_segment(dataset_folder.name),
+            quote_path_segment(SOURCE_FILE_NAME),
+        ]
+    )
+    return URIRef("/".join(parts))
+
+
+def validate_uri(value: URIRef, *, field_name: str) -> URIRef:
+    text = str(value)
+    if not HTTP_URI_RE.match(text):
+        raise MetadataGenerationError(
+            f"{field_name} must be an HTTP(S) URI; got {text!r}."
+        )
+    return URIRef(text)
+
+
+def validate_ontology_json(path: Path, *, check_source_file: bool) -> None:
+    """Validate that ontology.json exists and is parseable JSON when checking is enabled."""
+
+    if not check_source_file:
+        return
+    if not path.exists():
+        raise MetadataGenerationError(f"Missing required ontology JSON file: {path}")
+    if not path.is_file():
+        raise MetadataGenerationError(f"Ontology JSON path is not a file: {path}")
+    try:
+        with path.open("r", encoding="utf-8") as stream:
+            data = json.load(stream)
+    except json.JSONDecodeError as exc:
+        raise MetadataGenerationError(
+            f"Invalid ontology JSON file {path}: {exc}"
+        ) from exc
+    except OSError as exc:
+        raise MetadataGenerationError(
+            f"Could not read ontology JSON file {path}: {exc}"
+        ) from exc
+    if not isinstance(data, Mapping):
+        raise MetadataGenerationError(
+            f"Ontology JSON file must contain a JSON object at the top level: {path}"
+        )
+
+
+def current_metadata_timestamp() -> Literal:
+    """Return the current UTC timestamp as xsd:dateTime."""
+
+    value = (
+        datetime.now(timezone.utc)
+        .isoformat(timespec="microseconds")
+        .replace("+00:00", "Z")
+    )
+    return Literal(value, datatype=XSD.dateTime, normalize=False)
+
+
+def configured_metadata_timestamp(config: Config, target: Path) -> Literal:
+    """Return the explicit run timestamp used for FDP timestamp changes."""
+
+    if config.metadata_timestamp == "now":
+        return current_metadata_timestamp()
+    if config.metadata_timestamp:
+        if not XSD_DATETIME_RE.match(config.metadata_timestamp):
+            raise MetadataGenerationError(
+                "--metadata-timestamp must be an xsd:dateTime lexical value, "
+                "for example 2024-01-02T03:04:05Z. Use 'now' only when a "
+                "non-deterministic current timestamp is intentionally desired."
+            )
+        return Literal(
+            config.metadata_timestamp, datatype=XSD.dateTime, normalize=False
+        )
+    raise MetadataGenerationError(
+        f"No run timestamp is available to initialize fdpo:metadataIssued or update "
+        f"fdpo:metadataModified in {target}. Provide --metadata-timestamp, for example "
+        "--metadata-timestamp 2026-01-31T12:00:00Z. Use --metadata-timestamp now "
+        "only when a non-deterministic execution timestamp is acceptable."
+    )
+
+
+def term_n3(term: Any) -> str:
+    if isinstance(term, URIRef):
+        return term.n3(NS_MANAGER)
+    if isinstance(term, Literal):
+        return term.n3(NS_MANAGER)
+    raise TypeError(f"Unsupported RDF term type: {type(term).__name__}")
+
+
+def render_predicate_object(
+    predicate: URIRef, objects: list[Any], *, final: bool
+) -> str:
+    predicate_text = predicate.n3(NS_MANAGER)
+    object_texts = [term_n3(obj) for obj in objects]
+    suffix = " ." if final else ";"
+    if len(object_texts) == 1:
+        return f"    {predicate_text} {object_texts[0]}{suffix}"
+    joined = (",\n" + " " * (len(predicate_text) + 5)).join(object_texts)
+    return f"    {predicate_text} {joined}{suffix}"
+
+
+def render_turtle(subject: URIRef, statements: list[tuple[URIRef, list[Any]]]) -> str:
+    lines = [
+        "@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.",
+        "@prefix dcat: <http://www.w3.org/ns/dcat#>.",
+        "@prefix dct: <http://purl.org/dc/terms/>.",
+        "@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.",
+        "@prefix owl: <http://www.w3.org/2002/07/owl#>.",
+        "@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.",
+        "@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.",
+        "@prefix skos: <http://www.w3.org/2004/02/skos/core#>.",
+        "@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.",
+        "",
+        f"{subject.n3(NS_MANAGER)} a dcat:Distribution;",
+    ]
+    for index, (predicate, objects) in enumerate(statements):
+        lines.append(
+            render_predicate_object(
+                predicate, objects, final=index == len(statements) - 1
+            )
+        )
+    return "\n".join(lines) + "\n"
+
+
+def build_distribution_turtle(
+    model: ModelMetadata,
+    distribution_uri: URIRef,
+    existing: ExistingDistributionMetadata,
+    download_url: URIRef,
+    config: Config,
+    output_path: Path,
+    *,
+    update_metadata_modified: bool = False,
+) -> str:
+    """Build RDF/Turtle metadata for the JSON distribution."""
+
+    run_timestamp: Optional[Literal] = None
+
+    def get_run_timestamp() -> Literal:
+        nonlocal run_timestamp
+        if run_timestamp is None:
+            run_timestamp = configured_metadata_timestamp(config, output_path)
+        return run_timestamp
+
+    metadata_issued = existing.metadata_issued or get_run_timestamp()
+    if update_metadata_modified:
+        metadata_modified = get_run_timestamp()
+    else:
+        metadata_modified = existing.metadata_modified or metadata_issued
+
+    if model.license_uri is not None:
+        license_uri = model.license_uri
+    elif effective_allow_missing_license(config) and existing.license_uri is not None:
+        license_uri = existing.license_uri
+    else:
+        license_uri = None
+
+    schema_uri = validate_uri(
+        existing.schema_uri or JSON_SCHEMA_URI, field_name="ocmv:conformsToSchema"
+    )
+    download_url = validate_uri(download_url, field_name="dcat:downloadURL")
+
+    statements: list[tuple[URIRef, list[Any]]] = [
+        (DCT.isPartOf, [model.uri]),
+        (DCT.issued, [model.issued]),
+        (DCAT.mediaType, [JSON_MEDIA_TYPE]),
+    ]
+    if license_uri is not None:
+        statements.append((DCT.license, [license_uri]))
+    statements.extend(
+        [
+            (OCMV.conformsToSchema, [schema_uri]),
+            (
+                DCT.title,
+                [
+                    existing.title
+                    or Literal(f"JSON distribution of {model.title}", lang="en")
+                ],
+            ),
+            (DCAT.downloadURL, [download_url]),
+            (OCMV.isComplete, [Literal(True, datatype=XSD.boolean)]),
+        ]
+    )
+    if existing.editorial_note is not None:
+        statements.append((SKOS.editorialNote, [existing.editorial_note]))
+    statements.extend(
+        [
+            (FDPO.metadataIssued, [metadata_issued]),
+            (FDPO.metadataModified, [metadata_modified]),
+        ]
+    )
+
+    turtle = render_turtle(distribution_uri, statements)
+    graph = Graph()
+    bind_prefixes(graph)
+    try:
+        graph.parse(data=turtle, format="turtle")
+    except Exception as exc:  # noqa: BLE001 - surface RDFLib parse errors clearly
+        raise MetadataGenerationError(
+            f"Generated Turtle is not parseable: {exc}"
+        ) from exc
+    return turtle
+
+
+def process_dataset(dataset_folder: Path, config: Config) -> list[GeneratedFile]:
+    """Generate JSON distribution metadata for one dataset folder."""
+
+    dataset_folder = validate_dataset_folder(dataset_folder)
+    source_path = dataset_folder / SOURCE_FILE_NAME
+    output_path = dataset_folder / OUTPUT_FILE_NAME
+
+    validate_ontology_json(source_path, check_source_file=config.check_source_file)
+    title, issued, license_uri, yaml_uri = load_model_metadata(dataset_folder, config)
+    existing = read_existing_metadata(output_path)
+    model_uri = resolve_model_uri(
+        dataset_folder,
+        output_path,
+        existing.model_uri,
+        yaml_uri,
+        config,
+    )
+    model = ModelMetadata(
+        uri=model_uri, title=title, license_uri=license_uri, issued=issued
+    )
+    source_repo_path = repository_relative_source_path(dataset_folder, config)
+    distribution_uri = existing.uri or deterministic_distribution_uri(
+        model.uri, source_repo_path
+    )
+    download_url = existing.download_url or default_download_url(dataset_folder, config)
+
+    if output_path.exists() and not config.overwrite:
+        raise MetadataGenerationError(
+            f"Metadata file already exists and overwrite is disabled: {output_path}"
+        )
+
+    old_text = output_path.read_text(encoding="utf-8") if output_path.exists() else None
+    initial_text = build_distribution_turtle(
+        model,
+        distribution_uri,
+        existing,
+        download_url,
+        config,
+        output_path,
+    )
+    changed = old_text != initial_text
+    final_text = initial_text
+    if changed:
+        final_text = build_distribution_turtle(
+            model,
+            distribution_uri,
+            existing,
+            download_url,
+            config,
+            output_path,
+            update_metadata_modified=True,
+        )
+        changed = old_text != final_text
+
+    if config.check and changed and config.emit_diff:
+        if old_text is None:
+            print(f"Would create {output_path}")
+        else:
+            diff = difflib.unified_diff(
+                old_text.splitlines(),
+                final_text.splitlines(),
+                fromfile=str(output_path),
+                tofile=f"{output_path} (generated)",
+                lineterm="",
+            )
+            for line in diff:
+                print(line)
+
+    written = False
+    if changed and not config.dry_run and not config.check:
+        output_path.write_text(final_text, encoding="utf-8")
+        written = True
+
+    return [
+        GeneratedFile(
+            source_path=source_path,
+            metadata_path=output_path,
+            distribution_uri=distribution_uri,
+            model_uri=model.uri,
+            changed=changed,
+            written=written,
+        )
+    ]
+
+
+def discover_datasets(models_dir: Path) -> list[Path]:
+    """Discover model dataset folders under models_dir by metadata.yaml presence."""
+
+    models_dir = models_dir.resolve()
+    if not models_dir.exists():
+        raise MetadataSetupError(f"Models directory does not exist: {models_dir}")
+    if not models_dir.is_dir():
+        raise MetadataSetupError(f"Models path is not a directory: {models_dir}")
+    return sorted(
+        path
+        for path in models_dir.iterdir()
+        if path.is_dir() and (path / "metadata.yaml").exists()
+    )
+
+
+def resolve_targets(args: argparse.Namespace) -> list[Path]:
+    if args.all:
+        if args.datasets:
+            raise MetadataSetupError(
+                "Use either --all or explicit dataset folders, not both."
+            )
+        datasets = discover_datasets(args.models_dir)
+    elif args.datasets:
+        datasets = [validate_dataset_folder(path) for path in args.datasets]
+    else:
+        cwd = Path.cwd()
+        if (cwd / "metadata.yaml").exists():
+            datasets = [cwd]
+        else:
+            raise MetadataSetupError(
+                "No dataset folder provided. Pass one or more model folders, use --all, or run from a dataset folder."
+            )
+    if not datasets:
+        raise MetadataSetupError("No dataset folders with metadata.yaml were found.")
+    return datasets
+
+
+def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate metadata-json.ttl files from ontology.json files and metadata.yaml.",
+    )
+    parser.add_argument(
+        "datasets",
+        nargs="*",
+        type=Path,
+        help="Dataset folder(s) to process. If omitted, the current directory is used when it contains metadata.yaml.",
+    )
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Process all dataset folders below --models-dir.",
+    )
+    parser.add_argument(
+        "--models-dir",
+        type=Path,
+        default=Path(DEFAULT_MODELS_DIR),
+        help=f"Models directory used with --all. Default: {DEFAULT_MODELS_DIR}.",
+    )
+    parser.add_argument(
+        "--allow-missing-license",
+        action="store_true",
+        help="Allow generation for legacy datasets without license metadata; otherwise license is mandatory.",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Do not write files; exit 1 if metadata-json.ttl would change.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Validate inputs and report files that would be generated without writing them.",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("text", "json"),
+        default="text",
+        help="Summary output format. Default: text.",
+    )
+    parser.add_argument(
+        "-q",
+        "--quiet",
+        "--silent",
+        action="store_true",
+        help="Suppress per-file progress logs and the final text summary. Errors are still printed to stderr.",
+    )
+    parser.add_argument(
+        "--repository",
+        default=DEFAULT_REPOSITORY,
+        help=f"GitHub repository used for dcat:downloadURL. Default: {DEFAULT_REPOSITORY}.",
+    )
+    parser.add_argument(
+        "--branch",
+        default=DEFAULT_BRANCH,
+        help=f"Git branch used for dcat:downloadURL. Default: {DEFAULT_BRANCH}.",
+    )
+    parser.add_argument(
+        "--models-dir-name",
+        default=DEFAULT_MODELS_DIR,
+        help=f"Repository-relative models path used inside generated dcat:downloadURL values. Default: {DEFAULT_MODELS_DIR}.",
+    )
+    parser.add_argument(
+        "--model-iri-base",
+        default=DEFAULT_MODEL_IRI_BASE,
+        help=f"Base IRI used for deterministic UUIDv5 model IRIs when no existing catalog model IRI is available. Default: {DEFAULT_MODEL_IRI_BASE}.",
+    )
+    parser.add_argument(
+        "--no-overwrite",
+        action="store_true",
+        help="Fail if metadata-json.ttl already exists.",
+    )
+    parser.add_argument(
+        "--no-check-ontology-json",
+        action="store_true",
+        help="Do not require ontology.json to exist and be parseable before generating metadata-json.ttl.",
+    )
+    parser.add_argument(
+        "--metadata-timestamp",
+        help=(
+            "xsd:dateTime value used to initialize missing fdpo:metadataIssued values and "
+            "update fdpo:metadataModified when an existing metadata file changes. Required when "
+            "creating new metadata files, when existing files lack fdpo:metadataIssued, or when "
+            "existing files need regeneration changes. Use 'now' only when a non-deterministic "
+            "current timestamp is intentionally desired."
+        ),
+    )
+    parser.add_argument(
+        "--require-license",
+        action="store_true",
+        help=argparse.SUPPRESS,
+    )
+    args = parser.parse_args(argv)
+    if args.check and args.dry_run:
+        parser.error("--check and --dry-run cannot be used together.")
+    if args.allow_missing_license and args.require_license:
+        parser.error(
+            "--allow-missing-license and --require-license cannot be used together."
+        )
+    return args
+
+
+def action_label(config: Config, item: GeneratedFile) -> str:
+    if config.dry_run:
+        return "would generate"
+    if config.check:
+        return "needs update" if item.changed else "up to date"
+    return "generated" if item.written else "unchanged"
+
+
+def print_progress(item: GeneratedFile, config: Config) -> None:
+    print(f"{action_label(config, item)}: {item.metadata_path} <- {item.source_path}")
+
+
+def print_summary(
+    results: Sequence[GeneratedFile], error_count: int, config: Config
+) -> None:
+    if config.dry_run:
+        return
+    changed = sum(1 for item in results if item.changed)
+    written = sum(1 for item in results if item.written)
+    total = len(results) + error_count
+    if config.check:
+        print(
+            f"Summary: {total} file(s) processed, {len(results)} succeeded, "
+            f"{error_count} error(s), {changed} file(s) need update."
+        )
+    else:
+        print(
+            f"Summary: {total} file(s) processed, {len(results)} succeeded, "
+            f"{error_count} error(s), {written} written, {changed} changed."
+        )
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    args = parse_args(argv)
+    config = Config(
+        repository=args.repository,
+        branch=args.branch,
+        models_dir_name=args.models_dir_name,
+        model_iri_base=args.model_iri_base,
+        overwrite=not args.no_overwrite,
+        dry_run=args.dry_run,
+        check=args.check,
+        check_source_file=not args.no_check_ontology_json,
+        metadata_timestamp=args.metadata_timestamp,
+        allow_missing_license=args.allow_missing_license,
+        require_license=args.require_license or None,
+        emit_diff=args.format == "text" and not args.quiet,
+        quiet=args.quiet,
+    )
+
+    try:
+        targets = resolve_targets(args)
+    except MetadataSetupError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    results: list[GeneratedFile] = []
+    errors: list[dict[str, str]] = []
+    progress_enabled = args.format == "text" and not args.quiet
+    for target in targets:
+        try:
+            generated = process_dataset(target, config)
+            results.extend(generated)
+            if progress_enabled:
+                for item in generated:
+                    print_progress(item, config)
+        except MetadataGenerationError as exc:
+            errors.append({"dataset": str(target), "error": str(exc)})
+            print(f"ERROR {target}: {exc}", file=sys.stderr)
+
+    if args.format == "json":
+        print(
+            json.dumps(
+                {
+                    "ok": not errors
+                    and not (config.check and any(item.changed for item in results)),
+                    "results": [item.to_dict() for item in results],
+                    "errors": errors,
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+    elif not args.quiet:
+        print_summary(results, len(errors), config)
+
+    if errors:
+        return 1
+    if config.check and any(item.changed for item in results):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_generate_json_metadata.py
+++ b/scripts/tests/test_generate_json_metadata.py
@@ -1,0 +1,955 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import uuid
+from pathlib import Path
+
+import pytest
+
+
+def load_module():
+    script = None
+    for parent in Path(__file__).resolve().parents:
+        for candidate in (
+            parent / "generate_json_metadata.py",
+            parent / "scripts" / "generate_json_metadata.py",
+        ):
+            if candidate.exists():
+                script = candidate
+                break
+        if script is not None:
+            break
+    assert script is not None
+    spec = importlib.util.spec_from_file_location("generate_json_metadata", script)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def write_ontology_json(dataset: Path, content: object | None = None) -> None:
+    payload = content if content is not None else {"id": "project_1", "type": "Project"}
+    (dataset / "ontology.json").write_text(json.dumps(payload), encoding="utf-8")
+
+
+def write_metadata_yaml(
+    dataset: Path,
+    *,
+    title: str = "Reference Ontology of Trust",
+    issued: str = "2019",
+    license_value: str | None = "https://creativecommons.org/licenses/by/4.0/",
+    extra: str = "",
+) -> None:
+    license_line = f"license: {license_value}\n" if license_value is not None else ""
+    (dataset / "metadata.yaml").write_text(
+        f"""
+title: {title}
+issued: {issued}
+{license_line}{extra}""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def write_dataset(tmp_path: Path, *, name: str = "example-model") -> Path:
+    dataset = tmp_path / "models" / name
+    dataset.mkdir(parents=True)
+    write_ontology_json(dataset)
+    write_metadata_yaml(dataset)
+    return dataset
+
+
+def deterministic_model_uri(slug: str) -> str:
+    model_uuid = uuid.uuid5(
+        uuid.NAMESPACE_URL, f"https://w3id.org/ontouml-models/model|{slug}"
+    )
+    return f"https://w3id.org/ontouml-models/model/{model_uuid}"
+
+
+def write_existing_json_metadata(
+    dataset: Path,
+    *,
+    distribution_uri: str = "https://w3id.org/ontouml-models/distribution/existing-json/",
+    model_uri: str = "https://w3id.org/ontouml-models/model/existing-model",
+    title: str = "Curated JSON title",
+    download_url: str = "https://example.org/curated/ontology.json",
+    license_uri: str | None = "https://example.org/existing-license",
+    editorial_note: str | None = "Curated JSON editorial note.",
+    metadata_issued: str = "2023-04-14T17:35:29.862157131Z",
+    metadata_modified: str = "2023-04-14T17:35:30.862157131Z",
+) -> None:
+    license_line = f"    dct:license <{license_uri}>;\n" if license_uri else ""
+    editorial_line = (
+        f'    skos:editorialNote "{editorial_note}"@en;\n' if editorial_note else ""
+    )
+    (dataset / "metadata-json.ttl").write_text(
+        f"""
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#>.
+@prefix dct: <http://purl.org/dc/terms/>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
+@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+
+<{distribution_uri}> a dcat:Distribution;
+    dct:isPartOf <{model_uri}>;
+    dct:issued "2019"^^xsd:gYear;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+{license_line}    ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
+    dct:title "{title}"@en;
+    dcat:downloadURL <{download_url}>;
+    ocmv:isComplete "true"^^xsd:boolean;
+{editorial_line}    fdpo:metadataIssued "{metadata_issued}"^^xsd:dateTime;
+    fdpo:metadataModified "{metadata_modified}"^^xsd:dateTime .
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_json_metadata_generation_uses_metadata_yaml_when_metadata_ttl_is_absent(
+    tmp_path: Path,
+):
+    module = load_module()
+    dataset = write_dataset(tmp_path, name="new-json-model")
+
+    assert not (dataset / "metadata.ttl").exists()
+    module.process_dataset(
+        dataset, module.Config(metadata_timestamp="2024-01-02T03:04:05Z")
+    )
+
+    generated = (dataset / "metadata-json.ttl").read_text(encoding="utf-8")
+    assert 'dct:issued "2019"^^xsd:gYear' in generated
+    assert "JSON distribution of Reference Ontology of Trust" in generated
+    assert "https://creativecommons.org/licenses/by/4.0/" in generated
+    assert (
+        "dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>"
+        in generated
+    )
+    assert "ocmv:conformsToSchema <https://w3id.org/ontouml/schema>" in generated
+    assert 'ocmv:isComplete "true"^^xsd:boolean' in generated
+    assert "metadata.ttl" not in generated
+
+
+def test_metadata_ttl_is_not_used_when_distribution_metadata_provides_model_uri(
+    tmp_path: Path,
+):
+    module = load_module()
+    dataset = write_dataset(tmp_path, name="ignore-metadata-ttl")
+    (dataset / "metadata.ttl").write_text(
+        "<https://w3id.org/ontouml-models/model/from-metadata-ttl/> a <http://www.w3.org/ns/dcat#Dataset> .\n",
+        encoding="utf-8",
+    )
+    (dataset / "metadata-png-o-diagram.ttl").write_text(
+        """
+@prefix dcat: <http://www.w3.org/ns/dcat#>.
+@prefix dct: <http://purl.org/dc/terms/>.
+<https://w3id.org/ontouml-models/distribution/png-existing> a dcat:Distribution;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/from-distribution-metadata> .
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    module.process_dataset(
+        dataset, module.Config(metadata_timestamp="2024-01-02T03:04:05Z")
+    )
+
+    generated = (dataset / "metadata-json.ttl").read_text(encoding="utf-8")
+    assert "from-distribution-metadata" in generated
+    assert "from-metadata-ttl" not in generated
+
+
+def test_existing_json_is_part_of_is_preserved(tmp_path: Path):
+    module = load_module()
+    dataset = write_dataset(tmp_path, name="existing-json-is-part-of")
+    write_existing_json_metadata(
+        dataset,
+        model_uri="https://w3id.org/ontouml-models/model/preserved-json-model",
+    )
+
+    module.process_dataset(
+        dataset, module.Config(metadata_timestamp="2024-01-02T03:04:05Z")
+    )
+
+    generated = (dataset / "metadata-json.ttl").read_text(encoding="utf-8")
+    assert (
+        "dct:isPartOf <https://w3id.org/ontouml-models/model/preserved-json-model>"
+        in generated
+    )
+
+
+def test_other_distribution_is_part_of_is_used_when_json_metadata_is_absent(
+    tmp_path: Path,
+):
+    module = load_module()
+    dataset = write_dataset(tmp_path, name="other-distribution-uri")
+    (dataset / "metadata-vpp.ttl").write_text(
+        """
+@prefix dcat: <http://www.w3.org/ns/dcat#>.
+@prefix dct: <http://purl.org/dc/terms/>.
+<https://w3id.org/ontouml-models/distribution/vpp-existing> a dcat:Distribution;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/from-existing-vpp> .
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    module.process_dataset(
+        dataset, module.Config(metadata_timestamp="2024-01-02T03:04:05Z")
+    )
+
+    generated = (dataset / "metadata-json.ttl").read_text(encoding="utf-8")
+    assert (
+        "dct:isPartOf <https://w3id.org/ontouml-models/model/from-existing-vpp>"
+        in generated
+    )
+
+
+def test_conflicting_existing_distribution_model_uris_fail(tmp_path: Path):
+    module = load_module()
+    dataset = write_dataset(tmp_path, name="conflicting-model-uris")
+    write_existing_json_metadata(
+        dataset,
+        model_uri="https://w3id.org/ontouml-models/model/from-json",
+    )
+    (dataset / "metadata-vpp.ttl").write_text(
+        """
+@prefix dcat: <http://www.w3.org/ns/dcat#>.
+@prefix dct: <http://purl.org/dc/terms/>.
+<https://w3id.org/ontouml-models/distribution/vpp-existing> a dcat:Distribution;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/from-vpp> .
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(module.MetadataGenerationError, match="Conflicting model URIs"):
+        module.process_dataset(
+            dataset, module.Config(metadata_timestamp="2024-01-02T03:04:05Z")
+        )
+
+
+def test_new_dataset_uses_converter_compatible_deterministic_model_uri(tmp_path: Path):
+    module = load_module()
+    dataset = write_dataset(tmp_path, name="new-deterministic-json-model")
+
+    module.process_dataset(
+        dataset, module.Config(metadata_timestamp="2024-01-02T03:04:05Z")
+    )
+
+    generated = (dataset / "metadata-json.ttl").read_text(encoding="utf-8")
+    assert (
+        f"dct:isPartOf <{deterministic_model_uri('new-deterministic-json-model')}>"
+        in generated
+    )
+
+
+def test_existing_catalog_dataset_without_preservable_model_uri_fails(tmp_path: Path):
+    module = load_module()
+    dataset = write_dataset(tmp_path, name="existing-without-model-uri")
+    (dataset / "metadata.ttl").write_text("legacy model metadata\n", encoding="utf-8")
+
+    with pytest.raises(
+        module.MetadataGenerationError, match="No stable catalog model IRI"
+    ):
+        module.process_dataset(
+            dataset, module.Config(metadata_timestamp="2024-01-02T03:04:05Z")
+        )
+
+    assert not (dataset / "metadata-json.ttl").exists()
+
+
+def test_existing_distribution_iri_and_curated_values_are_preserved(tmp_path: Path):
+    module = load_module()
+    dataset = write_dataset(tmp_path, name="curated-json-values")
+    write_existing_json_metadata(dataset)
+
+    module.process_dataset(
+        dataset, module.Config(metadata_timestamp="2024-01-02T03:04:05Z")
+    )
+
+    generated = (dataset / "metadata-json.ttl").read_text(encoding="utf-8")
+    assert "https://w3id.org/ontouml-models/distribution/existing-json/" in generated
+    assert "Curated JSON title" in generated
+    assert "Curated JSON editorial note." in generated
+    assert "https://example.org/curated/ontology.json" in generated
+    assert "2023-04-14T17:35:29.862157131Z" in generated
+
+
+def test_missing_license_fails_without_allow_missing_license(tmp_path: Path):
+    module = load_module()
+    dataset = write_dataset(tmp_path, name="missing-license-json")
+    write_metadata_yaml(
+        dataset, title="Missing License JSON", issued="2024", license_value=None
+    )
+
+    with pytest.raises(module.MetadataGenerationError, match="license"):
+        module.process_dataset(
+            dataset, module.Config(metadata_timestamp="2024-01-02T03:04:05Z")
+        )
+
+    assert not (dataset / "metadata-json.ttl").exists()
+
+
+def test_missing_license_is_allowed_with_allow_missing_license(tmp_path: Path):
+    module = load_module()
+    dataset = write_dataset(tmp_path, name="allow-missing-license-json")
+    write_metadata_yaml(
+        dataset, title="Missing License JSON", issued="2024", license_value=None
+    )
+
+    module.process_dataset(
+        dataset,
+        module.Config(
+            metadata_timestamp="2024-01-02T03:04:05Z",
+            allow_missing_license=True,
+        ),
+    )
+
+    generated = (dataset / "metadata-json.ttl").read_text(encoding="utf-8")
+    assert "dct:license" not in generated
+    assert "Missing License JSON" in generated
+
+
+def test_existing_distribution_license_is_preserved_when_missing_license_is_allowed(
+    tmp_path: Path,
+):
+    module = load_module()
+    dataset = write_dataset(tmp_path, name="preserve-existing-license-json")
+    write_metadata_yaml(
+        dataset, title="Existing License JSON", issued="2024", license_value=None
+    )
+    write_existing_json_metadata(
+        dataset, license_uri="https://example.org/existing-json-license"
+    )
+
+    module.process_dataset(
+        dataset,
+        module.Config(
+            metadata_timestamp="2024-01-02T03:04:05Z",
+            allow_missing_license=True,
+        ),
+    )
+
+    generated = (dataset / "metadata-json.ttl").read_text(encoding="utf-8")
+    assert "https://example.org/existing-json-license" in generated
+
+
+def test_yaml_license_is_emitted_even_with_allow_missing_license(tmp_path: Path):
+    module = load_module()
+    dataset = write_dataset(tmp_path, name="allow-with-yaml-license-json")
+
+    module.process_dataset(
+        dataset,
+        module.Config(
+            metadata_timestamp="2024-01-02T03:04:05Z",
+            allow_missing_license=True,
+        ),
+    )
+
+    generated = (dataset / "metadata-json.ttl").read_text(encoding="utf-8")
+    assert "https://creativecommons.org/licenses/by/4.0/" in generated
+
+
+def test_new_file_timestamps_are_initialized_from_metadata_timestamp(tmp_path: Path):
+    module = load_module()
+    dataset = write_dataset(tmp_path, name="new-timestamp-json")
+
+    module.process_dataset(
+        dataset, module.Config(metadata_timestamp="2024-01-02T03:04:05Z")
+    )
+
+    generated = (dataset / "metadata-json.ttl").read_text(encoding="utf-8")
+    assert 'fdpo:metadataIssued "2024-01-02T03:04:05Z"^^xsd:dateTime' in generated
+    assert 'fdpo:metadataModified "2024-01-02T03:04:05Z"^^xsd:dateTime' in generated
+
+
+def test_existing_metadata_issued_is_preserved_and_modified_updates_when_changed(
+    tmp_path: Path,
+):
+    module = load_module()
+    dataset = write_dataset(tmp_path, name="changed-timestamp-json")
+    write_existing_json_metadata(dataset, title="Old Curated Title")
+    write_metadata_yaml(dataset, title="Changed Model Title", issued="2020")
+
+    module.process_dataset(
+        dataset, module.Config(metadata_timestamp="2024-01-02T03:04:05Z")
+    )
+
+    generated = (dataset / "metadata-json.ttl").read_text(encoding="utf-8")
+    assert "2023-04-14T17:35:29.862157131Z" in generated
+    assert "2023-04-14T17:35:30.862157131Z" not in generated
+    assert "2024-01-02T03:04:05Z" in generated
+
+
+def test_unchanged_existing_metadata_modified_is_preserved_without_new_timestamp(
+    tmp_path: Path,
+):
+    module = load_module()
+    dataset = write_dataset(tmp_path, name="unchanged-json")
+
+    first_results = module.process_dataset(
+        dataset, module.Config(metadata_timestamp="2024-01-02T03:04:05Z")
+    )
+    assert first_results[0].written
+    first_text = (dataset / "metadata-json.ttl").read_text(encoding="utf-8")
+
+    second_results = module.process_dataset(dataset, module.Config())
+    second_text = (dataset / "metadata-json.ttl").read_text(encoding="utf-8")
+
+    assert not second_results[0].changed
+    assert first_text == second_text
+    assert "2024-01-02T03:04:05Z" in second_text
+
+
+def test_missing_metadata_timestamp_for_new_file_fails(tmp_path: Path):
+    module = load_module()
+    dataset = write_dataset(tmp_path, name="missing-new-timestamp-json")
+
+    with pytest.raises(module.MetadataGenerationError, match="No run timestamp"):
+        module.process_dataset(dataset, module.Config())
+
+    assert not (dataset / "metadata-json.ttl").exists()
+
+
+def test_changed_existing_file_requires_metadata_timestamp(tmp_path: Path):
+    module = load_module()
+    dataset = write_dataset(tmp_path, name="changed-existing-requires-timestamp")
+    write_existing_json_metadata(dataset)
+    write_metadata_yaml(dataset, title="Changed JSON Title", issued="2022")
+
+    with pytest.raises(module.MetadataGenerationError, match="metadataModified"):
+        module.process_dataset(dataset, module.Config())
+
+    generated = (dataset / "metadata-json.ttl").read_text(encoding="utf-8")
+    assert "2023-04-14T17:35:30.862157131Z" in generated
+
+
+def test_cli_check_returns_one_and_does_not_write(tmp_path: Path):
+    module = load_module()
+    dataset = write_dataset(tmp_path, name="check-json")
+
+    exit_code = module.main(
+        [str(dataset), "--check", "--metadata-timestamp", "2024-01-02T03:04:05Z"]
+    )
+
+    assert exit_code == 1
+    assert not (dataset / "metadata-json.ttl").exists()
+
+
+def test_cli_dry_run_does_not_write(tmp_path: Path, capsys: pytest.CaptureFixture[str]):
+    module = load_module()
+    dataset = write_dataset(tmp_path, name="dry-run-json")
+
+    exit_code = module.main(
+        [str(dataset), "--dry-run", "--metadata-timestamp", "2024-01-02T03:04:05Z"]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "would generate:" in captured.out
+    assert not (dataset / "metadata-json.ttl").exists()
+
+
+def test_cli_json_output(tmp_path: Path, capsys: pytest.CaptureFixture[str]):
+    module = load_module()
+    dataset = write_dataset(tmp_path, name="json-output")
+
+    exit_code = module.main(
+        [
+            str(dataset),
+            "--format",
+            "json",
+            "--metadata-timestamp",
+            "2024-01-02T03:04:05Z",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert exit_code == 0
+    assert payload["ok"] is True
+    assert payload["errors"] == []
+    assert payload["results"][0]["metadata_path"].endswith("metadata-json.ttl")
+
+
+def test_invalid_ontology_json_fails_before_metadata_file_is_written(tmp_path: Path):
+    module = load_module()
+    dataset = write_dataset(tmp_path, name="invalid-source-json")
+    (dataset / "ontology.json").write_text("not valid json", encoding="utf-8")
+
+    with pytest.raises(module.MetadataGenerationError, match="Invalid ontology JSON"):
+        module.process_dataset(
+            dataset, module.Config(metadata_timestamp="2024-01-02T03:04:05Z")
+        )
+
+    assert not (dataset / "metadata-json.ttl").exists()
+
+
+def test_download_url_uses_repository_relative_path_not_local_absolute_path(
+    tmp_path: Path,
+):
+    module = load_module()
+    dataset = write_dataset(tmp_path, name="path-json")
+
+    module.process_dataset(
+        dataset,
+        module.Config(
+            metadata_timestamp="2024-01-02T03:04:05Z",
+            repository="Example/repo",
+            branch="feature-branch",
+            models_dir_name="models",
+        ),
+    )
+
+    generated = (dataset / "metadata-json.ttl").read_text(encoding="utf-8")
+    assert (
+        "https://raw.githubusercontent.com/Example/repo/feature-branch/models/path-json/ontology.json"
+        in generated
+    )
+    assert str(tmp_path) not in generated
+
+
+def test_explicit_yaml_model_uri_is_used_for_new_dataset_when_present(tmp_path: Path):
+    module = load_module()
+    dataset = tmp_path / "models" / "explicit-yaml-uri-json"
+    dataset.mkdir(parents=True)
+    write_ontology_json(dataset)
+    write_metadata_yaml(
+        dataset,
+        title="Explicit YAML URI",
+        issued="2024",
+        extra="model:\n  uri: https://w3id.org/ontouml-models/model/explicit-yaml-uri/\n",
+    )
+
+    module.process_dataset(
+        dataset, module.Config(metadata_timestamp="2024-01-02T03:04:05Z")
+    )
+
+    generated = (dataset / "metadata-json.ttl").read_text(encoding="utf-8")
+    assert (
+        "dct:isPartOf <https://w3id.org/ontouml-models/model/explicit-yaml-uri>"
+        in generated
+    )
+
+
+def write_catalog_fixture(
+    tmp_path: Path,
+    *,
+    folder_name: str,
+    metadata_yaml: str,
+    metadata_json_ttl: str,
+) -> Path:
+    """Create a minimal local copy of an existing catalog dataset fixture."""
+
+    dataset = tmp_path / "models" / folder_name
+    dataset.mkdir(parents=True)
+    (dataset / "metadata.yaml").write_text(
+        metadata_yaml.strip() + "\n", encoding="utf-8"
+    )
+    (dataset / "metadata-json.ttl").write_text(
+        metadata_json_ttl.strip() + "\n", encoding="utf-8"
+    )
+    write_ontology_json(dataset)
+    return dataset
+
+
+AMARAL2019ROT_METADATA_YAML = """
+title: Reference Ontology of Trust
+acronym: ROT
+issued: 2019
+modified: 2022
+contributor:
+ - https://dblp.org/pid/81/4277
+ - https://dblp.org/pid/134/4947
+ - https://dblp.org/pid/11/78
+ - https://dblp.org/pid/33/8219
+ - https://dblp.org/pid/91/3408
+ - https://dblp.org/pid/75/5043
+ - https://dblp.org/pid/m/JohnMylopoulos
+keyword:
+ - trust
+theme: Class H - Social Sciences
+editorialNote: "The files listed here were imported from ROT's github repository (https://github.com/unibz-core/trust-ontology) on March 23, 2022. Therefore, the ontology is much larger than that described in the paper identified as the main source here."
+ontologyType:
+ - domain
+language: en
+designedForTask:
+ - conceptual clarification
+context:
+ - research
+source:
+ - https://doi.org/10.1007/978-3-030-33246-4_1
+ - https://dblp.org/rec/conf/vmbo/AmaralSGP21
+ - https://doi.org/10.1007/978-3-030-63479-7_6
+ - https://doi.org/10.1007/978-3-030-62522-1_25
+representationStyle:
+ - ontouml
+landingPage: https://github.com/unibz-core/trust-ontology
+license: https://creativecommons.org/licenses/by/4.0/
+"""
+
+
+AMARAL2019ROT_METADATA_JSON = """
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#>.
+@prefix dct: <http://purl.org/dc/terms/>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
+@prefix owl: <http://www.w3.org/2002/07/owl#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+
+<https://w3id.org/ontouml-models/distribution/7c83f03b-c170-49d2-9dd9-0a600be6cc96/> a dcat:Distribution;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/d88fe48c-d574-43b4-85d6-a6e1aeaa6726>;
+    dct:issued "2019"^^xsd:gYear;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
+    dct:title "JSON distribution of Reference Ontology of Trust"@en;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/amaral2019rot/ontology.json>;
+    ocmv:isComplete "true"^^xsd:boolean;
+    fdpo:metadataIssued "2023-04-14T17:35:29.862157131Z"^^xsd:dateTime;
+    fdpo:metadataModified "2023-04-14T17:35:29.862157131Z"^^xsd:dateTime .
+"""
+
+
+ALPINEBITS2022_METADATA_YAML = """
+title: AlpineBits DestinationData Ontology
+acronym:
+issued: 2020
+modified: 2022
+contributor:
+ - https://dblp.org/pid/134/4947
+ - https://dblp.org/pid/169/2246
+keyword:
+ - tourism
+ - alpine tourism
+theme: Class G - Geography, Anthropology, and Recreation
+editorialNote: This version of the ontology is yet to be officially published. The expected release is scheduled to April 2022.
+ontologyType:
+ - domain
+language: en
+designedForTask:
+ - software engineering
+ - interoperability
+context:
+ - industry
+source:
+ - https://www.alpinebits.org/wp-content/uploads/2020/08/AlpineBits_2020-04.pdf
+representationStyle:
+ - ontouml
+landingPage: https://www.alpinebits.org/destinationdata/
+license: https://creativecommons.org/licenses/by-sa/3.0/
+"""
+
+
+ALPINEBITS2022_METADATA_JSON = """
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#>.
+@prefix dct: <http://purl.org/dc/terms/>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
+@prefix owl: <http://www.w3.org/2002/07/owl#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+
+<https://w3id.org/ontouml-models/distribution/b329a4b1-7b57-4aa4-a284-787a4c7abcf2/> a dcat:Distribution;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/ad142d17-1fcd-4189-b050-faed17165bc7>;
+    dct:issued "2020"^^xsd:gYear;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by-sa/3.0/>;
+    ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
+    dct:title "JSON distribution of AlpineBits DestinationData Ontology"@en;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/alpinebits2022/ontology.json>;
+    ocmv:isComplete "true"^^xsd:boolean;
+    fdpo:metadataIssued "2023-04-14T17:35:07.332997226Z"^^xsd:dateTime;
+    fdpo:metadataModified "2023-04-14T17:35:07.332997226Z"^^xsd:dateTime .
+"""
+
+
+ONTOBIO_METADATA_YAML_WITH_EMPTY_LICENSE = """
+title: OntoBio
+acronym:
+issued: 2011
+modified: 2016
+contributor:
+ - https://dblp.org/pid/135/0761
+ - https://dblp.org/pid/88/711
+ - https://dblp.org/pid/61/2142
+ - https://orcid.org/0000-0002-1904-3751
+ - https://dblp.org/pid/200/9519
+keyword:
+ - biology
+theme: Class Q - Science
+editorialNote: in the reference papers we do not have reference diagrams. However, we have a GitHub page were to get some visual information. Still, the quality of the images is very low. Some images are unreadable which led to them not being included in this model
+ontologyType:
+ - domain
+language: en
+designedForTask:
+ - software engineering
+ - interoperability
+context:
+ - research
+source:
+ - https://doi.org/10.1109/HICSS.2015.453
+ - https://tede.ufam.edu.br/handle/tede/2887
+ - https://dblp.org/rec/conf/ontobras/AlbuquerqueSJ16
+ - https://www.researchgate.net/profile/Marcos-De-Sousa-2/publication/284186226_Novas_Contribuicoes_e_Implementacoes_a_um_Modelo_Formal_de_Ontologia_de_Dominio_para_Biodiversidade/links/564f233708aeafc2aab39cca/Novas-Contribuicoes-e-Implementacoes-a-um-Modelo-Formal-de-Ontologia-de-Dominio-para-Biodiversidade.pdf
+representationStyle:
+ - ontouml
+landingPage: https://github.com/unibz-core/OntoBio_Ontology
+license:
+"""
+
+
+ONTOBIO_METADATA_JSON_WITH_EXISTING_LICENSE = """
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#>.
+@prefix dct: <http://purl.org/dc/terms/>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
+@prefix owl: <http://www.w3.org/2002/07/owl#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+
+<https://w3id.org/ontouml-models/distribution/faf6213a-d88b-4399-a12b-e6ea29a4ad01/> a dcat:Distribution;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/f3d40402-e30d-4bbc-8792-5566bc8c30e9>;
+    dct:issued "2011"^^xsd:gYear;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
+    dct:title "JSON distribution of OntoBio"@en;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/albuquerque2011ontobio/ontology.json>;
+    ocmv:isComplete "true"^^xsd:boolean;
+    fdpo:metadataIssued "2023-04-14T17:34:38.539952272Z"^^xsd:dateTime;
+    fdpo:metadataModified "2023-04-14T17:34:38.539952272Z"^^xsd:dateTime .
+"""
+
+
+@pytest.mark.parametrize(
+    ("folder_name", "metadata_yaml", "metadata_json_ttl"),
+    [
+        (
+            "amaral2019rot",
+            AMARAL2019ROT_METADATA_YAML,
+            AMARAL2019ROT_METADATA_JSON,
+        ),
+        (
+            "alpinebits2022",
+            ALPINEBITS2022_METADATA_YAML,
+            ALPINEBITS2022_METADATA_JSON,
+        ),
+    ],
+)
+def test_existing_catalog_fixtures_regenerate_unchanged_without_metadata_ttl(
+    tmp_path: Path,
+    folder_name: str,
+    metadata_yaml: str,
+    metadata_json_ttl: str,
+):
+    module = load_module()
+    dataset = write_catalog_fixture(
+        tmp_path,
+        folder_name=folder_name,
+        metadata_yaml=metadata_yaml,
+        metadata_json_ttl=metadata_json_ttl,
+    )
+    original = (dataset / "metadata-json.ttl").read_text(encoding="utf-8")
+
+    results = module.process_dataset(dataset, module.Config())
+    regenerated = (dataset / "metadata-json.ttl").read_text(encoding="utf-8")
+
+    assert not (dataset / "metadata.ttl").exists()
+    assert results[0].changed is False
+    assert regenerated == original
+
+
+def test_existing_catalog_fixture_with_empty_yaml_license_preserves_distribution_license(
+    tmp_path: Path,
+):
+    module = load_module()
+    dataset = write_catalog_fixture(
+        tmp_path,
+        folder_name="albuquerque2011ontobio",
+        metadata_yaml=ONTOBIO_METADATA_YAML_WITH_EMPTY_LICENSE,
+        metadata_json_ttl=ONTOBIO_METADATA_JSON_WITH_EXISTING_LICENSE,
+    )
+
+    with pytest.raises(module.MetadataGenerationError, match="license"):
+        module.process_dataset(
+            dataset, module.Config(metadata_timestamp="2024-01-02T03:04:05Z")
+        )
+
+    results = module.process_dataset(
+        dataset,
+        module.Config(
+            allow_missing_license=True,
+            metadata_timestamp="2024-01-02T03:04:05Z",
+        ),
+    )
+    regenerated = (dataset / "metadata-json.ttl").read_text(encoding="utf-8")
+
+    assert results[0].changed is True
+    assert "https://creativecommons.org/licenses/by/4.0/" in regenerated
+    assert "2023-04-14T17:34:38.539952272Z" in regenerated
+    assert "2024-01-02T03:04:05Z" in regenerated
+
+
+def test_no_overwrite_rejects_existing_metadata_json(tmp_path: Path):
+    module = load_module()
+    dataset = write_dataset(tmp_path, name="no-overwrite-json")
+    write_existing_json_metadata(dataset)
+
+    with pytest.raises(module.MetadataGenerationError, match="overwrite is disabled"):
+        module.process_dataset(
+            dataset,
+            module.Config(
+                metadata_timestamp="2024-01-02T03:04:05Z",
+                overwrite=False,
+            ),
+        )
+
+
+@pytest.mark.parametrize(
+    ("issued", "expected"),
+    [
+        ("2024-06", 'dct:issued "2024-06"^^xsd:gYearMonth'),
+        ("2024-06-23", 'dct:issued "2024-06-23"^^xsd:date'),
+        (
+            "2024-06-23T12:34:56Z",
+            'dct:issued "2024-06-23T12:34:56Z"^^xsd:dateTime',
+        ),
+    ],
+)
+def test_supported_issued_date_lexical_forms_are_emitted(
+    tmp_path: Path, issued: str, expected: str
+):
+    module = load_module()
+    dataset = write_dataset(tmp_path, name=f"issued-{issued.replace(':', '-')}")
+    write_metadata_yaml(dataset, title="Issued Date Model", issued=issued)
+
+    module.process_dataset(
+        dataset, module.Config(metadata_timestamp="2024-01-02T03:04:05Z")
+    )
+
+    generated = (dataset / "metadata-json.ttl").read_text(encoding="utf-8")
+    assert expected in generated
+
+
+def test_duplicate_yaml_keys_fail_before_writing(tmp_path: Path):
+    module = load_module()
+    dataset = tmp_path / "models" / "duplicate-yaml-keys"
+    dataset.mkdir(parents=True)
+    write_ontology_json(dataset)
+    (dataset / "metadata.yaml").write_text(
+        """
+title: First title
+title: Second title
+issued: 2024
+license: https://creativecommons.org/licenses/by/4.0/
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(module.MetadataGenerationError, match="duplicate key"):
+        module.process_dataset(
+            dataset, module.Config(metadata_timestamp="2024-01-02T03:04:05Z")
+        )
+    assert not (dataset / "metadata-json.ttl").exists()
+
+
+def test_invalid_existing_metadata_json_fails_before_rewriting(tmp_path: Path):
+    module = load_module()
+    dataset = write_dataset(tmp_path, name="invalid-existing-metadata")
+    (dataset / "metadata-json.ttl").write_text("not turtle", encoding="utf-8")
+
+    with pytest.raises(
+        module.MetadataGenerationError, match="Could not parse existing JSON metadata"
+    ):
+        module.process_dataset(
+            dataset, module.Config(metadata_timestamp="2024-01-02T03:04:05Z")
+        )
+    assert (dataset / "metadata-json.ttl").read_text(encoding="utf-8") == "not turtle"
+
+
+def test_json_array_source_fails_unless_source_check_is_disabled(tmp_path: Path):
+    module = load_module()
+    dataset = write_dataset(tmp_path, name="array-source-json")
+    write_ontology_json(dataset, content=[])
+
+    with pytest.raises(module.MetadataGenerationError, match="JSON object"):
+        module.process_dataset(
+            dataset, module.Config(metadata_timestamp="2024-01-02T03:04:05Z")
+        )
+
+    module.process_dataset(
+        dataset,
+        module.Config(
+            metadata_timestamp="2024-01-02T03:04:05Z",
+            check_source_file=False,
+        ),
+    )
+    assert (dataset / "metadata-json.ttl").exists()
+
+
+def test_custom_existing_schema_uri_is_preserved(tmp_path: Path):
+    module = load_module()
+    dataset = write_dataset(tmp_path, name="custom-schema-json")
+    write_existing_json_metadata(dataset)
+    existing = (dataset / "metadata-json.ttl").read_text(encoding="utf-8")
+    (dataset / "metadata-json.ttl").write_text(
+        existing.replace(
+            "https://w3id.org/ontouml/schema",
+            "https://example.org/custom-json-schema",
+        ),
+        encoding="utf-8",
+    )
+
+    module.process_dataset(
+        dataset, module.Config(metadata_timestamp="2024-01-02T03:04:05Z")
+    )
+    generated = (dataset / "metadata-json.ttl").read_text(encoding="utf-8")
+
+    assert "https://example.org/custom-json-schema" in generated
+
+
+def test_cli_quiet_suppresses_text_output(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+):
+    module = load_module()
+    dataset = write_dataset(tmp_path, name="quiet-json")
+
+    exit_code = module.main(
+        [
+            str(dataset),
+            "--quiet",
+            "--metadata-timestamp",
+            "2024-01-02T03:04:05Z",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert captured.out == ""
+    assert captured.err == ""
+
+
+def test_cli_setup_error_returns_two(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+):
+    module = load_module()
+
+    exit_code = module.main(["--all", "--models-dir", str(tmp_path / "missing")])
+
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert "Models directory does not exist" in captured.err


### PR DESCRIPTION
## Summary

This PR adds a YAML-based generator for JSON distribution metadata files (`metadata-json.ttl`) in the OntoUML/UFO Catalog.

The new generator follows the repository structure adopted for the updated distribution metadata generators:

- script under `scripts/`;
- documentation under `scripts/`;
- tests under `scripts/tests/`.

The goal is to support future metadata generation workflows in which distribution-level metadata is generated before the final model-level `metadata.ttl` aggregation.

## Files changed

This PR intentionally adds only the JSON metadata generator files:

- `scripts/generate_json_metadata.py`
- `scripts/generate-json-metadata.md`
- `scripts/tests/test_generate_json_metadata.py`

No generated model metadata files under `models/` are included.

## Motivation

The catalog metadata workflow is being reorganized so that distribution-level metadata can be generated independently before model-level metadata is aggregated.

In this workflow, `metadata.ttl` should be treated as a final generated aggregation product, not as the required source for generating distribution metadata.

For JSON distributions, this PR introduces a generator that uses `metadata.yaml` as the canonical editable source for model-level metadata and preserves stable catalog identifiers from existing distribution metadata when available.

## Main behavior

The generator creates or checks:

```text
metadata-json.ttl
```

for datasets containing:

```text
metadata.yaml
ontology.json
```

The generated JSON distribution metadata follows the existing catalog RDF pattern, including:

- `dcat:Distribution`;
- `dct:isPartOf`;
- `dct:issued`;
- `dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>`;
- `dct:license` when available;
- `ocmv:conformsToSchema <https://w3id.org/ontouml/schema>`;
- `dct:title`;
- `dcat:downloadURL`;
- `ocmv:isComplete true`;
- `fdpo:metadataIssued`;
- `fdpo:metadataModified`.

## No dependency on model-level metadata.ttl

The generator does not require model-level `metadata.ttl` to exist.

This allows the following future workflow order:

```text
1. validate/fix metadata.yaml
2. generate distribution-level metadata files, including metadata-json.ttl
3. generate final model-level metadata.ttl
```

This PR does not create or modify any GitHub Actions workflow.

## Identifier preservation strategy

The generator preserves stable catalog identifiers where possible.

Model IRI resolution follows this order:

1. existing `metadata-json.ttl`, using its `dct:isPartOf`;
2. other existing distribution metadata files in the same dataset folder, using their `dct:isPartOf`;
3. explicit HTTP(S) model URI in `metadata.yaml`, if present;
4. deterministic UUIDv5 model IRI for genuinely new datasets.

For existing catalog datasets, the generator avoids replacing existing UUID-based model IRIs with folder-name-based IRIs.

If conflicting existing `dct:isPartOf` values are found, generation fails clearly instead of guessing.

## Distribution IRI behavior

For existing `metadata-json.ttl` files, the existing JSON distribution IRI is preserved.

For new `metadata-json.ttl` files, the generator creates a deterministic UUIDv5 distribution IRI based on stable repository/catalog information rather than local absolute paths.

## Timestamp behavior

The generator uses explicit timestamp handling for FDP metadata fields.

For `fdpo:metadataIssued`:

- preserve the existing value when present;
- initialize from `--metadata-timestamp` for new files or files without an existing value.

For `fdpo:metadataModified`:

- preserve the existing value when the regenerated file is unchanged;
- update it from `--metadata-timestamp` when the file changes;
- initialize it from the same timestamp for new files.

The generator does not silently use the current time by default. `--metadata-timestamp now` is supported only for intentionally non-deterministic maintenance runs.

## Missing-license behavior

By default, missing license metadata fails.

The new `--allow-missing-license` option supports legacy datasets that lack license metadata in `metadata.yaml`.

When a license is present in `metadata.yaml`, it is emitted regardless of whether `--allow-missing-license` is used.

When `metadata.yaml` lacks a license but an existing JSON distribution-level `dct:license` is present, the existing distribution license can be preserved when `--allow-missing-license` is enabled.

## CLI support

The script supports CI/workflow-friendly execution options, including:

- selected dataset folders as positional arguments;
- `--all`;
- `--models-dir`;
- `--allow-missing-license`;
- `--metadata-timestamp`;
- `--check`;
- `--dry-run`;
- `--format text`;
- `--format json`;
- `--quiet` / `--silent`;
- repository and branch options for generated download URLs.

Example commands:

```bash
python scripts/generate_json_metadata.py models/amaral2019rot --metadata-timestamp 2026-06-23T12:00:00Z

python scripts/generate_json_metadata.py --all --models-dir models --check --allow-missing-license --metadata-timestamp 2026-06-23T12:00:00Z

python scripts/generate_json_metadata.py models/amaral2019rot --dry-run --metadata-timestamp 2026-06-23T12:00:00Z
```

## Tests

The new test suite covers:

- generation from `metadata.yaml` when `metadata.ttl` is absent;
- preservation of existing JSON distribution IRIs;
- preservation of existing `dct:isPartOf`;
- fallback to other distribution metadata for model IRI preservation;
- deterministic UUIDv5 fallback for new datasets;
- failure when existing catalog datasets lack a usable preserved model IRI;
- conflict detection for multiple preserved model IRIs;
- missing-license failure by default;
- legacy missing-license behavior with `--allow-missing-license`;
- preservation of existing distribution-level license when appropriate;
- timestamp initialization and preservation;
- update of `fdpo:metadataModified` only when needed;
- `--check`;
- `--dry-run`;
- text and JSON output behavior;
- invalid input handling;
- no partial writes after validation failures;
- repository-relative paths in generated download URLs and deterministic identifiers.

## Verification

The following checks were run locally:

```bash
python -m py_compile scripts/generate_json_metadata.py
python -m pytest -q scripts/tests/test_generate_json_metadata.py
python scripts/generate_json_metadata.py --help
```

Result:

```text
36 passed
```

## Scope exclusions

This PR intentionally does not:

- create or modify GitHub Actions workflows;
- regenerate metadata files under `models/`;
- modify model-level `metadata.ttl`;
- modify unrelated scripts;
- modify unrelated tests;
- include compatibility wrappers for old script names.