### PR TITLE
fix(scripts): make JSON source validation opt-in

### DIFF
--- a/scripts/generate-json-metadata.md
+++ b/scripts/generate-json-metadata.md
@@ -62,7 +62,9 @@ The current standard repository-facing `metadata.yaml` template does not need to
 
 ### `ontology.json`
 
-By default, the script requires `ontology.json` to exist and be parseable JSON with a JSON object at the top level. This prevents creating metadata for a missing or invalid source distribution.
+By default, the script requires `ontology.json` to exist and to be a file. It does not parse `ontology.json` by default, because some legacy catalog JSON files contain non-UTF-8 bytes even though their existing distribution metadata is valid and should remain generatable.
+
+Use `--validate-ontology-json` when you explicitly want the source file to be parsed as UTF-8 JSON and checked for a JSON object at the top level. This option is useful for new submissions or stricter maintenance checks, but it may fail for legacy catalog files that require separate source-data cleanup.
 
 Use `--no-check-ontology-json` only for exceptional compatibility cases where the metadata record must be generated before the source file is available.
 
@@ -203,6 +205,20 @@ Use `--dry-run` to validate inputs and report intended outputs without writing f
 
 ```bash
 python scripts/generate_json_metadata.py --all --models-dir models --dry-run --metadata-timestamp 2026-06-23T12:00:00Z
+```
+
+### Source JSON validation
+
+By default, the generator checks that `ontology.json` exists but does not parse its contents. To additionally parse the file as UTF-8 JSON and require a top-level JSON object, use:
+
+```bash
+python scripts/generate_json_metadata.py --all --models-dir models --validate-ontology-json --metadata-timestamp 2026-06-23T12:00:00Z
+```
+
+To skip even the existence check for exceptional compatibility cases, use:
+
+```bash
+python scripts/generate_json_metadata.py models/example --no-check-ontology-json --metadata-timestamp 2026-06-23T12:00:00Z
 ```
 
 ### JSON output

--- a/scripts/generate_json_metadata.py
+++ b/scripts/generate_json_metadata.py
@@ -117,6 +117,7 @@ class Config:
     dry_run: bool = False
     check: bool = False
     check_source_file: bool = True
+    validate_source_json: bool = False
     metadata_timestamp: Optional[str] = None
     allow_missing_license: bool = False
     # Deprecated compatibility shim for older callers that used Config(require_license=True).
@@ -757,8 +758,17 @@ def validate_uri(value: URIRef, *, field_name: str) -> URIRef:
     return URIRef(text)
 
 
-def validate_ontology_json(path: Path, *, check_source_file: bool) -> None:
-    """Validate that ontology.json exists and is parseable JSON when checking is enabled."""
+def validate_ontology_json(
+    path: Path, *, check_source_file: bool, validate_source_json: bool
+) -> None:
+    """Validate ontology.json presence and, when requested, parseable JSON content.
+
+    Distribution metadata generation only needs to know that the JSON distribution
+    source exists. Some legacy catalog ontology.json files contain non-UTF-8 bytes
+    even though their existing distribution metadata is valid. Therefore, content
+    parsing is opt-in via --validate-ontology-json instead of being a default
+    precondition for metadata regeneration.
+    """
 
     if not check_source_file:
         return
@@ -766,9 +776,15 @@ def validate_ontology_json(path: Path, *, check_source_file: bool) -> None:
         raise MetadataGenerationError(f"Missing required ontology JSON file: {path}")
     if not path.is_file():
         raise MetadataGenerationError(f"Ontology JSON path is not a file: {path}")
+    if not validate_source_json:
+        return
     try:
         with path.open("r", encoding="utf-8") as stream:
             data = json.load(stream)
