### PR TITLE
chore(metadata): regenerate Turtle distribution metadata

### DIFF
--- a/models/abel2015petroleum-system/metadata-turtle.ttl
+++ b/models/abel2015petroleum-system/metadata-turtle.ttl
@@ -1,19 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/f5c87f00-66fa-47a9-a0a8-07b88588b095/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/7ed5893a-ead6-4de1-b9c1-635e7af3de00>;
-    dct:issued "2015"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:title "Turtle distribution of Petroleum System Model"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/abel2015petroleum-system/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T17:33:26.603879933Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:33:26.603879933Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/f5c87f00-66fa-47a9-a0a8-07b88588b095/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/7ed5893a-ead6-4de1-b9c1-635e7af3de00> ;
+    dct:issued "2015"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Petroleum System Model"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/abel2015petroleum-system/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T17:33:26.603879933Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/abrahao2018agriculture-operations/metadata-turtle.ttl
+++ b/models/abrahao2018agriculture-operations/metadata-turtle.ttl
@@ -1,19 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/f8b97967-0e4a-491c-8b3f-85e86d44cb5f/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/d07d44af-d127-4407-8d0f-72b9e17a6479>;
-    dct:issued "2018"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:title "Turtle distribution of Agriculture Operations Task Ontology"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/abrahao2018agriculture-operations/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T17:33:41.463786671Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:33:41.463786671Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/f8b97967-0e4a-491c-8b3f-85e86d44cb5f/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/d07d44af-d127-4407-8d0f-72b9e17a6479> ;
+    dct:issued "2018"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Agriculture Operations Task Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/abrahao2018agriculture-operations/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T17:33:41.463786671Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/aguiar2018rdbs-o/metadata-turtle.ttl
+++ b/models/aguiar2018rdbs-o/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/20be03e0-f14f-41a4-bd63-4641247fd4e5/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/1c0413cd-ce41-4822-a227-68cddf6074e6>;
-    dct:issued "2018"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://www.gnu.org/licenses/gpl-3.0.en.html>;
-    dct:title "Turtle distribution of Relational Database System Ontology"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/aguiar2018rdbs-o/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T17:33:51.512032748Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:33:51.512032748Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/20be03e0-f14f-41a4-bd63-4641247fd4e5/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/1c0413cd-ce41-4822-a227-68cddf6074e6> ;
+    dct:issued "2018"^^xsd:gYear ;
+    dct:license <https://www.gnu.org/licenses/gpl-3.0.en.html> ;
+    dct:title "Turtle distribution of Relational Database System Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/aguiar2018rdbs-o/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T17:33:51.512032748Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/aguiar2019ooco/metadata-turtle.ttl
+++ b/models/aguiar2019ooco/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/e8511b6e-2606-46a1-85a9-13234dbaa1df/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/0647761f-976f-41c4-94c0-a907ae1ed577>;
-    dct:issued "2019"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://www.gnu.org/licenses/gpl-3.0.en.html>;
-    dct:title "Turtle distribution of Reference Ontology on Object-Oriented Code"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/aguiar2019ooco/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T17:34:08.12699855Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:34:08.12699855Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/e8511b6e-2606-46a1-85a9-13234dbaa1df/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/0647761f-976f-41c4-94c0-a907ae1ed577> ;
+    dct:issued "2019"^^xsd:gYear ;
+    dct:license <https://www.gnu.org/licenses/gpl-3.0.en.html> ;
+    dct:title "Turtle distribution of Reference Ontology on Object-Oriented Code"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/aguiar2019ooco/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T17:34:08.12699855Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/ahmad2018aviation/metadata-turtle.ttl
+++ b/models/ahmad2018aviation/metadata-turtle.ttl
@@ -1,19 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/69cd521b-671c-49f2-a176-e31910dec404/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/660ad6c4-dbc1-43e7-b582-d7eb9ec43739>;
-    dct:issued "2018"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:title "Turtle distribution of Aviation Safety Ontology"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/ahmad2018aviation/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T17:34:20.99131566Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:34:20.99131566Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/69cd521b-671c-49f2-a176-e31910dec404/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/660ad6c4-dbc1-43e7-b582-d7eb9ec43739> ;
+    dct:issued "2018"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Aviation Safety Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/ahmad2018aviation/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T17:34:20.99131566Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/aires2022valuenetworks-geo/metadata-turtle.ttl
+++ b/models/aires2022valuenetworks-geo/metadata-turtle.ttl
@@ -1,19 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/3109bec0-7e3c-4773-9cb2-7d982b38f11e/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/3886f70e-5a91-411d-a50e-370eb4f93c5a>;
-    dct:issued "2022"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:title "Turtle distribution of Ontology for Value Networks with Geographic Information"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/aires2022valuenetworks-geo/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T17:34:33.510918938Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:34:33.510918938Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/3109bec0-7e3c-4773-9cb2-7d982b38f11e/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/3886f70e-5a91-411d-a50e-370eb4f93c5a> ;
+    dct:issued "2022"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Ontology for Value Networks with Geographic Information"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/aires2022valuenetworks-geo/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T17:34:33.510918938Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/albuquerque2011ontobio/metadata-turtle.ttl
+++ b/models/albuquerque2011ontobio/metadata-turtle.ttl
@@ -1,19 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/f374fbe4-fffb-4ce0-afe8-3145fadf7c68/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/f3d40402-e30d-4bbc-8792-5566bc8c30e9>;
-    dct:issued "2011"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:title "Turtle distribution of OntoBio"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/albuquerque2011ontobio/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T17:35:02.712923077Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:35:02.712923077Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/f374fbe4-fffb-4ce0-afe8-3145fadf7c68/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/f3d40402-e30d-4bbc-8792-5566bc8c30e9> ;
+    dct:issued "2011"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of OntoBio"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/albuquerque2011ontobio/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T17:35:02.712923077Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/alkhalaf2024/metadata-turtle.ttl
+++ b/models/alkhalaf2024/metadata-turtle.ttl
@@ -1,0 +1,17 @@
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://w3id.org/ontouml-models/distribution/0d170a28-f559-5c50-93ab-505a4b60141a/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/alkhalaf2024> ;
+    dct:issued "2023"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Ontology to Explain SARS-CoV-2 Variants' Effects"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/alkhalaf2024/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/alpinebits2022/metadata-turtle.ttl
+++ b/models/alpinebits2022/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/c9f1c174-5b7e-441e-9318-6a5858d053b8/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/ad142d17-1fcd-4189-b050-faed17165bc7>;
-    dct:issued "2020"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by-sa/3.0/>;
-    dct:title "Turtle distribution of AlpineBits DestinationData Ontology"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/alpinebits2022/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T17:35:25.191496456Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:35:25.191496456Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/c9f1c174-5b7e-441e-9318-6a5858d053b8/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/ad142d17-1fcd-4189-b050-faed17165bc7> ;
+    dct:issued "2020"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by-sa/3.0/> ;
+    dct:title "Turtle distribution of AlpineBits DestinationData Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/alpinebits2022/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T17:35:25.191496456Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/amaral2019rot/metadata-turtle.ttl
+++ b/models/amaral2019rot/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/78713112-cf7e-45f1-8c74-c7b5906f5b7c/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/d88fe48c-d574-43b4-85d6-a6e1aeaa6726>;
-    dct:issued "2019"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:title "Turtle distribution of Reference Ontology of Trust"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/amaral2019rot/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T17:35:46.015703026Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:35:46.015703026Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/78713112-cf7e-45f1-8c74-c7b5906f5b7c/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/d88fe48c-d574-43b4-85d6-a6e1aeaa6726> ;
+    dct:issued "2019"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Reference Ontology of Trust"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/amaral2019rot/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T17:35:46.015703026Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/amaral2020game-theory/metadata-turtle.ttl
+++ b/models/amaral2020game-theory/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/ff7fb85f-71d4-4bb6-8d79-bebc5ddad162/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/0d5ccd09-3436-4dba-831a-9c0b705bb4fa>;
-    dct:issued "2021"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:title "Turtle distribution of Game Theory Ontology"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/amaral2020game-theory/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T17:35:58.475656462Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:35:58.475656462Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/ff7fb85f-71d4-4bb6-8d79-bebc5ddad162/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/0d5ccd09-3436-4dba-831a-9c0b705bb4fa> ;
+    dct:issued "2021"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Game Theory Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/amaral2020game-theory/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T17:35:58.475656462Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/amaral2020rome/metadata-turtle.ttl
+++ b/models/amaral2020rome/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/a46f55b3-84a1-4a39-a35f-f26fe9004ff0/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/d7a95e79-d01a-42cd-b059-400f314a8038>;
-    dct:issued "2020"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:title "Turtle distribution of Reference Ontology of Money and Virtual Currencies"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/amaral2020rome/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T17:36:16.045515991Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:36:16.045515991Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/a46f55b3-84a1-4a39-a35f-f26fe9004ff0/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/d7a95e79-d01a-42cd-b059-400f314a8038> ;
+    dct:issued "2020"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Reference Ontology of Money and Virtual Currencies"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/amaral2020rome/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T17:36:16.045515991Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/amaral2022ethical-requirements/metadata-turtle.ttl
+++ b/models/amaral2022ethical-requirements/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/b92781f6-ac50-40ef-b15b-5f901f20bac8/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/407f7c94-9ebb-44f1-adef-47cc0c22d89d>;
-    dct:issued "2022"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:title "Turtle distribution of Reference Ontology of Ethical Requirements"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/amaral2022ethical-requirements/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T17:36:28.798560392Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:36:28.798560392Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/b92781f6-ac50-40ef-b15b-5f901f20bac8/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/407f7c94-9ebb-44f1-adef-47cc0c22d89d> ;
+    dct:issued "2022"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Reference Ontology of Ethical Requirements"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/amaral2022ethical-requirements/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T17:36:28.798560392Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/andersson2018value-ascription/metadata-turtle.ttl
+++ b/models/andersson2018value-ascription/metadata-turtle.ttl
@@ -1,19 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/94303827-76ed-41cc-b2e1-4298b8a18a65/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/3df10e52-a7e6-4e42-a5e5-c34495a5826b>;
-    dct:issued "2018"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:title "Turtle distribution of Value Ascription Ontology"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/andersson2018value-ascription/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T17:36:38.583181445Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:36:38.583181445Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/94303827-76ed-41cc-b2e1-4298b8a18a65/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/3df10e52-a7e6-4e42-a5e5-c34495a5826b> ;
+    dct:issued "2018"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Value Ascription Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/andersson2018value-ascription/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T17:36:38.583181445Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/andrade2023integracao/metadata-turtle.ttl
+++ b/models/andrade2023integracao/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/2e6cdb7f-31a1-4b96-89be-fec35d1554a2/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/1b6b8e8d-92a6-4be9-b6d4-106f9ccb15a0>;
-    dct:issued "2023"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:title "Turtle distribution of Ontology for Scientific Publishing"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/andrade2023integracao/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T17:36:50.574439478Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:36:50.574439478Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/2e6cdb7f-31a1-4b96-89be-fec35d1554a2/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/1b6b8e8d-92a6-4be9-b6d4-106f9ccb15a0> ;
+    dct:issued "2023"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Ontology for Scientific Publishing"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/andrade2023integracao/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T17:36:50.574439478Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/aristotle-ontology2019/metadata-turtle.ttl
+++ b/models/aristotle-ontology2019/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/f1e201ef-d234-4922-abfc-a21ef6a4e4a8/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/667449b5-c595-4ecf-84b3-c461252353c6>;
-    dct:issued "2019"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:title "Turtle distribution of Aristotle Ontology"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/aristotle-ontology2019/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T17:37:28.788041529Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:37:28.788041529Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/f1e201ef-d234-4922-abfc-a21ef6a4e4a8/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/667449b5-c595-4ecf-84b3-c461252353c6> ;
+    dct:issued "2019"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Aristotle Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/aristotle-ontology2019/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T17:37:28.788041529Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/bank-account2013/metadata-turtle.ttl
+++ b/models/bank-account2013/metadata-turtle.ttl
@@ -1,0 +1,17 @@
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://w3id.org/ontouml-models/distribution/ad06eeab-ae93-56e4-80a8-cf85d632cf16/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/bank-account2013> ;
+    dct:issued "2013"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Bank Account Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/bank-account2013/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/bank-model/metadata-turtle.ttl
+++ b/models/bank-model/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/3212e572-0bf6-43cd-824c-d533db24bd19/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/db57ef4e-b335-4fcd-9935-609e932ba8e8>;
-    dct:issued "2013"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:title "Turtle distribution of Bank Model"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/bank-model/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T17:37:38.134405036Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:37:38.134405036Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/3212e572-0bf6-43cd-824c-d533db24bd19/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/db57ef4e-b335-4fcd-9935-609e932ba8e8> ;
+    dct:issued "2013"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Bank Model"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/bank-model/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T17:37:38.134405036Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/barcelos2013normative-acts/metadata-turtle.ttl
+++ b/models/barcelos2013normative-acts/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/2092feea-b4b2-4c24-9e7b-1f6f829c9808/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/bbf816c7-da70-4f18-9c45-376612673f38>;
-    dct:issued "2013"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:title "Turtle distribution of Normative Acts"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/barcelos2013normative-acts/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T17:38:02.037930322Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:38:02.037930322Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/2092feea-b4b2-4c24-9e7b-1f6f829c9808/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/bbf816c7-da70-4f18-9c45-376612673f38> ;
+    dct:issued "2013"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Normative Acts"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/barcelos2013normative-acts/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T17:38:02.037930322Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/barcelos2015transport-networks/metadata-turtle.ttl
+++ b/models/barcelos2015transport-networks/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/6a4ad553-2143-4fcd-a636-82d693f1c149/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/ff3e16d6-8349-4bea-81e1-c1213e652170>;
-    dct:issued "2015"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:title "Turtle distribution of Technology-independent Multi-layer Transport Networks"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/barcelos2015transport-networks/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T17:42:50.609657359Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:42:50.609657359Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/6a4ad553-2143-4fcd-a636-82d693f1c149/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/ff3e16d6-8349-4bea-81e1-c1213e652170> ;
+    dct:issued "2015"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Technology-independent Multi-layer Transport Networks"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/barcelos2015transport-networks/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T17:42:50.609657359Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/barcelos2024resiliont/metadata-turtle.ttl
+++ b/models/barcelos2024resiliont/metadata-turtle.ttl
@@ -1,0 +1,17 @@
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://w3id.org/ontouml-models/distribution/2f285809-c949-5fd1-a4fc-24724627f42f/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/barcelos2024resiliont> ;
+    dct:issued "2024"^^xsd:gYear ;
+    dct:license <https://www.apache.org/licenses/LICENSE-2.0> ;
+    dct:title "Turtle distribution of Resilience Core Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/barcelos2024resiliont/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/barros2020programming/metadata-turtle.ttl
+++ b/models/barros2020programming/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/4dd299af-a36d-4fa6-a3fc-52c7d80ffe1b/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/65a05fab-35fe-4eff-bf19-2eb0aea54022>;
-    dct:issued "2020"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:title "Turtle distribution of Ontology of Nationality according to the Federal Constitution of Brazil"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/barros2020programming/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T17:42:59.265724728Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:42:59.265724728Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/4dd299af-a36d-4fa6-a3fc-52c7d80ffe1b/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/65a05fab-35fe-4eff-bf19-2eb0aea54022> ;
+    dct:issued "2020"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Ontology of Nationality according to the Federal Constitution of Brazil"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/barros2020programming/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T17:42:59.265724728Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/bernasconi2021ontovcm/metadata-turtle.ttl
+++ b/models/bernasconi2021ontovcm/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/6e0dfae8-179e-4910-92d8-e50f98cea75e/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/37ec1d52-b8c1-4e6e-9917-d6e4b58d1c6d>;
-    dct:issued "2021"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:title "Turtle distribution of Ontological Viral Conceptual Model"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/bernasconi2021ontovcm/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T17:43:12.303603598Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:43:12.303603598Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/6e0dfae8-179e-4910-92d8-e50f98cea75e/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/37ec1d52-b8c1-4e6e-9917-d6e4b58d1c6d> ;
+    dct:issued "2021"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Ontological Viral Conceptual Model"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/bernasconi2021ontovcm/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T17:43:12.303603598Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/bernasconi2023fair-principles/metadata-turtle.ttl
+++ b/models/bernasconi2023fair-principles/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/77f09632-9ee2-445e-9263-140aff501f7c/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/648b1a98-41f6-49b9-be93-6b012d52593c>;
-    dct:issued "2023"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:title "Turtle distribution of OntoUML FAIR Principles Schema"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/bernasconi2023fair-principles/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-05-30T14:35:04.568556828Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-05-30T14:35:04.568556828Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/77f09632-9ee2-445e-9263-140aff501f7c/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/648b1a98-41f6-49b9-be93-6b012d52593c> ;
+    dct:issued "2023"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of OntoUML FAIR Principles Schema"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/bernasconi2023fair-principles/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-05-30T14:35:04.568556828Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/blums2024ccf/metadata-turtle.ttl
+++ b/models/blums2024ccf/metadata-turtle.ttl
@@ -1,0 +1,17 @@
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://w3id.org/ontouml-models/distribution/dd60b709-eb38-52ae-a11c-f5d793b8736c/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/blums2024ccf> ;
+    dct:issued "2024"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Ontology of Converged Conceptual Frameworks for Financial Reporting"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/blums2024ccf/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/blums2025cofris/metadata-turtle.ttl
+++ b/models/blums2025cofris/metadata-turtle.ttl
@@ -1,0 +1,17 @@
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://w3id.org/ontouml-models/distribution/96ca04ce-dd03-5d50-995f-5623a8f7f27c/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/blums2025cofris> ;
+    dct:issued "2025"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Core Ontology for Financial Reporting Information Systems 3.0"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/blums2025cofris/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/brazilian-governmental-organizational-structures/metadata-turtle.ttl
+++ b/models/brazilian-governmental-organizational-structures/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/9ff8b4d0-0765-45d6-9740-d1aa16b59c20/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/3ed5bea4-4acf-4d1d-9810-4d1e478b92aa>;
-    dct:issued "2011"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:title "Turtle distribution of Brazilian Federal Organizational Structures - Ontology Draft"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/brazilian-governmental-organizational-structures/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T17:43:21.186822365Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:43:21.186822365Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/9ff8b4d0-0765-45d6-9740-d1aa16b59c20/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/3ed5bea4-4acf-4d1d-9810-4d1e478b92aa> ;
+    dct:issued "2011"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Brazilian Federal Organizational Structures - Ontology Draft"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/brazilian-governmental-organizational-structures/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T17:43:21.186822365Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/buchtela2020connection/metadata-turtle.ttl
+++ b/models/buchtela2020connection/metadata-turtle.ttl
@@ -1,19 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/038e6492-9309-40f8-8a64-fb34f92362f6/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/1b479664-a287-4503-9d2b-7d8cf8bed271>;
-    dct:issued "2020"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:title "Turtle distribution of Knowledge Representation Model of Students' Activities"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/buchtela2020connection/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T17:43:30.351180289Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:43:30.351180289Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/038e6492-9309-40f8-8a64-fb34f92362f6/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/1b479664-a287-4503-9d2b-7d8cf8bed271> ;
+    dct:issued "2020"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Knowledge Representation Model of Students' Activities"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/buchtela2020connection/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T17:43:30.351180289Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/buridan-ontology2021/metadata-turtle.ttl
+++ b/models/buridan-ontology2021/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/abfd99c5-0674-47bd-bb59-94a76aadabbc/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/7a585e3c-9a42-4bd7-8d50-bdbd9332c9ba>;
-    dct:issued "2021"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:title "Turtle distribution of Buridan Ontology"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/buridan-ontology2021/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T17:43:45.566816016Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:43:45.566816016Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/abfd99c5-0674-47bd-bb59-94a76aadabbc/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/7a585e3c-9a42-4bd7-8d50-bdbd9332c9ba> ;
+    dct:issued "2021"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Buridan Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/buridan-ontology2021/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T17:43:45.566816016Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/calhau2024capabilities/metadata-turtle.ttl
+++ b/models/calhau2024capabilities/metadata-turtle.ttl
@@ -1,0 +1,17 @@
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://w3id.org/ontouml-models/distribution/6f939874-403a-5cb2-b381-3304e7d9f004/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/calhau2024capabilities> ;
+    dct:issued "2024"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Capabilities Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/calhau2024capabilities/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/carolla2014campus-management/metadata-turtle.ttl
+++ b/models/carolla2014campus-management/metadata-turtle.ttl
@@ -1,19 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/ef15add8-be4c-413a-8927-beb28f0371ec/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/e58213c9-beec-47f7-ac55-b5530bad3930>;
-    dct:issued "2014"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:title "Turtle distribution of Campus Management System Reference Data Model"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/carolla2014campus-management/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T17:43:54.460629304Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:43:54.460629304Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/ef15add8-be4c-413a-8927-beb28f0371ec/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/e58213c9-beec-47f7-ac55-b5530bad3930> ;
+    dct:issued "2014"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Campus Management System Reference Data Model"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/carolla2014campus-management/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T17:43:54.460629304Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/castro2012cloudvulnerability/metadata-turtle.ttl
+++ b/models/castro2012cloudvulnerability/metadata-turtle.ttl
@@ -1,19 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/333f75a6-bc22-4a06-942c-7e52fe469587/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/9d3dc47b-2ca8-430e-8e57-c2c0a5ed8015>;
-    dct:issued "2012"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:title "Turtle distribution of Cloud Vulnerability Ontology"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/castro2012cloudvulnerability/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T17:44:12.578385805Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:44:12.578385805Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/333f75a6-bc22-4a06-942c-7e52fe469587/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/9d3dc47b-2ca8-430e-8e57-c2c0a5ed8015> ;
+    dct:issued "2012"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Cloud Vulnerability Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/castro2012cloudvulnerability/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T17:44:12.578385805Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/cgts2021sebim/metadata-turtle.ttl
+++ b/models/cgts2021sebim/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/7cb3817d-6732-4371-a8a1-91180018dc4c/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/71fdda05-0b9e-4c78-8436-4e470b1e6208>;
-    dct:issued "2021"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:title "Turtle distribution of Semantic Building Information Modeling Ontology"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/cgts2021sebim/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T17:44:21.622731509Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:44:21.622731509Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/7cb3817d-6732-4371-a8a1-91180018dc4c/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/71fdda05-0b9e-4c78-8436-4e470b1e6208> ;
+    dct:issued "2021"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Semantic Building Information Modeling Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/cgts2021sebim/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T17:44:21.622731509Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/chartered-service/metadata-turtle.ttl
+++ b/models/chartered-service/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/e9788338-9faa-44f7-9c1a-b4b8d18132be/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/81ee57e0-d340-4da4-826b-f99e361652d5>;
-    dct:issued "2013"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:title "Turtle distribution of Chartered Service Ontology"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/chartered-service/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T17:44:30.331074785Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:44:30.331074785Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/e9788338-9faa-44f7-9c1a-b4b8d18132be/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/81ee57e0-d340-4da4-826b-f99e361652d5> ;
+    dct:issued "2013"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Chartered Service Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/chartered-service/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T17:44:30.331074785Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/clergy-ontology/metadata-turtle.ttl
+++ b/models/clergy-ontology/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/568d3128-1436-4d7c-a3e5-c2d66f4b630b/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/931db746-c36d-4077-bde7-1c317bfa5bcd>;
-    dct:issued "2013"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:title "Turtle distribution of Clergy Ontology"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/clergy-ontology/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T17:44:39.21653548Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:44:39.21653548Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/568d3128-1436-4d7c-a3e5-c2d66f4b630b/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/931db746-c36d-4077-bde7-1c317bfa5bcd> ;
+    dct:issued "2013"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Clergy Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/clergy-ontology/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T17:44:39.21653548Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/cmpo2017/metadata-turtle.ttl
+++ b/models/cmpo2017/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/5df65aff-1413-44ab-bc14-236531846377/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/e9047c5f-2c8c-45cf-90e3-208c9791bba8>;
-    dct:issued "2012"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:title "Turtle distribution of Configuration Management Process Ontology"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/cmpo2017/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T17:44:48.015406198Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:44:48.015406198Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/5df65aff-1413-44ab-bc14-236531846377/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/e9047c5f-2c8c-45cf-90e3-208c9791bba8> ;
+    dct:issued "2012"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Configuration Management Process Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/cmpo2017/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T17:44:48.015406198Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/construction-model/metadata-turtle.ttl
+++ b/models/construction-model/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/910fce8d-e1df-4e7a-a28d-5e03fcdf8d22/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/0bf7f860-ed96-41a8-be3d-965c8de83b6d>;
-    dct:issued "2013"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:title "Turtle distribution of The Construction Model"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/construction-model/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T17:44:56.860741388Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:44:56.860741388Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/910fce8d-e1df-4e7a-a28d-5e03fcdf8d22/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/0bf7f860-ed96-41a8-be3d-965c8de83b6d> ;
+    dct:issued "2013"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of The Construction Model"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/construction-model/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T17:44:56.860741388Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/core-o2023/metadata-turtle.ttl
+++ b/models/core-o2023/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/ea80f423-ae53-4deb-947c-71ad0e748259/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/2b3d29db-eaea-4966-83e5-af9ca54f3086>;
-    dct:issued "2023"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:title "Turtle distribution of Competence Reference Ontology"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/core-o2023/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-05-30T14:35:27.470737161Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-05-30T14:35:27.470737161Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/ea80f423-ae53-4deb-947c-71ad0e748259/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/2b3d29db-eaea-4966-83e5-af9ca54f3086> ;
+    dct:issued "2023"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Competence Reference Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/core-o2023/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-05-30T14:35:27.470737161Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/cunha2025soberana/metadata-turtle.ttl
+++ b/models/cunha2025soberana/metadata-turtle.ttl
@@ -1,0 +1,17 @@
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://w3id.org/ontouml-models/distribution/3f947d3b-f3b4-5162-9c13-cf1a064545a7/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/cunha2025soberana> ;
+    dct:issued "2023"^^xsd:gYear ;
+    dct:license <https://opensource.org/license/mit> ;
+    dct:title "Turtle distribution of Soberana Domain Reference Ontology for describing an International Data Spaces Ecosystem"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/cunha2025soberana/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/dcat-mlt-ufo2023/metadata-turtle.ttl
+++ b/models/dcat-mlt-ufo2023/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/556883d0-b35f-4cb8-8c74-f7d0ec169d6f/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/a2b41412-02d5-4716-bdb0-c4112a2626d7>;
-    dct:issued "2022"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:title "Turtle distribution of Ontology-based Multi-level Conceptual Model for Descriptors of Catalogued Resources"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/dcat-mlt-ufo2023/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-05-30T14:35:40.013475276Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-05-30T14:35:40.013475276Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/556883d0-b35f-4cb8-8c74-f7d0ec169d6f/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/a2b41412-02d5-4716-bdb0-c4112a2626d7> ;
+    dct:issued "2022"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Ontology-based Multi-level Conceptual Model for Descriptors of Catalogued Resources"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/dcat-mlt-ufo2023/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-05-30T14:35:40.013475276Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/debbech2019gosmo/metadata-turtle.ttl
+++ b/models/debbech2019gosmo/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/4c152305-3a4d-4a9f-b4f0-db4db4886192/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/09d75270-acbd-4533-b7ed-6c498cf2a3c6>;
-    dct:issued "2019"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:title "Turtle distribution of Goal-Oriented Safety Management Ontology"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/debbech2019gosmo/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T17:45:05.910892579Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:45:05.910892579Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/4c152305-3a4d-4a9f-b4f0-db4db4886192/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/09d75270-acbd-4533-b7ed-6c498cf2a3c6> ;
+    dct:issued "2019"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Goal-Oriented Safety Management Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/debbech2019gosmo/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T17:45:05.910892579Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/debbech2020dysfunction-analysis/metadata-turtle.ttl
+++ b/models/debbech2020dysfunction-analysis/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/97526a1e-7c8d-4d15-9513-7e8012dd1b2a/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/1516b7a7-5310-4dda-a7a6-ff711d73f925>;
-    dct:issued "2020"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by-nd/4.0/>;
-    dct:title "Turtle distribution of Dysfuntion Analysis Ontology"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/debbech2020dysfunction-analysis/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T17:45:18.174728409Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:45:18.174728409Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/97526a1e-7c8d-4d15-9513-7e8012dd1b2a/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/1516b7a7-5310-4dda-a7a6-ff711d73f925> ;
+    dct:issued "2020"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by-nd/4.0/> ;
+    dct:title "Turtle distribution of Dysfuntion Analysis Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/debbech2020dysfunction-analysis/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T17:45:18.174728409Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/demori2023miscon/metadata-turtle.ttl
+++ b/models/demori2023miscon/metadata-turtle.ttl
@@ -1,0 +1,17 @@
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://w3id.org/ontouml-models/distribution/e609438b-9f0d-5d7a-b4cd-cbfa303c33b4/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/demori2023miscon> ;
+    dct:issued "2023"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Military Scenario Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/demori2023miscon/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/derave2019dpo/metadata-turtle.ttl
+++ b/models/derave2019dpo/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/9039a548-ba12-422e-addf-e605320e2ede/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/203d95b5-1957-46ae-9d3b-065da02ada09>;
-    dct:issued "2019"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:title "Turtle distribution of Digital Platform Ontology"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/derave2019dpo/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T17:47:02.830466436Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:47:02.830466436Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/9039a548-ba12-422e-addf-e605320e2ede/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/203d95b5-1957-46ae-9d3b-065da02ada09> ;
+    dct:issued "2019"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Digital Platform Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/derave2019dpo/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T17:47:02.830466436Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/digitaldoctor2022/metadata-turtle.ttl
+++ b/models/digitaldoctor2022/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/7c79b244-496b-47a2-8bc0-1e9b16c71d0a/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/f898284f-601b-4492-a515-cc39de252d1c>;
-    dct:issued "2022"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:title "Turtle distribution of Digital Doctor Ontology"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/digitaldoctor2022/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T17:47:15.262567734Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:47:15.262567734Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/7c79b244-496b-47a2-8bc0-1e9b16c71d0a/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/f898284f-601b-4492-a515-cc39de252d1c> ;
+    dct:issued "2022"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Digital Doctor Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/digitaldoctor2022/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T17:47:15.262567734Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/dpo2017/metadata-turtle.ttl
+++ b/models/dpo2017/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/4c1c1a76-955e-4e4a-82a3-e3bba910fe75/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/b7c158b4-2fce-4ab6-a53b-db8ef28f5883>;
-    dct:issued "2016"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:title "Turtle distribution of Design Process Ontology"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/dpo2017/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T17:47:24.284942437Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:47:24.284942437Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/4c1c1a76-955e-4e4a-82a3-e3bba910fe75/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/b7c158b4-2fce-4ab6-a53b-db8ef28f5883> ;
+    dct:issued "2016"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Design Process Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/dpo2017/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T17:47:24.284942437Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/duarte2018osdef/metadata-turtle.ttl
+++ b/models/duarte2018osdef/metadata-turtle.ttl
@@ -1,19 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/3e52de2d-b288-4ffe-beef-83b21351d7fc/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/bfc2ffb6-b4bb-4f6c-9f8f-cc522d13dc94>;
-    dct:issued "2018"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:title "Turtle distribution of Ontology of Software Defects, Errors and Failures"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/duarte2018osdef/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T17:47:33.449644488Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:47:33.449644488Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/3e52de2d-b288-4ffe-beef-83b21351d7fc/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/bfc2ffb6-b4bb-4f6c-9f8f-cc522d13dc94> ;
+    dct:issued "2018"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Ontology of Software Defects, Errors and Failures"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/duarte2018osdef/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T17:47:33.449644488Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/duarte2018reqon/metadata-turtle.ttl
+++ b/models/duarte2018reqon/metadata-turtle.ttl
@@ -1,19 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/4c864267-b753-49e6-b4e0-95d54a1ad48a/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/10c716c3-7da2-4457-9e40-9f847d4cf37d>;
-    dct:issued "2018"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:title "Turtle distribution of Requirements Engineering Ontology"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/duarte2018reqon/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T17:47:49.974396024Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:47:49.974396024Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/4c864267-b753-49e6-b4e0-95d54a1ad48a/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/10c716c3-7da2-4457-9e40-9f847d4cf37d> ;
+    dct:issued "2018"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Requirements Engineering Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/duarte2018reqon/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T17:47:49.974396024Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/duarte2020jogabilidade/metadata-turtle.ttl
+++ b/models/duarte2020jogabilidade/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/1f5c8844-cf52-424f-9566-253b21c5e986/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/059dca17-0539-4e2c-8f50-fccc4e243242>;
-    dct:issued "2020"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:title "Turtle distribution of Gameplay Ontology"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/duarte2020jogabilidade/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T17:48:02.408338529Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:48:02.408338529Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/1f5c8844-cf52-424f-9566-253b21c5e986/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/059dca17-0539-4e2c-8f50-fccc4e243242> ;
+    dct:issued "2020"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Gameplay Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/duarte2020jogabilidade/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T17:48:02.408338529Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/duarte2021ross/metadata-turtle.ttl
+++ b/models/duarte2021ross/metadata-turtle.ttl
@@ -1,19 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/48151b6e-a47c-422a-932c-2cc0d141dae2/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/3adf4afc-9f96-403d-914a-72e41547f673>;
-    dct:issued "2021"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:title "Turtle distribution of Reference Ontology of Software Systems"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/duarte2021ross/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T17:48:20.936741361Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:48:20.936741361Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/48151b6e-a47c-422a-932c-2cc0d141dae2/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/3adf4afc-9f96-403d-914a-72e41547f673> ;
+    dct:issued "2021"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Reference Ontology of Software Systems"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/duarte2021ross/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T17:48:20.936741361Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/elghosh2020cargos/metadata-turtle.ttl
+++ b/models/elghosh2020cargos/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/9f388762-ba0e-42ce-8b63-11d2c07fee60/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/644b5d61-61df-429a-983b-5862fef2ff2a>;
-    dct:issued "2020"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:title "Turtle distribution of CargO-S Rule 1"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/elghosh2020cargos/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T17:48:30.337785798Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:48:30.337785798Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/9f388762-ba0e-42ce-8b63-11d2c07fee60/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/644b5d61-61df-429a-983b-5862fef2ff2a> ;
+    dct:issued "2020"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of CargO-S Rule 1"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/elghosh2020cargos/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T17:48:30.337785798Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/elghosh2024eucaim/metadata-turtle.ttl
+++ b/models/elghosh2024eucaim/metadata-turtle.ttl
@@ -1,0 +1,17 @@
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://w3id.org/ontouml-models/distribution/edb7829f-e323-5a11-81e8-68f96fe41e1e/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/elghosh2024eucaim> ;
+    dct:issued "2024"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of EUCAIM's Hyper-Ontology (Core Layer)"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/elghosh2024eucaim/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/elghosh2025crimonto/metadata-turtle.ttl
+++ b/models/elghosh2025crimonto/metadata-turtle.ttl
@@ -1,0 +1,17 @@
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://w3id.org/ontouml-models/distribution/1e6dea9d-4250-5d4d-a863-0340724e72d9/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/elghosh2025crimonto> ;
+    dct:issued "2025"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Criminal Modular Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/elghosh2025crimonto/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/elikan2018brand-identity/metadata-turtle.ttl
+++ b/models/elikan2018brand-identity/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/6c606e4b-d92c-4a95-a7a5-9d9cce5eba55/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/ebdd4665-72c7-4c33-aa4a-d31b5c088981>;
-    dct:issued "2018"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:title "Turtle distribution of Brand Identity Ontology"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/elikan2018brand-identity/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T17:48:39.589091562Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:48:39.589091562Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/6c606e4b-d92c-4a95-a7a5-9d9cce5eba55/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/ebdd4665-72c7-4c33-aa4a-d31b5c088981> ;
+    dct:issued "2018"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Brand Identity Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/elikan2018brand-identity/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T17:48:39.589091562Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/eu-rent-refactored2022/metadata-turtle.ttl
+++ b/models/eu-rent-refactored2022/metadata-turtle.ttl
@@ -1,19 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/5ce51d8b-2238-4d10-bfa1-20e36880ba6a/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/e4940b3f-a31f-4341-a21d-494423c8d876>;
-    dct:issued "2022"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:title "Turtle distribution of EU-Rent Car Rentals Refactored"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/eu-rent-refactored2022/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T17:48:47.372215969Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:48:47.372215969Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/5ce51d8b-2238-4d10-bfa1-20e36880ba6a/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/e4940b3f-a31f-4341-a21d-494423c8d876> ;
+    dct:issued "2022"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of EU-Rent Car Rentals Refactored"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/eu-rent-refactored2022/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T17:48:47.372215969Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/experiment2013/metadata-turtle.ttl
+++ b/models/experiment2013/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/8221fc87-d4d9-49b1-b67e-1e672f9f2724/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/34ed86ed-d667-41d2-9eef-cbe8f238e1f9>;
-    dct:issued "2013"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:title "Turtle distribution of Experiment Model"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/experiment2013/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T17:48:57.733218645Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:48:57.733218645Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/8221fc87-d4d9-49b1-b67e-1e672f9f2724/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/34ed86ed-d667-41d2-9eef-cbe8f238e1f9> ;
+    dct:issued "2013"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Experiment Model"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/experiment2013/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T17:48:57.733218645Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/falduci2022non-consensual-pornography/metadata-turtle.ttl
+++ b/models/falduci2022non-consensual-pornography/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/ce90ff3d-dc2b-4cbb-ad6b-c1e20b156647/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/1f701487-b0c6-4647-883d-5ca5fae94a24>;
-    dct:issued "2022"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:title "Turtle distribution of Non-Consensual Pornography Phenomenon"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/falduci2022non-consensual-pornography/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T17:49:12.008418016Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:49:12.008418016Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/ce90ff3d-dc2b-4cbb-ad6b-c1e20b156647/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/1f701487-b0c6-4647-883d-5ca5fae94a24> ;
+    dct:issued "2022"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Non-Consensual Pornography Phenomenon"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/falduci2022non-consensual-pornography/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T17:49:12.008418016Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/fernandez-cejas2022curie-o/metadata-turtle.ttl
+++ b/models/fernandez-cejas2022curie-o/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/ae67e1d5-85d2-4970-8d64-52c690500998/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/a1eaeceb-2031-4095-8bd0-92767646919c>;
-    dct:issued "2022"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:title "Turtle distribution of Customer Relationship, Intelligence and Experiences Ontology"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/fernandez-cejas2022curie-o/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T17:49:19.659002146Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:49:19.659002146Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/ae67e1d5-85d2-4970-8d64-52c690500998/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/a1eaeceb-2031-4095-8bd0-92767646919c> ;
+    dct:issued "2022"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Customer Relationship, Intelligence and Experiences Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/fernandez-cejas2022curie-o/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T17:49:19.659002146Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/ferreira2015ontoemergeplan/metadata-turtle.ttl
+++ b/models/ferreira2015ontoemergeplan/metadata-turtle.ttl
@@ -1,19 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/b38da854-2538-4a87-a80b-5ad7aa609db4/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/dddeec28-4c7c-4e5f-b22e-b536fa79ac72>;
-    dct:issued "2013"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:title "Turtle distribution of Ontology for Emergency Plans"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/ferreira2015ontoemergeplan/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T17:49:54.233038499Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:49:54.233038499Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/b38da854-2538-4a87-a80b-5ad7aa609db4/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/dddeec28-4c7c-4e5f-b22e-b536fa79ac72> ;
+    dct:issued "2013"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Ontology for Emergency Plans"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/ferreira2015ontoemergeplan/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T17:49:54.233038499Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/ferreira2024ontopix/metadata-turtle.ttl
+++ b/models/ferreira2024ontopix/metadata-turtle.ttl
@@ -1,0 +1,17 @@
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://w3id.org/ontouml-models/distribution/a2f806f2-4448-50bd-ab05-d3c7572455ce/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/ferreira2024ontopix> ;
+    dct:issued "2024"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of OntoPIX"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/ferreira2024ontopix/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/fischer2018ontorea/metadata-turtle.ttl
+++ b/models/fischer2018ontorea/metadata-turtle.ttl
@@ -1,19 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/17762858-8496-463a-92d0-8ae74867f317/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/dca91792-d4d7-4233-a62b-50040c242cf0>;
-    dct:issued "2017"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:title "Turtle distribution of OntoREA© Accounting and Finance Model"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/fischer2018ontorea/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T17:50:03.707577525Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:50:03.707577525Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/17762858-8496-463a-92d0-8ae74867f317/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/dca91792-d4d7-4233-a62b-50040c242cf0> ;
+    dct:issued "2017"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of OntoREA© Accounting and Finance Model"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/fischer2018ontorea/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T17:50:03.707577525Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/fonseca2022incorporating/metadata-turtle.ttl
+++ b/models/fonseca2022incorporating/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/a0fce354-b5b4-4894-90a0-2632662060e3/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/ad016e7d-9ec8-42e3-b3e1-6d60cf178a78>;
-    dct:issued "2022"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:title "Turtle distribution of Examples of Multi-level Modeling"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/fonseca2022incorporating/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T17:50:20.936187417Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:50:20.936187417Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/a0fce354-b5b4-4894-90a0-2632662060e3/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/ad016e7d-9ec8-42e3-b3e1-6d60cf178a78> ;
+    dct:issued "2022"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Examples of Multi-level Modeling"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/fonseca2022incorporating/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T17:50:20.936187417Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/formula-one2023/metadata-turtle.ttl
+++ b/models/formula-one2023/metadata-turtle.ttl
@@ -1,0 +1,17 @@
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://w3id.org/ontouml-models/distribution/7e031f34-d837-5b0f-9b30-f4b9da349326/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/formula-one2023> ;
+    dct:issued "2023"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Formula One Example Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/formula-one2023/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/fraller2019abc/metadata-turtle.ttl
+++ b/models/fraller2019abc/metadata-turtle.ttl
@@ -1,19 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/5511de05-7efc-49bc-bd8a-b76e16667238/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/dbd5fed6-8332-458f-90ec-b9270e7b6fdc>;
-    dct:issued "2019"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:title "Turtle distribution of Capacity-Based Activity-Based Costing System Model"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/fraller2019abc/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T17:50:50.267540831Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:50:50.267540831Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/5511de05-7efc-49bc-bd8a-b76e16667238/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/dbd5fed6-8332-458f-90ec-b9270e7b6fdc> ;
+    dct:issued "2019"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Capacity-Based Activity-Based Costing System Model"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/fraller2019abc/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T17:50:50.267540831Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/franco2018rpg/metadata-turtle.ttl
+++ b/models/franco2018rpg/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/bc948025-aae9-463a-af79-a70b2c80f885/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/0aa4b475-184e-4452-a030-56b7bd4fd931>;
-    dct:issued "2018"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:title "Turtle distribution of Role Playing Games Ontology"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/franco2018rpg/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T17:51:00.705549738Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:51:00.705549738Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/bc948025-aae9-463a-af79-a70b2c80f885/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/0aa4b475-184e-4452-a030-56b7bd4fd931> ;
+    dct:issued "2018"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Role Playing Games Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/franco2018rpg/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T17:51:00.705549738Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/freshbz2023/metadata-turtle.ttl
+++ b/models/freshbz2023/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/9e27f11b-ed1a-400d-a0dd-01246adfffbc/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/243da519-dae6-40d8-923b-064b50bce14c>;
-    dct:issued "2023"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0>;
-    dct:title "Turtle distribution of FreshBZ Application UML"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/freshbz2023/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T17:51:16.677577469Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:51:16.677577469Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/9e27f11b-ed1a-400d-a0dd-01246adfffbc/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/243da519-dae6-40d8-923b-064b50bce14c> ;
+    dct:issued "2023"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0> ;
+    dct:title "Turtle distribution of FreshBZ Application UML"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/freshbz2023/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T17:51:16.677577469Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/fumagalli2022criminal-investigation/metadata-turtle.ttl
+++ b/models/fumagalli2022criminal-investigation/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/74bb1cb5-3c79-4b91-8c51-2907287519fd/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/8353ae58-e924-4b13-8cbe-7078e59830ac>;
-    dct:issued "2022"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:title "Turtle distribution of OntoUML Model Representing a Subset of Criminal Investigation Domain"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/fumagalli2022criminal-investigation/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T17:51:24.774292058Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:51:24.774292058Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/74bb1cb5-3c79-4b91-8c51-2907287519fd/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/8353ae58-e924-4b13-8cbe-7078e59830ac> ;
+    dct:issued "2022"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of OntoUML Model Representing a Subset of Criminal Investigation Domain"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/fumagalli2022criminal-investigation/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T17:51:24.774292058Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/g809-2015/metadata-turtle.ttl
+++ b/models/g809-2015/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/84120461-ab7c-49ab-8b47-6fc8d8b89b4c/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/886bc5e1-a538-449e-9235-5ef0cc1cadf0>;
-    dct:issued "2013"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:title "Turtle distribution of G.809 Model"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/g809-2015/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T17:51:33.976848358Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:51:33.976848358Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/84120461-ab7c-49ab-8b47-6fc8d8b89b4c/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/886bc5e1-a538-449e-9235-5ef0cc1cadf0> ;
+    dct:issued "2013"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of G.809 Model"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/g809-2015/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T17:51:33.976848358Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/gailly2016value/metadata-turtle.ttl
+++ b/models/gailly2016value/metadata-turtle.ttl
@@ -1,19 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/9535f276-2f73-4268-893e-5778df89b8ce/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/27838506-29aa-4445-a1fe-73e710c9c186>;
-    dct:issued "2016"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:title "Turtle distribution of Core Value Ontology"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/gailly2016value/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T17:51:43.757471202Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:51:43.757471202Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/9535f276-2f73-4268-893e-5778df89b8ce/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/27838506-29aa-4445-a1fe-73e710c9c186> ;
+    dct:issued "2016"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Core Value Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/gailly2016value/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T17:51:43.757471202Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/garcia2022human-genome-events/metadata-turtle.ttl
+++ b/models/garcia2022human-genome-events/metadata-turtle.ttl
@@ -1,19 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/6d9762e4-6f5e-413d-aa9a-aaaeebc5f070/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/765516ef-53fe-4933-a0e5-0a38079d25c3>;
-    dct:issued "2022"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:title "Turtle distribution of Ontologically enriched version of Conceptual Schema of the Human Genome"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/garcia2022human-genome-events/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T17:51:53.026791321Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:51:53.026791321Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/6d9762e4-6f5e-413d-aa9a-aaaeebc5f070/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/765516ef-53fe-4933-a0e5-0a38079d25c3> ;
+    dct:issued "2022"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Ontologically enriched version of Conceptual Schema of the Human Genome"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/garcia2022human-genome-events/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T17:51:53.026791321Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/genealogy2013/metadata-turtle.ttl
+++ b/models/genealogy2013/metadata-turtle.ttl
@@ -1,0 +1,17 @@
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://w3id.org/ontouml-models/distribution/7a9ae84f-bfe2-5191-bf4a-e915fd688077/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/genealogy2013> ;
+    dct:issued "2013"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Simple Genealogy Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/genealogy2013/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/gi2mo/metadata-turtle.ttl
+++ b/models/gi2mo/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/a81c0f04-d421-4fc8-adb9-548e294b9ee0/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/bbc30d79-0cea-4f92-bdbb-827d5c4c54e5>;
-    dct:issued "2013"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:title "Turtle distribution of Generic Idea and Innovation Management Ontology Refactored"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/gi2mo/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T17:52:12.14938287Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:52:12.14938287Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/a81c0f04-d421-4fc8-adb9-548e294b9ee0/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/bbc30d79-0cea-4f92-bdbb-827d5c4c54e5> ;
+    dct:issued "2013"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Generic Idea and Innovation Management Ontology Refactored"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/gi2mo/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T17:52:12.14938287Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/gomes2022digital-technology/metadata-turtle.ttl
+++ b/models/gomes2022digital-technology/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/80b00c56-c5aa-4ea2-9186-522bc006bdce/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/b4b680b4-5bf6-47cd-9d53-b89277ca1ae3>;
-    dct:issued "2022"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:title "Turtle distribution of Digital Technology"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/gomes2022digital-technology/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T17:52:20.104827025Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:52:20.104827025Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/80b00c56-c5aa-4ea2-9186-522bc006bdce/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/b4b680b4-5bf6-47cd-9d53-b89277ca1ae3> ;
+    dct:issued "2022"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Digital Technology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/gomes2022digital-technology/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T17:52:20.104827025Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/goncalves2011ecg/metadata-turtle.ttl
+++ b/models/goncalves2011ecg/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/b7cff426-16b4-4276-af6a-c4b4106343b5/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/ad222e18-67f9-4393-b6c4-8da9c003bc74>;
-    dct:issued "2007"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0>;
-    dct:title "Turtle distribution of Electrocardiogram (ECG) Ontology"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/goncalves2011ecg/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T17:53:06.020395331Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:53:06.020395331Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/b7cff426-16b4-4276-af6a-c4b4106343b5/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/ad222e18-67f9-4393-b6c4-8da9c003bc74> ;
+    dct:issued "2007"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0> ;
+    dct:title "Turtle distribution of Electrocardiogram (ECG) Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/goncalves2011ecg/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T17:53:06.020395331Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/grueau2013towards/metadata-turtle.ttl
+++ b/models/grueau2013towards/metadata-turtle.ttl
@@ -1,19 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/e309f16f-4618-4502-ab00-bf37008c6967/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/12a721da-35ae-460f-9417-a2cf55e0f203>;
-    dct:issued "2014"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:title "Turtle distribution of MAS/LUCC Domain Ontology (excerpt - the agents' layer)"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/grueau2013towards/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T17:53:16.18200434Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:53:16.18200434Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/e309f16f-4618-4502-ab00-bf37008c6967/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/12a721da-35ae-460f-9417-a2cf55e0f203> ;
+    dct:issued "2014"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of MAS/LUCC Domain Ontology (excerpt - the agents' layer)"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/grueau2013towards/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T17:53:16.18200434Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/guarino2016value/metadata-turtle.ttl
+++ b/models/guarino2016value/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/9aa1be44-137f-48c1-a48d-2f89e11ab6d6/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/2a5b8924-d39a-40fc-8c68-cf1be0dd694e>;
-    dct:issued "2016"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:title "Turtle distribution of Value Ascription Ontology"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/guarino2016value/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T17:53:25.81460639Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:53:25.81460639Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/9aa1be44-137f-48c1-a48d-2f89e11ab6d6/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/2a5b8924-d39a-40fc-8c68-cf1be0dd694e> ;
+    dct:issued "2016"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Value Ascription Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/guarino2016value/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T17:53:25.81460639Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/guarino2018rea/metadata-turtle.ttl
+++ b/models/guarino2018rea/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/91345ba4-e724-4593-ad3a-cc41d99b77f6/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/3f07650f-fc02-409b-9101-35063fce9692>;
-    dct:issued "2018"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:title "Turtle distribution of Ontological Analysis of REA"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/guarino2018rea/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T17:53:34.940769474Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:53:34.940769474Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/91345ba4-e724-4593-ad3a-cc41d99b77f6/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/3f07650f-fc02-409b-9101-35063fce9692> ;
+    dct:issued "2018"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Ontological Analysis of REA"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/guarino2018rea/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T17:53:34.940769474Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/guizzardi2005ontological/metadata-turtle.ttl
+++ b/models/guizzardi2005ontological/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/2a797116-72db-4193-873d-54f2f4e63972/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/f829c6e9-1dd6-48ce-8403-421efbe15f25>;
-    dct:issued "2005"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:title "Turtle distribution of Example of Integrated Ontology"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/guizzardi2005ontological/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T17:53:44.298547759Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:53:44.298547759Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/2a797116-72db-4193-873d-54f2f4e63972/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/f829c6e9-1dd6-48ce-8403-421efbe15f25> ;
+    dct:issued "2005"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Example of Integrated Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/guizzardi2005ontological/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T17:53:44.298547759Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/guizzardi2014nfr/metadata-turtle.ttl
+++ b/models/guizzardi2014nfr/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/19f963af-95c2-40ce-ab4d-6e9360c66e82/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/0e262d1c-b8aa-49ec-8ad7-12f97ecb3269>;
-    dct:issued "2014"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:title "Turtle distribution of Non-Functional Requirements Ontology"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/guizzardi2014nfr/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T17:53:53.494228311Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:53:53.494228311Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/19f963af-95c2-40ce-ab4d-6e9360c66e82/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/0e262d1c-b8aa-49ec-8ad7-12f97ecb3269> ;
+    dct:issued "2014"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Non-Functional Requirements Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/guizzardi2014nfr/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T17:53:53.494228311Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/guizzardi2020decision-making/metadata-turtle.ttl
+++ b/models/guizzardi2020decision-making/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/bbe8a2c5-cf74-402a-854e-6e02bc892af8/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/4daaeace-2d0c-4341-a5fb-b00c320201df>;
-    dct:issued "2020"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:title "Turtle distribution of Decision Making Ontology"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/guizzardi2020decision-making/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T17:54:08.507229182Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:54:08.507229182Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/bbe8a2c5-cf74-402a-854e-6e02bc892af8/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/4daaeace-2d0c-4341-a5fb-b00c320201df> ;
+    dct:issued "2020"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Decision Making Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/guizzardi2020decision-making/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T17:54:08.507229182Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/guizzardi2022ufo/metadata-turtle.ttl
+++ b/models/guizzardi2022ufo/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/f6e46f5c-98a7-492c-b101-1485882847e6/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/86597da3-8afe-45e4-b836-03fc9ecb6ffc>;
-    dct:issued "2021"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:title "Turtle distribution of OntoUML Examples"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/guizzardi2022ufo/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T17:54:25.525856553Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:54:25.525856553Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/f6e46f5c-98a7-492c-b101-1485882847e6/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/86597da3-8afe-45e4-b836-03fc9ecb6ffc> ;
+    dct:issued "2021"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of OntoUML Examples"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/guizzardi2022ufo/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T17:54:25.525856553Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/haridy2021egyptian-e-government/metadata-turtle.ttl
+++ b/models/haridy2021egyptian-e-government/metadata-turtle.ttl
@@ -1,19 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/280910f3-6369-4c2e-9785-ea4ad1588e1f/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/5f85d9aa-67ac-4315-b60d-0212ea910320>;
-    dct:issued "2021"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:title "Turtle distribution of Egyptian E-Government Conceptual Model"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/haridy2021egyptian-e-government/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T17:54:38.5149831Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:54:38.5149831Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/280910f3-6369-4c2e-9785-ea4ad1588e1f/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/5f85d9aa-67ac-4315-b60d-0212ea910320> ;
+    dct:issued "2021"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Egyptian E-Government Conceptual Model"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/haridy2021egyptian-e-government/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T17:54:38.5149831Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/health-organizations/metadata-turtle.ttl
+++ b/models/health-organizations/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/6b943f53-9faf-4526-9dcc-fcaecb133821/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/c6d2e61a-4904-47ec-8935-2e2e56669220>;
-    dct:issued "2013"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:title "Turtle distribution of Model of Health Organizations"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/health-organizations/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T17:54:48.106409149Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:54:48.106409149Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/6b943f53-9faf-4526-9dcc-fcaecb133821/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/c6d2e61a-4904-47ec-8935-2e2e56669220> ;
+    dct:issued "2013"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Model of Health Organizations"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/health-organizations/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T17:54:48.106409149Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/heirbrant2023boekbazaar/metadata-turtle.ttl
+++ b/models/heirbrant2023boekbazaar/metadata-turtle.ttl
@@ -1,0 +1,17 @@
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://w3id.org/ontouml-models/distribution/c19d5651-7eb9-576d-8652-f96cc6dde1ea/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/heirbrant2023boekbazaar> ;
+    dct:issued "2023"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Boekbazaar Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/heirbrant2023boekbazaar/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/idaf2013/metadata-turtle.ttl
+++ b/models/idaf2013/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/e21e8a3e-17dd-40e0-9c26-5f643723fcd7/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/291e45be-4c9d-41b1-a237-f3f47714226d>;
-    dct:issued "2013"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:title "Turtle distribution of Structure of the IDAF Ontology"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/idaf2013/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T17:55:00.900647533Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:55:00.900647533Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/e21e8a3e-17dd-40e0-9c26-5f643723fcd7/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/291e45be-4c9d-41b1-a237-f3f47714226d> ;
+    dct:issued "2013"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Structure of the IDAF Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/idaf2013/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T17:55:00.900647533Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/internal-affairs2013/metadata-turtle.ttl
+++ b/models/internal-affairs2013/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/2a2976ce-dbbc-4462-a1fd-bc061dcfae2f/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/c150fd37-6fa4-4b0a-a2d0-7aff5e6a6cde>;
-    dct:issued "2013"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:title "Turtle distribution of Internal Affairs Ontology"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/internal-affairs2013/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T17:55:17.938336793Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:55:17.938336793Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/2a2976ce-dbbc-4462-a1fd-bc061dcfae2f/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/c150fd37-6fa4-4b0a-a2d0-7aff5e6a6cde> ;
+    dct:issued "2013"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Internal Affairs Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/internal-affairs2013/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T17:55:17.938336793Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/internship/metadata-turtle.ttl
+++ b/models/internship/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/afae5dde-8be6-4122-b0e8-c6b447789de9/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/b6660078-f212-4051-b469-279863bb5e33>;
-    dct:issued "2013"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0>;
-    dct:title "Turtle distribution of Internship Ontology"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/internship/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T17:55:27.912752267Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:55:27.912752267Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/afae5dde-8be6-4122-b0e8-c6b447789de9/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/b6660078-f212-4051-b469-279863bb5e33> ;
+    dct:issued "2013"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0> ;
+    dct:title "Turtle distribution of Internship Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/internship/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T17:55:27.912752267Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/it-infrastructure/metadata-turtle.ttl
+++ b/models/it-infrastructure/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/cdaa0242-2fd2-4d5b-b54a-06e70629160d/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/3c25eb5e-58d7-43cf-8027-31bd0827044e>;
-    dct:issued "2013"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0>;
-    dct:title "Turtle distribution of IT Infrastructure Model"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/it-infrastructure/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T17:55:37.69031002Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:55:37.69031002Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/cdaa0242-2fd2-4d5b-b54a-06e70629160d/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/3c25eb5e-58d7-43cf-8027-31bd0827044e> ;
+    dct:issued "2013"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0> ;
+    dct:title "Turtle distribution of IT Infrastructure Model"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/it-infrastructure/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T17:55:37.69031002Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/jacobs2022sdpontology/metadata-turtle.ttl
+++ b/models/jacobs2022sdpontology/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/e7762868-a760-4436-8d95-8f30014886fc/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/d6c9a835-4c50-42a2-a383-952cd9de8497>;
-    dct:issued "2022"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0>;
-    dct:title "Turtle distribution of Software Development Project Ontology"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/jacobs2022sdpontology/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T17:55:50.104942345Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:55:50.104942345Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/e7762868-a760-4436-8d95-8f30014886fc/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/d6c9a835-4c50-42a2-a383-952cd9de8497> ;
+    dct:issued "2022"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0> ;
+    dct:title "Turtle distribution of Software Development Project Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/jacobs2022sdpontology/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T17:55:50.104942345Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/junior2018o4c/metadata-turtle.ttl
+++ b/models/junior2018o4c/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/fde1054c-f762-4fe4-8f67-47d286d11b5b/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/4768da76-c638-4fb1-b0c8-5a4f98872ef4>;
-    dct:issued "2018"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:title "Turtle distribution of Ontology for Concerns"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/junior2018o4c/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T17:55:59.57195263Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:55:59.57195263Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/fde1054c-f762-4fe4-8f67-47d286d11b5b/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/4768da76-c638-4fb1-b0c8-5a4f98872ef4> ;
+    dct:issued "2018"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Ontology for Concerns"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/junior2018o4c/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T17:55:59.57195263Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/khantong2020ontology/metadata-turtle.ttl
+++ b/models/khantong2020ontology/metadata-turtle.ttl
@@ -1,19 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/48407f93-c4e4-4925-ba5c-3518169e223e/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/5a426516-e211-4e7b-abc5-dca6b11d2d6a>;
-    dct:issued "2019"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:title "Turtle distribution of Disaster Response Ontology - Flood Response Scenarios"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/khantong2020ontology/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T17:56:09.099167712Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:56:09.099167712Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/48407f93-c4e4-4925-ba5c-3518169e223e/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/5a426516-e211-4e7b-abc5-dca6b11d2d6a> ;
+    dct:issued "2019"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Disaster Response Ontology - Flood Response Scenarios"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/khantong2020ontology/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T17:56:09.099167712Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/kostov2017towards/metadata-turtle.ttl
+++ b/models/kostov2017towards/metadata-turtle.ttl
@@ -1,19 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/8c8d9f3e-c061-4804-8cc2-f51099c85074/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/b8d64beb-327f-4e7c-96a7-a10ab1a9da3e>;
-    dct:issued "2016"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:title "Turtle distribution of Aviation Safety Ontology"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/kostov2017towards/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T17:56:25.572750358Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:56:25.572750358Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/8c8d9f3e-c061-4804-8cc2-f51099c85074/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/b8d64beb-327f-4e7c-96a7-a10ab1a9da3e> ;
+    dct:issued "2016"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Aviation Safety Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/kostov2017towards/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T17:56:25.572750358Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/kritz2020ontobg/metadata-turtle.ttl
+++ b/models/kritz2020ontobg/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/23712593-71f1-46e8-9dc2-d467cb0429c7/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/47cee156-e106-40c9-ae22-f2933d56abc6>;
-    dct:issued "2020"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:title "Turtle distribution of Ontology of Board Games"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/kritz2020ontobg/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T17:56:46.473903149Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:56:46.473903149Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/23712593-71f1-46e8-9dc2-d467cb0429c7/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/47cee156-e106-40c9-ae22-f2933d56abc6> ;
+    dct:issued "2020"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Ontology of Board Games"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/kritz2020ontobg/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T17:56:46.473903149Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/laurier2018rea/metadata-turtle.ttl
+++ b/models/laurier2018rea/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/d9996b63-d792-4fa3-aa34-722c1eeecb89/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/c71c375d-a9b6-4a3c-b10b-376357286b51>;
-    dct:issued "2018"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:title "Turtle distribution of REA Ontology"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/laurier2018rea/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T17:57:02.770890146Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:57:02.770890146Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/d9996b63-d792-4fa3-aa34-722c1eeecb89/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/c71c375d-a9b6-4a3c-b10b-376357286b51> ;
+    dct:issued "2018"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of REA Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/laurier2018rea/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T17:57:02.770890146Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/leao2024ontomed/metadata-turtle.ttl
+++ b/models/leao2024ontomed/metadata-turtle.ttl
@@ -1,0 +1,17 @@
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://w3id.org/ontouml-models/distribution/184bcd0a-704c-52c2-b383-d818b91a2912/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/leao2024ontomed> ;
+    dct:issued "2024"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Ontology for Medication Interaction Decision Support"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/leao2024ontomed/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/library/metadata-turtle.ttl
+++ b/models/library/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/4777506b-c2c4-4996-a100-cbe75575804f/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/c26c4ec3-c554-4988-9b19-581855aa4646>;
-    dct:issued "2013"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0>;
-    dct:title "Turtle distribution of Library Ontology"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/library/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T17:57:12.13521171Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:57:12.13521171Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/4777506b-c2c4-4996-a100-cbe75575804f/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/c26c4ec3-c554-4988-9b19-581855aa4646> ;
+    dct:issued "2013"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0> ;
+    dct:title "Turtle distribution of Library Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/library/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T17:57:12.13521171Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/lindeberg2022full-ontorights/metadata-turtle.ttl
+++ b/models/lindeberg2022full-ontorights/metadata-turtle.ttl
@@ -1,0 +1,17 @@
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://w3id.org/ontouml-models/distribution/788fcf62-18df-5829-81b5-fb3c526de497/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/lindeberg2022full-ontorights> ;
+    dct:issued "2022"^^xsd:gYear ;
+    dct:license <https://unlicense.org/> ;
+    dct:title "Turtle distribution of Full OntoRights"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/lindeberg2022full-ontorights/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/lindeberg2022simple-ontorights/metadata-turtle.ttl
+++ b/models/lindeberg2022simple-ontorights/metadata-turtle.ttl
@@ -1,0 +1,17 @@
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://w3id.org/ontouml-models/distribution/b570dd14-c589-5dc3-9906-f9e835fb814c/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/lindeberg2022simple-ontorights> ;
+    dct:issued "2022"^^xsd:gYear ;
+    dct:license <https://unlicense.org/> ;
+    dct:title "Turtle distribution of Easy OntoRights"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/lindeberg2022simple-ontorights/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/lindeberg2024legal-enforcement/metadata-turtle.ttl
+++ b/models/lindeberg2024legal-enforcement/metadata-turtle.ttl
@@ -1,0 +1,17 @@
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://w3id.org/ontouml-models/distribution/4984cc72-93fd-542f-a9c2-0613fee4cb1f/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/lindeberg2024legal-enforcement> ;
+    dct:issued "2024"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Legal Enforcement Meta-Model"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/lindeberg2024legal-enforcement/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/machacova2023gym/metadata-turtle.ttl
+++ b/models/machacova2023gym/metadata-turtle.ttl
@@ -1,0 +1,17 @@
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://w3id.org/ontouml-models/distribution/34297856-b225-50d1-b977-8c6980309de1/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/machacova2023gym> ;
+    dct:issued "2023"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Example Ontology for Gym Products"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/machacova2023gym/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/maddalena2021ontocovid/metadata-turtle.ttl
+++ b/models/maddalena2021ontocovid/metadata-turtle.ttl
@@ -1,19 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/8ba63420-bbe8-4151-9918-14aab50751b7/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/731a9856-9d6f-4a07-859c-48ec758fe5ce>;
-    dct:issued "2021"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:title "Turtle distribution of OntoCovid"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/maddalena2021ontocovid/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T17:58:19.5761608Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:58:19.5761608Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/8ba63420-bbe8-4151-9918-14aab50751b7/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/731a9856-9d6f-4a07-859c-48ec758fe5ce> ;
+    dct:issued "2021"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of OntoCovid"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/maddalena2021ontocovid/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T17:58:19.5761608Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/martinez2013human-genome/metadata-turtle.ttl
+++ b/models/martinez2013human-genome/metadata-turtle.ttl
@@ -1,19 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/5239badd-3f17-4eaf-9ef4-bab107211d70/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/7509f026-5e24-48e7-a995-ab2f419ce4d7>;
-    dct:issued "2013"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:title "Turtle distribution of Conceptual Schema of Human Genome"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/martinez2013human-genome/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T17:58:32.329139435Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:58:32.329139435Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/5239badd-3f17-4eaf-9ef4-bab107211d70/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/7509f026-5e24-48e7-a995-ab2f419ce4d7> ;
+    dct:issued "2013"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Conceptual Schema of Human Genome"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/martinez2013human-genome/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T17:58:32.329139435Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/meirelles2024credit-operations/metadata-turtle.ttl
+++ b/models/meirelles2024credit-operations/metadata-turtle.ttl
@@ -1,0 +1,17 @@
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://w3id.org/ontouml-models/distribution/83f87631-ab15-5e92-a552-497804ca354d/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/meirelles2024credit-operations> ;
+    dct:issued "2024"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Ontologia de Referência para o Domínio de Operações de Crédito"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/meirelles2024credit-operations/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/mello2022monotheism/metadata-turtle.ttl
+++ b/models/mello2022monotheism/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/feb7c004-899f-4d76-a93f-9ba0ecb4f07c/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/01b11d4e-3eb1-4aae-ab31-5daa5220fffc>;
-    dct:issued "2022"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:title "Turtle distribution of Ontology of Monotheism"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/mello2022monotheism/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T17:58:41.495367869Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:58:41.495367869Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/feb7c004-899f-4d76-a93f-9ba0ecb4f07c/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/01b11d4e-3eb1-4aae-ab31-5daa5220fffc> ;
+    dct:issued "2022"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Ontology of Monotheism"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/mello2022monotheism/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T17:58:41.495367869Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/melo2024onto-educational/metadata-turtle.ttl
+++ b/models/melo2024onto-educational/metadata-turtle.ttl
@@ -1,0 +1,17 @@
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://w3id.org/ontouml-models/distribution/4b6344d0-3e95-5984-9afe-b8d896edfa2f/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/melo2024onto-educational> ;
+    dct:issued "2024"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Ontologia para Integração de Dados de Evasão Escolar, Desempenho Acadêmico e Concessão de Auxílios Socioeconômicos"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/melo2024onto-educational/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/mgic-antt2011/metadata-turtle.ttl
+++ b/models/mgic-antt2011/metadata-turtle.ttl
@@ -1,0 +1,16 @@
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://w3id.org/ontouml-models/distribution/76f7b904-b5ab-5ab2-825d-8c7d60458552/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/mgic-antt2011> ;
+    dct:issued "2011"^^xsd:gYear ;
+    dct:title "Turtle distribution of National Agency of Terrestrial Transportation (ANTT) Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/mgic-antt2011/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/moreira2018saref4health/metadata-turtle.ttl
+++ b/models/moreira2018saref4health/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/e1758a7a-de62-4633-9eba-906a1937b43a/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/0ed90b91-3f0c-46e2-9710-7e14cc846b34>;
-    dct:issued "2018"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:title "Turtle distribution of Ambient Assisted Living Ontology"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/moreira2018saref4health/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T18:06:23.081377295Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:06:23.081377295Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/e1758a7a-de62-4633-9eba-906a1937b43a/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/0ed90b91-3f0c-46e2-9710-7e14cc846b34> ;
+    dct:issued "2018"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Ambient Assisted Living Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/moreira2018saref4health/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T18:06:23.081377295Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/music-ontology/metadata-turtle.ttl
+++ b/models/music-ontology/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/4dbee2f8-a170-4836-89fd-9877152a1a76/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/daca2352-8735-4a4b-a1c2-952862fb594f>;
-    dct:issued "2013"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:title "Turtle distribution of Music Ontology"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/music-ontology/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T18:06:32.637241514Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:06:32.637241514Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/4dbee2f8-a170-4836-89fd-9877152a1a76/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/daca2352-8735-4a4b-a1c2-952862fb594f> ;
+    dct:issued "2013"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Music Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/music-ontology/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T18:06:32.637241514Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/nardi2015ufo-s/metadata-turtle.ttl
+++ b/models/nardi2015ufo-s/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/9c05d925-4fcc-4802-afa6-003e56c7b8c2/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/05b32152-3907-4a0a-915e-c5ff81117ded>;
-    dct:issued "2013"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:title "Turtle distribution of Commitment-based Reference Ontology for Services"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/nardi2015ufo-s/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T18:07:03.907044611Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:07:03.907044611Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/9c05d925-4fcc-4802-afa6-003e56c7b8c2/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/05b32152-3907-4a0a-915e-c5ff81117ded> ;
+    dct:issued "2013"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Commitment-based Reference Ontology for Services"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/nardi2015ufo-s/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T18:07:03.907044611Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/nascimento2023spacecon/metadata-turtle.ttl
+++ b/models/nascimento2023spacecon/metadata-turtle.ttl
@@ -1,0 +1,17 @@
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://w3id.org/ontouml-models/distribution/8a4e1f2c-c3fb-528a-8820-431a023a32bb/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/nascimento2023spacecon> ;
+    dct:issued "2023"^^xsd:gYear ;
+    dct:license <https://opensource.org/license/mit> ;
+    dct:title "Turtle distribution of Smart Spaces Context Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/nascimento2023spacecon/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/nazar2024marchine-learning/metadata-turtle.ttl
+++ b/models/nazar2024marchine-learning/metadata-turtle.ttl
@@ -1,0 +1,17 @@
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://w3id.org/ontouml-models/distribution/112100e7-a797-529b-95b9-1ff51411b981/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/nazar2024marchine-learning> ;
+    dct:issued "2024"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Machine Learning Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/nazar2024marchine-learning/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/neves2020nwpontology/metadata-turtle.ttl
+++ b/models/neves2020nwpontology/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/3196e4b2-9bf3-4c27-b5fe-72951bfb0d3f/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/7f3cddbe-6810-45a9-9a7d-08b996705c77>;
-    dct:issued "2020"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:title "Turtle distribution of NWPOntology"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/neves2020nwpontology/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T18:07:13.253713852Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:07:13.253713852Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/3196e4b2-9bf3-4c27-b5fe-72951bfb0d3f/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/7f3cddbe-6810-45a9-9a7d-08b996705c77> ;
+    dct:issued "2020"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of NWPOntology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/neves2020nwpontology/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T18:07:13.253713852Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/neves2021grain-production/metadata-turtle.ttl
+++ b/models/neves2021grain-production/metadata-turtle.ttl
@@ -1,19 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/1e79d4ec-d6c5-4f71-8696-900f0458dfe7/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/1d378243-6061-4e3a-b32e-05436601d9d9>;
-    dct:issued "2021"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:title "Turtle distribution of Grain Production Ontology"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/neves2021grain-production/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T18:07:23.112471369Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:07:23.112471369Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/1e79d4ec-d6c5-4f71-8696-900f0458dfe7/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/1d378243-6061-4e3a-b32e-05436601d9d9> ;
+    dct:issued "2021"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Grain Production Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/neves2021grain-production/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T18:07:23.112471369Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/niederkofler2019dssapple/metadata-turtle.ttl
+++ b/models/niederkofler2019dssapple/metadata-turtle.ttl
@@ -1,19 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/cb560e3e-8fad-4d7c-9168-35be47fc94fc/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/5f97c733-db8a-44cc-b94d-a28b7d3e85cc>;
-    dct:issued "2019"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:title "Turtle distribution of DSSApple Ontology"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/niederkofler2019dssapple/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T18:07:45.229898669Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:07:45.229898669Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/cb560e3e-8fad-4d7c-9168-35be47fc94fc/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/5f97c733-db8a-44cc-b94d-a28b7d3e85cc> ;
+    dct:issued "2019"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of DSSApple Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/niederkofler2019dssapple/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T18:07:45.229898669Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/o3ontology2015/metadata-turtle.ttl
+++ b/models/o3ontology2015/metadata-turtle.ttl
@@ -1,0 +1,17 @@
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://w3id.org/ontouml-models/distribution/e55f3a8d-6fa8-5d27-abb7-b3f82a1e05bf/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/o3ontology2015> ;
+    dct:issued "2015"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of O3 Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/o3ontology2015/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/oliveira2007collaboration/metadata-turtle.ttl
+++ b/models/oliveira2007collaboration/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/ebf17084-aa6e-49bf-a39f-5680cd3bd611/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/1823a511-3915-42e1-978b-0dcee8d5bd97>;
-    dct:issued "2007"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:title "Turtle distribution of Towards a collaboration ontology"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/oliveira2007collaboration/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T18:07:58.015966419Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:07:58.015966419Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/ebf17084-aa6e-49bf-a39f-5680cd3bd611/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/1823a511-3915-42e1-978b-0dcee8d5bd97> ;
+    dct:issued "2007"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Towards a collaboration ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/oliveira2007collaboration/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T18:07:58.015966419Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/oliveira2022rose/metadata-turtle.ttl
+++ b/models/oliveira2022rose/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/6865a8b2-d930-4316-9309-9beca149a9ab/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/cdd96c73-7f49-4f22-8748-1bd39eec9ceb>;
-    dct:issued "2022"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://opensource.org/license/mit>;
-    dct:title "Turtle distribution of Ontology of Security from a Risk Treatment Perspective"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/oliveira2022rose/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T18:08:15.057140596Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:08:15.057140596Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/6865a8b2-d930-4316-9309-9beca149a9ab/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/cdd96c73-7f49-4f22-8748-1bd39eec9ceb> ;
+    dct:issued "2022"^^xsd:gYear ;
+    dct:license <https://opensource.org/license/mit> ;
+    dct:title "Turtle distribution of Ontology of Security from a Risk Treatment Perspective"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/oliveira2022rose/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T18:08:15.057140596Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/oliveira2024phishing/metadata-turtle.ttl
+++ b/models/oliveira2024phishing/metadata-turtle.ttl
@@ -1,0 +1,17 @@
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://w3id.org/ontouml-models/distribution/9b6c68b1-cb27-5f19-8436-d3ebaae178ce/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/oliveira2024phishing> ;
+    dct:issued "2024"^^xsd:gYear ;
+    dct:license <https://www.apache.org/licenses/LICENSE-2.0> ;
+    dct:title "Turtle distribution of Phishing Attack Process Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/oliveira2024phishing/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/online-mentoring/metadata-turtle.ttl
+++ b/models/online-mentoring/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/0edd8dd8-5606-43d8-b525-033a487323f7/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/68e2c350-96a5-495f-b573-b2b14bfde3e2>;
-    dct:issued "2013"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0>;
-    dct:title "Turtle distribution of Online Mentoring Model"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/online-mentoring/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T18:08:24.417863384Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:08:24.417863384Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/0edd8dd8-5606-43d8-b525-033a487323f7/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/68e2c350-96a5-495f-b573-b2b14bfde3e2> ;
+    dct:issued "2013"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0> ;
+    dct:title "Turtle distribution of Online Mentoring Model"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/online-mentoring/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T18:08:24.417863384Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/parking-business2013/metadata-turtle.ttl
+++ b/models/parking-business2013/metadata-turtle.ttl
@@ -1,0 +1,17 @@
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://w3id.org/ontouml-models/distribution/3b449a3a-5fe7-50d2-b1dd-2eed83c49579/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/parking-business2013> ;
+    dct:issued "2013"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Parking Business Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/parking-business2013/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/peixoto2025anchorlogy/metadata-turtle.ttl
+++ b/models/peixoto2025anchorlogy/metadata-turtle.ttl
@@ -1,0 +1,17 @@
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://w3id.org/ontouml-models/distribution/d08a5fe2-b0bd-51f9-9f5d-905583d4fe08/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/peixoto2025anchorlogy> ;
+    dct:issued "2025"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Anchorlogy Ontology for Anchoring Bias in Forecasting"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/peixoto2025anchorlogy/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/pereira2015doacao-orgaos/metadata-turtle.ttl
+++ b/models/pereira2015doacao-orgaos/metadata-turtle.ttl
@@ -1,19 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/a26bccc2-0f0f-4e02-9044-7c84c52a0dc0/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/ff633ccf-80c1-4276-b9e2-7bf969b0d05b>;
-    dct:issued "2015"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:title "Turtle distribution of Ontologia de Doação de Órgão e Tecidos"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/pereira2015doacao-orgaos/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T18:08:36.717219926Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:08:36.717219926Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/a26bccc2-0f0f-4e02-9044-7c84c52a0dc0/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/ff633ccf-80c1-4276-b9e2-7bf969b0d05b> ;
+    dct:issued "2015"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Ontologia de Doação de Órgão e Tecidos"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/pereira2015doacao-orgaos/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T18:08:36.717219926Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/pereira2020ontotrans/metadata-turtle.ttl
+++ b/models/pereira2020ontotrans/metadata-turtle.ttl
@@ -1,19 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/d5a06614-857b-474b-b32b-5336aa4338bf/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/0a01a029-1863-498e-aba5-6e9580f94dc5>;
-    dct:issued "2020"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:title "Turtle distribution of OntoTrans"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/pereira2020ontotrans/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T18:08:46.46680544Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:08:46.46680544Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/d5a06614-857b-474b-b32b-5336aa4338bf/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/0a01a029-1863-498e-aba5-6e9580f94dc5> ;
+    dct:issued "2020"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of OntoTrans"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/pereira2020ontotrans/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T18:08:46.46680544Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/photography/metadata-turtle.ttl
+++ b/models/photography/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/0fb16505-8029-49c6-8d89-1933658ea08d/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/62dac1a5-a19d-4520-a68b-2bc94844128f>;
-    dct:issued "2013"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:title "Turtle distribution of Photography Collection Ontology"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/photography/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T18:08:55.943342887Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:08:55.943342887Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/0fb16505-8029-49c6-8d89-1933658ea08d/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/62dac1a5-a19d-4520-a68b-2bc94844128f> ;
+    dct:issued "2013"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Photography Collection Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/photography/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T18:08:55.943342887Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/piest2024dsr-kb/metadata-turtle.ttl
+++ b/models/piest2024dsr-kb/metadata-turtle.ttl
@@ -1,0 +1,17 @@
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://w3id.org/ontouml-models/distribution/176b0514-afd7-5f08-884f-c9ae6d9ef5b3/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/piest2024dsr-kb> ;
+    dct:issued "2024"^^xsd:gYear ;
+    dct:license <https://opensource.org/licenses/MIT> ;
+    dct:title "Turtle distribution of Domain Reference Ontology for Design Science Research Knowledge Bases"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/piest2024dsr-kb/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/pinheiro2024api/metadata-turtle.ttl
+++ b/models/pinheiro2024api/metadata-turtle.ttl
@@ -1,0 +1,17 @@
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://w3id.org/ontouml-models/distribution/a89fba2b-8444-580c-a610-fd013f888a18/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/pinheiro2024api> ;
+    dct:issued "2024"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Reference Ontology for Enterprise Architecture Mining from APIs"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/pinheiro2024api/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/plato-ontology2019/metadata-turtle.ttl
+++ b/models/plato-ontology2019/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/9918a840-5572-4a1e-b8fb-d6ca7a1bf784/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/db8cf905-98d1-4ba5-acff-587d4fc91890>;
-    dct:issued "2019"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0>;
-    dct:title "Turtle distribution of Plato Ontology"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/plato-ontology2019/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T18:09:15.589673707Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:09:15.589673707Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/9918a840-5572-4a1e-b8fb-d6ca7a1bf784/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/db8cf905-98d1-4ba5-acff-587d4fc91890> ;
+    dct:issued "2019"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0> ;
+    dct:title "Turtle distribution of Plato Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/plato-ontology2019/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T18:09:15.589673707Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/porello2020coex/metadata-turtle.ttl
+++ b/models/porello2020coex/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/4b71ed7d-4527-4503-bd36-33705dfae0bd/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/da6748bf-3355-478a-b22f-d197518c6e54>;
-    dct:issued "2021"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:title "Turtle distribution of Core ontology for economic exchange"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/porello2020coex/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T18:09:28.252332984Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:09:28.252332984Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/4b71ed7d-4527-4503-bd36-33705dfae0bd/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/da6748bf-3355-478a-b22f-d197518c6e54> ;
+    dct:issued "2021"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Core ontology for economic exchange"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/porello2020coex/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T18:09:28.252332984Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/ppo-o2021/metadata-turtle.ttl
+++ b/models/ppo-o2021/metadata-turtle.ttl
@@ -1,19 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/df59c12e-bc63-4ed4-8e65-c71c923382da/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/6c200266-ceb5-4cc6-8c8a-b01038687b72>;
-    dct:issued "2021"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:title "Turtle distribution of PreProcessing Operators Ontology"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/ppo-o2021/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T18:09:47.926037495Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:09:47.926037495Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/df59c12e-bc63-4ed4-8e65-c71c923382da/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/6c200266-ceb5-4cc6-8c8a-b01038687b72> ;
+    dct:issued "2021"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of PreProcessing Operators Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/ppo-o2021/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T18:09:47.926037495Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/project-assets2013/metadata-turtle.ttl
+++ b/models/project-assets2013/metadata-turtle.ttl
@@ -1,0 +1,17 @@
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://w3id.org/ontouml-models/distribution/f6f3e02b-a63b-5ce9-bc1d-b70bc1bd1ede/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/project-assets2013> ;
+    dct:issued "2013"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Project Assets"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/project-assets2013/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/project-management-ontology/metadata-turtle.ttl
+++ b/models/project-management-ontology/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/a7426d79-cecc-499d-86e1-91139978bf72/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/3788bfab-abc8-4765-80ec-7744f927c0e7>;
-    dct:issued "2013"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:title "Turtle distribution of Project Management Ontology"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/project-management-ontology/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T18:09:57.353914841Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:09:57.353914841Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/a7426d79-cecc-499d-86e1-91139978bf72/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/3788bfab-abc8-4765-80ec-7744f927c0e7> ;
+    dct:issued "2013"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Project Management Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/project-management-ontology/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T18:09:57.353914841Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/public-expense-ontology2020/metadata-turtle.ttl
+++ b/models/public-expense-ontology2020/metadata-turtle.ttl
@@ -1,19 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/5eeec4ed-31ef-4b42-b206-9d13675eddb5/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/0a044a49-bd7c-4429-8b83-68769b9037ee>;
-    dct:issued "2020"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:title "Turtle distribution of Public Expense Ontology"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/public-expense-ontology2020/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T18:10:12.967672109Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:10:12.967672109Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/5eeec4ed-31ef-4b42-b206-9d13675eddb5/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/0a044a49-bd7c-4429-8b83-68769b9037ee> ;
+    dct:issued "2020"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Public Expense Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/public-expense-ontology2020/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T18:10:12.967672109Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/public-organization2013/metadata-turtle.ttl
+++ b/models/public-organization2013/metadata-turtle.ttl
@@ -1,0 +1,17 @@
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://w3id.org/ontouml-models/distribution/080c7676-e715-5878-8227-564af19542e0/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/public-organization2013> ;
+    dct:issued "2013"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Ecology Public Organization"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/public-organization2013/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/public-tender/metadata-turtle.ttl
+++ b/models/public-tender/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/fde644b5-7d41-467e-a14c-7f3fdd6820b0/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/de0e84e8-9b55-4845-b8a5-17b495466d9f>;
-    dct:issued "2013"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0>;
-    dct:title "Turtle distribution of Public Tender Model"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/public-tender/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T18:10:38.344038576Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:10:38.344038576Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/fde644b5-7d41-467e-a14c-7f3fdd6820b0/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/de0e84e8-9b55-4845-b8a5-17b495466d9f> ;
+    dct:issued "2013"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0> ;
+    dct:title "Turtle distribution of Public Tender Model"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/public-tender/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T18:10:38.344038576Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/qam/metadata-turtle.ttl
+++ b/models/qam/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/f39081f9-416d-4d2f-832f-1b82d4a7d4cf/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/0b6d6128-81e6-4985-8f0e-bd5af9a295f3>;
-    dct:issued "2013"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0>;
-    dct:title "Turtle distribution of Quality Assurance Model"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/qam/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T18:10:47.674011631Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:10:47.674011631Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/f39081f9-416d-4d2f-832f-1b82d4a7d4cf/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/0b6d6128-81e6-4985-8f0e-bd5af9a295f3> ;
+    dct:issued "2013"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0> ;
+    dct:title "Turtle distribution of Quality Assurance Model"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/qam/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T18:10:47.674011631Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/quality-assurance-process-ontology2017/metadata-turtle.ttl
+++ b/models/quality-assurance-process-ontology2017/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/b5652eaf-ea14-4989-a37f-786fa3688231/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/5b9a7ca3-3579-46aa-b24e-63f5b9011253>;
-    dct:issued "2016"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:title "Turtle distribution of Quality Assurance Process Ontology"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/quality-assurance-process-ontology2017/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T18:10:57.497614002Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:10:57.497614002Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/b5652eaf-ea14-4989-a37f-786fa3688231/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/5b9a7ca3-3579-46aa-b24e-63f5b9011253> ;
+    dct:issued "2016"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Quality Assurance Process Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/quality-assurance-process-ontology2017/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T18:10:57.497614002Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/ramirez2015userfeedback/metadata-turtle.ttl
+++ b/models/ramirez2015userfeedback/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/ef1031db-2b7e-4262-a46c-691c642110eb/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/d8502133-b2b2-4b8a-b96f-dd8285863b23>;
-    dct:issued "2015"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:title "Turtle distribution of User Feedback Ontology"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/ramirez2015userfeedback/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T18:11:16.421579348Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:11:16.421579348Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/ef1031db-2b7e-4262-a46c-691c642110eb/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/d8502133-b2b2-4b8a-b96f-dd8285863b23> ;
+    dct:issued "2015"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of User Feedback Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/ramirez2015userfeedback/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T18:11:16.421579348Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/ramos2021bias/metadata-turtle.ttl
+++ b/models/ramos2021bias/metadata-turtle.ttl
@@ -1,19 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/d17cb65c-4e65-4f05-9f99-87e6bc2339c6/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/e3e0f697-53e8-45dc-8d32-bf282b5434cb>;
-    dct:issued "2021"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:title "Turtle distribution of Decision Making Ontology Extended with Intuitive Decision Making"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/ramos2021bias/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T18:11:25.872733476Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:11:25.872733476Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/d17cb65c-4e65-4f05-9f99-87e6bc2339c6/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/e3e0f697-53e8-45dc-8d32-bf282b5434cb> ;
+    dct:issued "2021"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Decision Making Ontology Extended with Intuitive Decision Making"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/ramos2021bias/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T18:11:25.872733476Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/real-estate-ontology/metadata-turtle.ttl
+++ b/models/real-estate-ontology/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/0e7bd522-511e-4f27-859f-3cfc1f900302/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/4b53123f-83f0-493a-951e-5c9d70ae6bda>;
-    dct:issued "2013"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:title "Turtle distribution of Real Estate Model"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/real-estate-ontology/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T18:11:35.170847316Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:11:35.170847316Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/0e7bd522-511e-4f27-859f-3cfc1f900302/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/4b53123f-83f0-493a-951e-5c9d70ae6bda> ;
+    dct:issued "2013"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Real Estate Model"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/real-estate-ontology/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T18:11:35.170847316Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/recommendation-ontology/metadata-turtle.ttl
+++ b/models/recommendation-ontology/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/050508f6-d536-4516-8529-029949230707/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/451e3138-fc99-40bf-81c7-430b3a321863>;
-    dct:issued "2013"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:title "Turtle distribution of Recommendation Ontology"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/recommendation-ontology/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T18:11:44.490448276Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:11:44.490448276Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/050508f6-d536-4516-8529-029949230707/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/451e3138-fc99-40bf-81c7-430b3a321863> ;
+    dct:issued "2013"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Recommendation Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/recommendation-ontology/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T18:11:44.490448276Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/repa2021public-administration/metadata-turtle.ttl
+++ b/models/repa2021public-administration/metadata-turtle.ttl
@@ -1,19 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/44c92bf9-fa31-4f0d-ab28-a476b9c45e2a/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/54af0ca8-e341-4457-b0dc-2594425a6489>;
-    dct:issued "2015"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:title "Turtle distribution of Public Administration Ontology Model"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/repa2021public-administration/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T18:11:53.959505498Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:11:53.959505498Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/44c92bf9-fa31-4f0d-ab28-a476b9c45e2a/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/54af0ca8-e341-4457-b0dc-2594425a6489> ;
+    dct:issued "2015"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Public Administration Ontology Model"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/repa2021public-administration/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T18:11:53.959505498Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/richetti2019tdecision/metadata-turtle.ttl
+++ b/models/richetti2019tdecision/metadata-turtle.ttl
@@ -1,19 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/c1a8a442-85b5-4375-80c9-77e6cbf8ff18/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/a0ce75d5-54d0-4949-b9d0-444bad20573c>;
-    dct:issued "2019"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:title "Turtle distribution of Decision Making in knowledge intensive process in Value Ascription and Goal processing"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/richetti2019tdecision/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T18:12:06.865654861Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:12:06.865654861Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/c1a8a442-85b5-4375-80c9-77e6cbf8ff18/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/a0ce75d5-54d0-4949-b9d0-444bad20573c> ;
+    dct:issued "2019"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Decision Making in knowledge intensive process in Value Ascription and Goal processing"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/richetti2019tdecision/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T18:12:06.865654861Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/road-accident2013/metadata-turtle.ttl
+++ b/models/road-accident2013/metadata-turtle.ttl
@@ -1,0 +1,17 @@
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://w3id.org/ontouml-models/distribution/0f6fbdf9-c4f7-5cd5-a86d-1265a99bfd44/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/road-accident2013> ;
+    dct:issued "2013"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Road Traffic Accident Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/road-accident2013/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/rocha2023ciencia-aberta/metadata-turtle.ttl
+++ b/models/rocha2023ciencia-aberta/metadata-turtle.ttl
@@ -1,0 +1,17 @@
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://w3id.org/ontouml-models/distribution/948e227d-0b01-547d-a885-51e7428a74dd/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/rocha2023ciencia-aberta> ;
+    dct:issued "2023"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Ciência Aberta"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/rocha2023ciencia-aberta/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/rodrigues2017urinary-profiles/metadata-turtle.ttl
+++ b/models/rodrigues2017urinary-profiles/metadata-turtle.ttl
@@ -1,19 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/62fd42c9-77be-4991-809f-e91e6864bf22/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/ab12ac77-6476-4b22-9c2b-bb70a9c6f26d>;
-    dct:issued "2015"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:title "Turtle distribution of Ontological Model for Urinary Profiles and Events"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/rodrigues2017urinary-profiles/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T18:12:35.109135636Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:12:35.109135636Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/62fd42c9-77be-4991-809f-e91e6864bf22/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/ab12ac77-6476-4b22-9c2b-bb70a9c6f26d> ;
+    dct:issued "2015"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Ontological Model for Urinary Profiles and Events"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/rodrigues2017urinary-profiles/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T18:12:35.109135636Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/rodrigues2019ontocrime/metadata-turtle.ttl
+++ b/models/rodrigues2019ontocrime/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/a2d7d59b-2369-4690-8fa4-267bb7993f49/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/f0f7917c-32c0-411d-a4b0-cd2159fd1cf2>;
-    dct:issued "2019"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:title "Turtle distribution of Brazilian Criminal Law Ontology"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/rodrigues2019ontocrime/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T18:13:03.999154642Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:13:03.999154642Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/a2d7d59b-2369-4690-8fa4-267bb7993f49/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/f0f7917c-32c0-411d-a4b0-cd2159fd1cf2> ;
+    dct:issued "2019"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Brazilian Criminal Law Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/rodrigues2019ontocrime/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T18:13:03.999154642Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/rodrigues2019turbidite/metadata-turtle.ttl
+++ b/models/rodrigues2019turbidite/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/950acc83-d5c8-4999-a7ba-53a61de08f71/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/e3b58861-ccf1-4dc5-971d-cba03a3aaf88>;
-    dct:issued "2019"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:title "Turtle distribution of Turbidity Channel Migration Ontology"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/rodrigues2019turbidite/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T18:13:25.953397485Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:13:25.953397485Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/950acc83-d5c8-4999-a7ba-53a61de08f71/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/e3b58861-ccf1-4dc5-971d-cba03a3aaf88> ;
+    dct:issued "2019"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Turbidity Channel Migration Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/rodrigues2019turbidite/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T18:13:25.953397485Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/romanenko2023what/metadata-turtle.ttl
+++ b/models/romanenko2023what/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/2f5d69a4-8724-401b-8d2e-e5181da2de22/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/f7a6d395-077a-4a83-b554-f169733c2329>;
-    dct:issued "2022"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://www.gnu.org/licenses/gpl-3.0.en.html>;
-    dct:title "Turtle distribution of Library management system"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/romanenko2023what/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T18:13:33.583510375Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:13:33.583510375Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/2f5d69a4-8724-401b-8d2e-e5181da2de22/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/f7a6d395-077a-4a83-b554-f169733c2329> ;
+    dct:issued "2022"^^xsd:gYear ;
+    dct:license <https://www.gnu.org/licenses/gpl-3.0.en.html> ;
+    dct:title "Turtle distribution of Library management system"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/romanenko2023what/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T18:13:33.583510375Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/saleme2019mulseonto/metadata-turtle.ttl
+++ b/models/saleme2019mulseonto/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/7bcdf4b0-bede-4a19-85f0-0a7bea011aa7/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/702dccd6-11ad-4a8a-889f-2c65bff7b64e>;
-    dct:issued "2018"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:title "Turtle distribution of MulseOnto"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/saleme2019mulseonto/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T18:13:52.813455486Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:13:52.813455486Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/7bcdf4b0-bede-4a19-85f0-0a7bea011aa7/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/702dccd6-11ad-4a8a-889f-2c65bff7b64e> ;
+    dct:issued "2018"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of MulseOnto"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/saleme2019mulseonto/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T18:13:52.813455486Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/sales2018competition/metadata-turtle.ttl
+++ b/models/sales2018competition/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/ce97de16-6275-4aba-9389-c7f91c830dba/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/664d2c61-a600-4730-848d-83e46f7dec6e>;
-    dct:issued "2018"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:title "Turtle distribution of Ontology of Competition"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/sales2018competition/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T18:14:03.670406699Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:14:03.670406699Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/ce97de16-6275-4aba-9389-c7f91c830dba/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/664d2c61-a600-4730-848d-83e46f7dec6e> ;
+    dct:issued "2018"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Ontology of Competition"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/sales2018competition/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T18:14:03.670406699Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/sales2018cover/metadata-turtle.ttl
+++ b/models/sales2018cover/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/f84cb3d6-0a40-4ca4-9a97-b2add219c016/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/ef85708e-02ce-40b4-8fdb-57799201ee28>;
-    dct:issued "2018"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:title "Turtle distribution of Common Ontology of Value and Risk"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/sales2018cover/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T18:14:38.642887287Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:14:38.642887287Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/f84cb3d6-0a40-4ca4-9a97-b2add219c016/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/ef85708e-02ce-40b4-8fdb-57799201ee28> ;
+    dct:issued "2018"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Common Ontology of Value and Risk"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/sales2018cover/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T18:14:38.642887287Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/santos2020valuenetworks/metadata-turtle.ttl
+++ b/models/santos2020valuenetworks/metadata-turtle.ttl
@@ -1,19 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/6eb5fef7-837f-49ef-8c8f-8d7a7ccc174f/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/87dea242-75d9-4b89-99f3-6f52c0855f3a>;
-    dct:issued "2020"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:title "Turtle distribution of Ontology for Value Networks with Corporate Responsibility"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/santos2020valuenetworks/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T18:14:47.948717151Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:14:47.948717151Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/6eb5fef7-837f-49ef-8c8f-8d7a7ccc174f/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/87dea242-75d9-4b89-99f3-6f52c0855f3a> ;
+    dct:issued "2020"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Ontology for Value Networks with Corporate Responsibility"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/santos2020valuenetworks/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T18:14:47.948717151Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/sariev2024maritime/metadata-turtle.ttl
+++ b/models/sariev2024maritime/metadata-turtle.ttl
@@ -1,0 +1,17 @@
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://w3id.org/ontouml-models/distribution/5a86b8a7-bc04-5b02-b8bf-810326f4a82b/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/sariev2024maritime> ;
+    dct:issued "2024"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Ontology for Digital Twin Development in Maritime Logistics"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/sariev2024maritime/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/schoonderbeek2024eamon/metadata-turtle.ttl
+++ b/models/schoonderbeek2024eamon/metadata-turtle.ttl
@@ -1,0 +1,17 @@
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://w3id.org/ontouml-models/distribution/0645e244-fb00-5576-bcd0-e19159f13d66/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/schoonderbeek2024eamon> ;
+    dct:issued "2024"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Enterprise Architecture Modeling Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/schoonderbeek2024eamon/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/scientific-experiment2013/metadata-turtle.ttl
+++ b/models/scientific-experiment2013/metadata-turtle.ttl
@@ -1,0 +1,17 @@
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://w3id.org/ontouml-models/distribution/8bde29fa-6257-5fef-ad38-a519c07945d2/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/scientific-experiment2013> ;
+    dct:issued "2013"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Scientific Experiment Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/scientific-experiment2013/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/scientific-publication2013/metadata-turtle.ttl
+++ b/models/scientific-publication2013/metadata-turtle.ttl
@@ -1,0 +1,17 @@
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://w3id.org/ontouml-models/distribution/4cef6969-e520-5505-85da-b38641c0c6d1/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/scientific-publication2013> ;
+    dct:issued "2013"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Scientific Publication Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/scientific-publication2013/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/services2015/metadata-turtle.ttl
+++ b/models/services2015/metadata-turtle.ttl
@@ -1,0 +1,17 @@
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://w3id.org/ontouml-models/distribution/c0d5e8fc-64e0-575f-8679-e668aa38f327/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/services2015> ;
+    dct:issued "2015"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Services Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/services2015/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/short-examples2013/metadata-turtle.ttl
+++ b/models/short-examples2013/metadata-turtle.ttl
@@ -1,0 +1,17 @@
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://w3id.org/ontouml-models/distribution/e338b615-e867-5fe1-92df-9b02f0108bab/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/short-examples2013> ;
+    dct:issued "2013"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Short Examples of OntoUML Ontologies"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/short-examples2013/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/sikora2021online-education/metadata-turtle.ttl
+++ b/models/sikora2021online-education/metadata-turtle.ttl
@@ -1,19 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/b03c171f-b771-4ea0-9fa0-91024d89168e/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/c3b6f81b-7d10-4e11-bdf2-4e291d0f8f70>;
-    dct:issued "2021"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:title "Turtle distribution of Online Education Ontology"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/sikora2021online-education/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T18:15:32.375722128Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:15:32.375722128Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/b03c171f-b771-4ea0-9fa0-91024d89168e/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/c3b6f81b-7d10-4e11-bdf2-4e291d0f8f70> ;
+    dct:issued "2021"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Online Education Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/sikora2021online-education/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T18:15:32.375722128Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/silva2012itarchitecture/metadata-turtle.ttl
+++ b/models/silva2012itarchitecture/metadata-turtle.ttl
@@ -1,19 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/e8d04b21-786c-425e-9efc-48ef7846493d/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/65c6c4c6-a903-48dd-bd28-dcb4f0b8fe6d>;
-    dct:issued "2012"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:title "Turtle distribution of IT Architecture Ontology (PAS 77:2006 Ontology)"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/silva2012itarchitecture/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T18:15:50.492598337Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:15:50.492598337Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/e8d04b21-786c-425e-9efc-48ef7846493d/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/65c6c4c6-a903-48dd-bd28-dcb4f0b8fe6d> ;
+    dct:issued "2012"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of IT Architecture Ontology (PAS 77:2006 Ontology)"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/silva2012itarchitecture/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T18:15:50.492598337Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/silva2021sebim/metadata-turtle.ttl
+++ b/models/silva2021sebim/metadata-turtle.ttl
@@ -1,0 +1,17 @@
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://w3id.org/ontouml-models/distribution/06a5670c-5524-51bd-8379-4cdbe04d3a22/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/silva2021sebim> ;
+    dct:issued "2021"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Semantic BIM"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/silva2021sebim/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/silva2023onto4caal/metadata-turtle.ttl
+++ b/models/silva2023onto4caal/metadata-turtle.ttl
@@ -1,0 +1,17 @@
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://w3id.org/ontouml-models/distribution/0663f28a-fecb-5606-bc60-b7573ff081d6/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/silva2023onto4caal> ;
+    dct:issued "2023"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by-nc-nd/3.0/br/> ;
+    dct:title "Turtle distribution of Requirements Ontology for AAL Systems"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/silva2023onto4caal/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/silva2023onto4elev/metadata-turtle.ttl
+++ b/models/silva2023onto4elev/metadata-turtle.ttl
@@ -1,0 +1,17 @@
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://w3id.org/ontouml-models/distribution/beb0f37f-e7e5-53b2-bb49-217c9c83f7c5/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/silva2023onto4elev> ;
+    dct:issued "2023"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by-nc-nd/3.0/br/> ;
+    dct:title "Turtle distribution of Requirements Ontology for Vertical Lifting Platform"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/silva2023onto4elev/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/silveira2021oap/metadata-turtle.ttl
+++ b/models/silveira2021oap/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/aaef387b-f3b4-42a6-9242-7b77d2282e9c/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/3585c8fe-d974-4ef3-801f-597cc683a1d2>;
-    dct:issued "2021"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:title "Turtle distribution of Ontologia de Referência para Arquiteturas Pedagógicas"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/silveira2021oap/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T18:16:02.928309089Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:16:02.928309089Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/aaef387b-f3b4-42a6-9242-7b77d2282e9c/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/3585c8fe-d974-4ef3-801f-597cc683a1d2> ;
+    dct:issued "2021"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Ontologia de Referência para Arquiteturas Pedagógicas"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/silveira2021oap/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T18:16:02.928309089Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/soares2024fair/metadata-turtle.ttl
+++ b/models/soares2024fair/metadata-turtle.ttl
@@ -1,0 +1,17 @@
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://w3id.org/ontouml-models/distribution/908ad819-1a81-5911-9e41-1df4153e1efa/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/soares2024fair> ;
+    dct:issued "2024"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Conceptual Model of a FAIR Metadata Schema"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/soares2024fair/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/social-contract/metadata-turtle.ttl
+++ b/models/social-contract/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/5e09f3d1-bec6-435a-9bdf-f1f183210914/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/3a5e93f8-8a29-47cb-be7d-9c5609d754a8>;
-    dct:issued "2013"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:title "Turtle distribution of Social Contract Model"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/social-contract/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T18:16:12.411910126Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:16:12.411910126Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/5e09f3d1-bec6-435a-9bdf-f1f183210914/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/3a5e93f8-8a29-47cb-be7d-9c5609d754a8> ;
+    dct:issued "2013"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Social Contract Model"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/social-contract/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T18:16:12.411910126Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/social-contracts2013/metadata-turtle.ttl
+++ b/models/social-contracts2013/metadata-turtle.ttl
@@ -1,0 +1,17 @@
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://w3id.org/ontouml-models/distribution/fdf2fd4d-0434-52d6-899a-6aa82cd56cfa/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/social-contracts2013> ;
+    dct:issued "2013"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of State and Social Contracts Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/social-contracts2013/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/sousa2022triponto/metadata-turtle.ttl
+++ b/models/sousa2022triponto/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/ca5096a4-78f7-419a-95e2-1d5b95a09560/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/5cf371b9-49ce-4d94-8718-80c8743ec335>;
-    dct:issued "2022"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:title "Turtle distribution of TripOnto"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/sousa2022triponto/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T18:16:23.713768886Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:16:23.713768886Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/ca5096a4-78f7-419a-95e2-1d5b95a09560/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/5cf371b9-49ce-4d94-8718-80c8743ec335> ;
+    dct:issued "2022"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of TripOnto"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/sousa2022triponto/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T18:16:23.713768886Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/spmo2017/metadata-turtle.ttl
+++ b/models/spmo2017/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/ecb32d95-6ad5-4ef6-b637-7e9aae17b744/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/aff42152-f0e2-4e62-957f-c9b7b3f45df5>;
-    dct:issued "2015"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:title "Turtle distribution of Software Project Management Ontology"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/spmo2017/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T18:16:39.321622873Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:16:39.321622873Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/ecb32d95-6ad5-4ef6-b637-7e9aae17b744/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/aff42152-f0e2-4e62-957f-c9b7b3f45df5> ;
+    dct:issued "2015"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Software Project Management Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/spmo2017/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T18:16:39.321622873Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/spo2017/metadata-turtle.ttl
+++ b/models/spo2017/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/14ac31e2-249c-4f69-b0fe-d37fd5519097/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/5ea6c44d-0aa9-4ba2-bfc4-9ff926c92888>;
-    dct:issued "2008"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:title "Turtle distribution of Software Process Ontology"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/spo2017/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T18:17:33.722401929Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:17:33.722401929Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/14ac31e2-249c-4f69-b0fe-d37fd5519097/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/5ea6c44d-0aa9-4ba2-bfc4-9ff926c92888> ;
+    dct:issued "2008"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Software Process Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/spo2017/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T18:17:33.722401929Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/sportbooking2021/metadata-turtle.ttl
+++ b/models/sportbooking2021/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/a939b50b-047a-46fa-9967-fb20b97f2bae/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/1df923e9-f84b-4c79-8b54-19d5d67325f6>;
-    dct:issued "2021"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:title "Turtle distribution of Sport Booking Model"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/sportbooking2021/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T18:17:47.521085365Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:17:47.521085365Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/a939b50b-047a-46fa-9967-fb20b97f2bae/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/1df923e9-f84b-4c79-8b54-19d5d67325f6> ;
+    dct:issued "2021"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Sport Booking Model"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/sportbooking2021/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T18:17:47.521085365Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/srro-ontology/metadata-turtle.ttl
+++ b/models/srro-ontology/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/a7c0b077-0cc9-4c2b-bf7d-22dce821aa03/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/b80dd4c8-7cb9-4f0e-b8ac-ce17a0931a63>;
-    dct:issued "2013"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:title "Turtle distribution of SRRO Ontology"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/srro-ontology/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T18:17:56.475574933Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:17:56.475574933Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/a7c0b077-0cc9-4c2b-bf7d-22dce821aa03/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/b80dd4c8-7cb9-4f0e-b8ac-ce17a0931a63> ;
+    dct:issued "2013"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of SRRO Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/srro-ontology/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T18:17:56.475574933Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/stock-broker2021/metadata-turtle.ttl
+++ b/models/stock-broker2021/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/3e1780de-7507-4557-97be-4a11dd7406b3/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/8728fdd1-9c4e-46ef-a244-e20407ad16ec>;
-    dct:issued "2013"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0>;
-    dct:title "Turtle distribution of Stock Brokerage Model"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/stock-broker2021/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T18:18:05.646569662Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:18:05.646569662Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/3e1780de-7507-4557-97be-4a11dd7406b3/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/8728fdd1-9c4e-46ef-a244-e20407ad16ec> ;
+    dct:issued "2013"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0> ;
+    dct:title "Turtle distribution of Stock Brokerage Model"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/stock-broker2021/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T18:18:05.646569662Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/swo2016/metadata-turtle.ttl
+++ b/models/swo2016/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/7dc2bddc-69aa-4071-b078-560059dc6a92/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/1c5f6781-3bd6-4258-be2a-2442957a0d9c>;
-    dct:issued "2016"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:title "Turtle distribution of Software Ontology"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/swo2016/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T18:18:14.911092227Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:18:14.911092227Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/7dc2bddc-69aa-4071-b078-560059dc6a92/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/1c5f6781-3bd6-4258-be2a-2442957a0d9c> ;
+    dct:issued "2016"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Software Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/swo2016/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T18:18:14.911092227Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/telecom-equipment2013/metadata-turtle.ttl
+++ b/models/telecom-equipment2013/metadata-turtle.ttl
@@ -1,0 +1,17 @@
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://w3id.org/ontouml-models/distribution/356bea0c-ff08-5fc6-87d4-4ae2b00e3eef/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/telecom-equipment2013> ;
+    dct:issued "2013"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Telecommunications Equipment"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/telecom-equipment2013/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/tender2013/metadata-turtle.ttl
+++ b/models/tender2013/metadata-turtle.ttl
@@ -1,0 +1,17 @@
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://w3id.org/ontouml-models/distribution/5f3f16b1-9468-56d0-8fb2-0a318fb416c8/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/tender2013> ;
+    dct:issued "2013"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Tender Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/tender2013/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/tesolin2023hint/metadata-turtle.ttl
+++ b/models/tesolin2023hint/metadata-turtle.ttl
@@ -1,0 +1,17 @@
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://w3id.org/ontouml-models/distribution/1ff8a9bc-376c-5079-9b33-802d82cb8ddc/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/tesolin2023hint> ;
+    dct:issued "2023"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Heterogeneous wIreless Network onTology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/tesolin2023hint/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/tourbo2021/metadata-turtle.ttl
+++ b/models/tourbo2021/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/e7e3a7a1-9277-4f49-b381-eeefcbbca142/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/3c99f544-a5b2-4bd2-bcde-7c689d077c62>;
-    dct:issued "2021"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:title "Turtle distribution of Tour Guide Booking Ontology"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/tourbo2021/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T18:18:26.085919915Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:18:26.085919915Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/e7e3a7a1-9277-4f49-b381-eeefcbbca142/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/3c99f544-a5b2-4bd2-bcde-7c689d077c62> ;
+    dct:issued "2021"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Tour Guide Booking Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/tourbo2021/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T18:18:26.085919915Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/unimatch-ontology2022/metadata-turtle.ttl
+++ b/models/unimatch-ontology2022/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/da98e8d8-3aaf-4096-8529-c6e665746e36/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/51036663-ba06-4fd0-9244-f984146a335a>;
-    dct:issued "2023"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:title "Turtle distribution of Predictive System for University Admissions \"UniMatch\""@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/unimatch-ontology2022/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T18:18:34.001196144Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:18:34.001196144Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/da98e8d8-3aaf-4096-8529-c6e665746e36/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/51036663-ba06-4fd0-9244-f984146a335a> ;
+    dct:issued "2023"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Predictive System for University Admissions \"UniMatch\""@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/unimatch-ontology2022/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T18:18:34.001196144Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/university-ontology/metadata-turtle.ttl
+++ b/models/university-ontology/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/52ae3c15-0f1f-40ea-a11f-52d0cca0b5f2/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/8ef525ba-e4e6-48a7-9512-b1338ba45769>;
-    dct:issued "2013"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:title "Turtle distribution of University Ontology"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/university-ontology/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T18:18:46.14760575Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:18:46.14760575Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/52ae3c15-0f1f-40ea-a11f-52d0cca0b5f2/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/8ef525ba-e4e6-48a7-9512-b1338ba45769> ;
+    dct:issued "2013"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of University Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/university-ontology/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T18:18:46.14760575Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/valaski2020medical-appointment/metadata-turtle.ttl
+++ b/models/valaski2020medical-appointment/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/5c7fa526-9462-4786-9594-a7106676f1c3/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/03f684a6-3a6c-4cc0-8ca6-6375f74d5081>;
-    dct:issued "2020"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:title "Turtle distribution of Medical Appointment Ontology"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/valaski2020medical-appointment/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T18:18:55.705289845Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:18:55.705289845Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/5c7fa526-9462-4786-9594-a7106676f1c3/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/03f684a6-3a6c-4cc0-8ca6-6375f74d5081> ;
+    dct:issued "2020"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Medical Appointment Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/valaski2020medical-appointment/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T18:18:55.705289845Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/van-ee2021modular/metadata-turtle.ttl
+++ b/models/van-ee2021modular/metadata-turtle.ttl
@@ -1,19 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/9b158615-87dd-4118-8eb0-2481a53029f7/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/c6ec6f27-cffa-4a38-9927-8e6b921e996a>;
-    dct:issued "2021"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:title "Turtle distribution of Modular Construction Ontology"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/van-ee2021modular/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T18:19:16.0170111Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:19:16.0170111Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/9b158615-87dd-4118-8eb0-2481a53029f7/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/c6ec6f27-cffa-4a38-9927-8e6b921e996a> ;
+    dct:issued "2021"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Modular Construction Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/van-ee2021modular/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T18:19:16.0170111Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/van-wingerde2020smart-contracts/metadata-turtle.ttl
+++ b/models/van-wingerde2020smart-contracts/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/90c360da-de86-4166-8a01-047492d199b9/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/e9489d3d-035b-41c9-b13f-e5bc7aee0ed2>;
-    dct:issued "2020"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:title "Turtle distribution of An ontological analysis of artifact-centric business processes managed by smart contracts"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/van-wingerde2020smart-contracts/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T18:19:31.464584239Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:19:31.464584239Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/90c360da-de86-4166-8a01-047492d199b9/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/e9489d3d-035b-41c9-b13f-e5bc7aee0ed2> ;
+    dct:issued "2020"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of An ontological analysis of artifact-centric business processes managed by smart contracts"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/van-wingerde2020smart-contracts/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T18:19:31.464584239Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/vieira2020weathering/metadata-turtle.ttl
+++ b/models/vieira2020weathering/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/cea35d08-2468-4228-a8b2-16c54ceb8846/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/06130cd9-ba26-4324-9f1e-88bd03b88ca9>;
-    dct:issued "2020"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:title "Turtle distribution of Weathering Ontology"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/vieira2020weathering/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T18:20:00.238993393Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:20:00.238993393Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/cea35d08-2468-4228-a8b2-16c54ceb8846/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/06130cd9-ba26-4324-9f1e-88bd03b88ca9> ;
+    dct:issued "2020"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Weathering Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/vieira2020weathering/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T18:20:00.238993393Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/weigand2021artifact/metadata-turtle.ttl
+++ b/models/weigand2021artifact/metadata-turtle.ttl
@@ -1,20 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/e636ee11-36bf-4716-aaf3-9333ba8d0a6d/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/9746dec7-6303-4b95-88bc-712c95def0b8>;
-    dct:issued "2020"^^xsd:gYear;
-    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
-    dct:title "Turtle distribution of Design Science Artifact Ontology"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/weigand2021artifact/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T18:20:22.079942972Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:20:22.079942972Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/e636ee11-36bf-4716-aaf3-9333ba8d0a6d/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/9746dec7-6303-4b95-88bc-712c95def0b8> ;
+    dct:issued "2020"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Design Science Artifact Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/weigand2021artifact/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T18:20:22.079942972Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/xhani2023xmlpo/metadata-turtle.ttl
+++ b/models/xhani2023xmlpo/metadata-turtle.ttl
@@ -1,0 +1,17 @@
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<https://w3id.org/ontouml-models/distribution/ff09e49c-acd2-51d1-ac4d-09f9eb26a7db/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/xhani2023xmlpo> ;
+    dct:issued "2023"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Explainable Machine Learning Pipeline Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/xhani2023xmlpo/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/zanetti2019orm-o/metadata-turtle.ttl
+++ b/models/zanetti2019orm-o/metadata-turtle.ttl
@@ -1,19 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/00adef72-c45f-420e-aabb-9183fb5f25ae/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/c528d763-ff22-4d52-9e03-e881b41805ce>;
-    dct:issued "2019"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:title "Turtle distribution of Object/Relational Mapping Ontology"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/zanetti2019orm-o/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T18:20:37.653132847Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:20:37.653132847Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/00adef72-c45f-420e-aabb-9183fb5f25ae/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/c528d763-ff22-4d52-9e03-e881b41805ce> ;
+    dct:issued "2019"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Object/Relational Mapping Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/zanetti2019orm-o/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T18:20:37.653132847Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/zhou2017hazard-ontology-robotic-strolling/metadata-turtle.ttl
+++ b/models/zhou2017hazard-ontology-robotic-strolling/metadata-turtle.ttl
@@ -1,19 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/b709fd18-79b6-429b-a323-465254b9f34d/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/c7dbcd4e-e12a-4f9f-a20c-e08137c36db5>;
-    dct:issued "2017"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:title "Turtle distribution of Robotic Strolling System"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/zhou2017hazard-ontology-robotic-strolling/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T18:20:47.951837871Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:20:47.951837871Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/b709fd18-79b6-429b-a323-465254b9f34d/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/c7dbcd4e-e12a-4f9f-a20c-e08137c36db5> ;
+    dct:issued "2017"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Robotic Strolling System"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/zhou2017hazard-ontology-robotic-strolling/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T18:20:47.951837871Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/zhou2017hazard-ontology-train-control/metadata-turtle.ttl
+++ b/models/zhou2017hazard-ontology-train-control/metadata-turtle.ttl
@@ -1,19 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/e31b4d0f-4abb-47fd-b4e9-600d5811b821/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/0ea32c8f-85e8-4749-97b9-24b59ae41dbd>;
-    dct:issued "2017"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:title "Turtle distribution of Train Control System"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/zhou2017hazard-ontology-train-control/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T18:21:00.761872034Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:21:00.761872034Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/e31b4d0f-4abb-47fd-b4e9-600d5811b821/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/0ea32c8f-85e8-4749-97b9-24b59ae41dbd> ;
+    dct:issued "2017"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Train Control System"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/zhou2017hazard-ontology-train-control/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T18:21:00.761872034Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+

--- a/models/zhou2017hazard/metadata-turtle.ttl
+++ b/models/zhou2017hazard/metadata-turtle.ttl
@@ -1,19 +1,17 @@
-@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
-@prefix dcat: <http://www.w3.org/ns/dcat#>.
-@prefix dct: <http://purl.org/dc/terms/>.
-@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://w3id.org/ontouml-models/distribution/93bbe0fc-3e47-4037-b4bf-1fb5b88664b1/> a dcat:Distribution;
-    dct:isPartOf <https://w3id.org/ontouml-models/model/e28bed62-0a6b-49a4-a3a9-01c8e4f527e3>;
-    dct:issued "2017"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle>;
-    dct:title "Turtle distribution of Hazard Ontology"@en;
-    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/zhou2017hazard/ontology.ttl>;
-    ocmv:isComplete "true"^^xsd:boolean;
-    fdpo:metadataIssued "2023-04-14T18:21:10.272090048Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:21:10.272090048Z"^^xsd:dateTime .
+<https://w3id.org/ontouml-models/distribution/93bbe0fc-3e47-4037-b4bf-1fb5b88664b1/> a dcat:Distribution ;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/e28bed62-0a6b-49a4-a3a9-01c8e4f527e3> ;
+    dct:issued "2017"^^xsd:gYear ;
+    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
+    dct:title "Turtle distribution of Hazard Ontology"@en ;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/zhou2017hazard/ontology.ttl> ;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+    fdpo:metadataIssued "2023-04-14T18:21:10.272090048Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    ocmv:isComplete true .
+


### PR DESCRIPTION
## Summary

This PR regenerates Turtle distribution metadata files across the catalog using the new YAML-first Turtle metadata generator.

The affected files are expected to be `metadata-turtle.ttl` files under `models/`.

No generator code, documentation, tests, GitHub Actions workflow, or CI configuration is changed in this PR.

## Motivation

The Turtle distribution metadata files need to be aligned with the updated metadata-generation strategy, where distribution-level metadata can be generated before the final model-level `metadata.ttl` aggregation step.

This regeneration applies the Turtle metadata generator consistently across all model folders using a deterministic metadata timestamp.

## Generation command

The metadata was regenerated with a fixed timestamp to make the run reproducible:

```bash
python scripts/generate_turtle_metadata.py --all --models-dir models --allow-missing-license --metadata-timestamp 2026-06-24T12:00:00Z
```

The `--allow-missing-license` option was used because some legacy catalog datasets still lack model-level license metadata. When available, license metadata is still emitted or preserved.

## Expected scope

This PR should only modify generated Turtle distribution metadata files:

```text
models/**/metadata-turtle.ttl
```

It should not modify:

- `metadata.yaml`;
- model-level `metadata.ttl`;
- `ontology.ttl`;
- source model files;
- scripts;
- tests;
- documentation;
- GitHub Actions workflows;
- CI configuration.

## Metadata behavior

The regeneration follows the behavior of the new Turtle metadata generator:

- uses `metadata.yaml` as the editable model-level source;
- does not depend on model-level `metadata.ttl`;
- preserves existing Turtle distribution IRIs where available;
- preserves existing `dct:isPartOf` model IRIs where available;
- uses deterministic identifiers for genuinely new distribution metadata;
- emits `dcat:mediaType` as `text/turtle`;
- emits `ocmv:isComplete true` for Turtle model distributions;
- preserves or updates FDP metadata timestamps according to the deterministic timestamp strategy.

## Verification

The generator was previously validated through its dedicated test suite.

For this regeneration, the intended checks are:

```bash
python -m pytest scripts/tests/test_generate_turtle_metadata.py
python -m py_compile scripts/generate_turtle_metadata.py scripts/tests/test_generate_turtle_metadata.py
python scripts/generate_turtle_metadata.py --help
```

The generated-file scope can be checked with:

```bash
git diff --name-only | grep -v '^models/.*/metadata-turtle.ttl$'
```

On Windows CMD, the equivalent check is:

```cmd
git diff --name-only | findstr /V /R "^models/.*/metadata-turtle.ttl$"
```

This command should return no files if the PR is limited to Turtle distribution metadata regeneration.

## Review focus

Reviewers should mainly check that:

- only `metadata-turtle.ttl` files under `models/` changed;
- no source model files or model-level metadata files were modified;
- existing catalog identifiers were preserved where expected;
- the generated Turtle distribution metadata follows the established catalog pattern.

## Notes

This PR is a generated metadata update. It is separated from the generator implementation PR to keep the tooling change and the generated metadata regeneration reviewable independently.