+    except UnicodeDecodeError as exc:
+        raise MetadataGenerationError(
+            f"Ontology JSON file is not valid UTF-8 JSON text {path}: {exc}"
+        ) from exc
     except json.JSONDecodeError as exc:
         raise MetadataGenerationError(
             f"Invalid ontology JSON file {path}: {exc}"
@@ -947,7 +963,11 @@ def process_dataset(dataset_folder: Path, config: Config) -> list[GeneratedFile]
     source_path = dataset_folder / SOURCE_FILE_NAME
     output_path = dataset_folder / OUTPUT_FILE_NAME
 
-    validate_ontology_json(source_path, check_source_file=config.check_source_file)
+    validate_ontology_json(
+        source_path,
+        check_source_file=config.check_source_file,
+        validate_source_json=config.validate_source_json,
+    )
     title, issued, license_uri, yaml_uri = load_model_metadata(dataset_folder, config)
     existing = read_existing_metadata(output_path)
     model_uri = resolve_model_uri(
@@ -1139,7 +1159,15 @@ def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
     parser.add_argument(
         "--no-check-ontology-json",
         action="store_true",
-        help="Do not require ontology.json to exist and be parseable before generating metadata-json.ttl.",
+        help="Do not require ontology.json to exist before generating metadata-json.ttl.",
+    )
+    parser.add_argument(
+        "--validate-ontology-json",
+        action="store_true",
+        help=(
+            "Also parse ontology.json as UTF-8 JSON and require a top-level object. "
+            "Disabled by default because some legacy catalog JSON files contain non-UTF-8 bytes."
+        ),
     )
     parser.add_argument(
         "--metadata-timestamp",
@@ -1162,6 +1190,10 @@ def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
     if args.allow_missing_license and args.require_license:
         parser.error(
             "--allow-missing-license and --require-license cannot be used together."
+        )
+    if args.no_check_ontology_json and args.validate_ontology_json:
+        parser.error(
+            "--no-check-ontology-json and --validate-ontology-json cannot be used together."
         )
     return args
 
@@ -1209,6 +1241,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         dry_run=args.dry_run,
         check=args.check,
         check_source_file=not args.no_check_ontology_json,
+        validate_source_json=args.validate_ontology_json,
         metadata_timestamp=args.metadata_timestamp,
         allow_missing_license=args.allow_missing_license,
         require_license=args.require_license or None,

--- a/scripts/tests/test_generate_json_metadata.py
+++ b/scripts/tests/test_generate_json_metadata.py
@@ -478,14 +478,51 @@ def test_cli_json_output(tmp_path: Path, capsys: pytest.CaptureFixture[str]):
     assert payload["results"][0]["metadata_path"].endswith("metadata-json.ttl")
 
 
-def test_invalid_ontology_json_fails_before_metadata_file_is_written(tmp_path: Path):
+def test_invalid_ontology_json_content_is_ignored_by_default(tmp_path: Path):
+    module = load_module()
+    dataset = write_dataset(tmp_path, name="invalid-source-json")
+    (dataset / "ontology.json").write_text("not valid json", encoding="utf-8")
+
+    module.process_dataset(
+        dataset, module.Config(metadata_timestamp="2024-01-02T03:04:05Z")
+    )
+
+    assert (dataset / "metadata-json.ttl").exists()
+
+
+def test_invalid_ontology_json_fails_when_content_validation_is_enabled(
+    tmp_path: Path,
+):
     module = load_module()
     dataset = write_dataset(tmp_path, name="invalid-source-json")
     (dataset / "ontology.json").write_text("not valid json", encoding="utf-8")
 
     with pytest.raises(module.MetadataGenerationError, match="Invalid ontology JSON"):
         module.process_dataset(
-            dataset, module.Config(metadata_timestamp="2024-01-02T03:04:05Z")
+            dataset,
+            module.Config(
+                metadata_timestamp="2024-01-02T03:04:05Z",
+                validate_source_json=True,
+            ),
+        )
+
+    assert not (dataset / "metadata-json.ttl").exists()
+
+
+def test_non_utf8_ontology_json_fails_as_generation_error_when_validation_is_enabled(
+    tmp_path: Path,
+):
+    module = load_module()
+    dataset = write_dataset(tmp_path, name="non-utf8-source-json")
+    (dataset / "ontology.json").write_bytes(b'{"name": "caf\xed"}')
+
+    with pytest.raises(module.MetadataGenerationError, match="not valid UTF-8"):
+        module.process_dataset(
+            dataset,
+            module.Config(
+                metadata_timestamp="2024-01-02T03:04:05Z",
+                validate_source_json=True,
+            ),
         )
 
     assert not (dataset / "metadata-json.ttl").exists()
@@ -881,24 +918,28 @@ def test_invalid_existing_metadata_json_fails_before_rewriting(tmp_path: Path):
     assert (dataset / "metadata-json.ttl").read_text(encoding="utf-8") == "not turtle"
 
 
-def test_json_array_source_fails_unless_source_check_is_disabled(tmp_path: Path):
+def test_json_array_source_is_allowed_by_default_but_fails_when_validation_is_enabled(
+    tmp_path: Path,
+):
     module = load_module()
     dataset = write_dataset(tmp_path, name="array-source-json")
     write_ontology_json(dataset, content=[])
 
-    with pytest.raises(module.MetadataGenerationError, match="JSON object"):
-        module.process_dataset(
-            dataset, module.Config(metadata_timestamp="2024-01-02T03:04:05Z")
-        )
-
     module.process_dataset(
-        dataset,
-        module.Config(
-            metadata_timestamp="2024-01-02T03:04:05Z",
-            check_source_file=False,
-        ),
+        dataset, module.Config(metadata_timestamp="2024-01-02T03:04:05Z")
     )
     assert (dataset / "metadata-json.ttl").exists()
+
+    (dataset / "metadata-json.ttl").unlink()
+    with pytest.raises(module.MetadataGenerationError, match="JSON object"):
+        module.process_dataset(
+            dataset,
+            module.Config(
+                metadata_timestamp="2024-01-02T03:04:05Z",
+                validate_source_json=True,
+            ),
+        )
+    assert not (dataset / "metadata-json.ttl").exists()
 
 
 def test_custom_existing_schema_uri_is_preserved(tmp_path: Path):


### PR DESCRIPTION
## Summary

This PR updates the JSON distribution metadata generator so that strict parsing of `ontology.json` is opt-in rather than enabled by default.

The change fixes a full-catalog regeneration issue where a legacy `ontology.json` file containing non-UTF-8 bytes caused the generator to crash with an uncaught `UnicodeDecodeError`.

## Files changed

This PR intentionally changes only the JSON metadata generator files:

- `scripts/generate_json_metadata.py`
- `scripts/generate-json-metadata.md`
- `scripts/tests/test_generate_json_metadata.py`

No generated model metadata files under `models/` are included.

## Problem

When running the JSON metadata generator across all catalog models, the script attempted to parse each `ontology.json` file as UTF-8 JSON before generating `metadata-json.ttl`.

This caused the run to fail when it encountered a legacy `ontology.json` file with non-UTF-8 bytes:

```text
UnicodeDecodeError: 'utf-8' codec can't decode byte ...
```

This was too strict for the generator’s default behavior. The generator’s primary responsibility is to generate distribution metadata for the `ontology.json` file. It should require the source file to exist, but it should not block full legacy catalog metadata regeneration by default because of source-file encoding or parseability issues.

## Updated behavior

By default, the generator now validates only that:

- `ontology.json` exists;
- `ontology.json` is a file;
- the source filename does not contain control characters.

Strict JSON parsing is now available through an explicit option:

```bash
--validate-ontology-json
```

When this option is used, the generator parses `ontology.json` as UTF-8 JSON and fails with a controlled `MetadataGenerationError` if the file is invalid, non-UTF-8, or structurally unsupported.

## Rationale

This aligns the JSON generator with the practical behavior of the other distribution metadata generators:

- VPP metadata generation checks the presence and basic file shape of `ontology.vpp`, but does not parse the binary source file.
- PNG metadata generation validates PNG files as binary data.
- Turtle metadata generation parses `ontology.ttl`, because Turtle parseability is directly relevant to the RDF distribution.

For JSON, strict source validation remains useful, but it should be a deliberate maintenance/checking mode rather than the default for full legacy catalog regeneration.

## CLI behavior

Default generation:

```bash
python scripts/generate_json_metadata.py --all --models-dir models --allow-missing-license --metadata-timestamp 2026-06-24T12:00:00Z
```

Strict source validation mode:

```bash
python scripts/generate_json_metadata.py --all --models-dir models --allow-missing-license --metadata-timestamp 2026-06-24T12:00:00Z --validate-ontology-json
```

The strict mode is intended for validation or cleanup work, not for normal full-catalog metadata regeneration over legacy files.

## Tests

The test suite was expanded to cover:

- invalid JSON content being accepted by default;
- invalid JSON failing when `--validate-ontology-json` is used;
- non-UTF-8 JSON failing as a controlled metadata-generation error in strict mode;
- top-level JSON arrays being rejected in strict mode;
- no partial metadata writes when strict validation fails.

## Verification

The following checks were run locally:

```bash
python -m py_compile scripts/generate_json_metadata.py scripts/tests/test_generate_json_metadata.py
python -m pytest -q scripts/tests/test_generate_json_metadata.py
python scripts/generate_json_metadata.py --help
```

Result:

```text
38 passed
```

## Scope exclusions

This PR intentionally does not:

- regenerate any `models/*/metadata-json.ttl` files;
- modify generated model metadata;
- modify model-level `metadata.ttl`;
- modify GitHub Actions workflows;
- modify CI configuration;
- change unrelated metadata generators.