### PR TITLE
chore(metadata): regenerate JSON distribution metadata

### DIFF
--- a/models/abel2015petroleum-system/metadata-json.ttl
+++ b/models/abel2015petroleum-system/metadata-json.ttl
@@ -11,10 +11,11 @@
 <https://w3id.org/ontouml-models/distribution/ccddedaa-6508-41ee-a621-9d7f56c06419/> a dcat:Distribution;
     dct:isPartOf <https://w3id.org/ontouml-models/model/7ed5893a-ead6-4de1-b9c1-635e7af3de00>;
     dct:issued "2015"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of Petroleum System Model"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/abel2015petroleum-system/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T17:33:20.976070312Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:33:20.976070312Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/abrahao2018agriculture-operations/metadata-json.ttl
+++ b/models/abrahao2018agriculture-operations/metadata-json.ttl
@@ -11,10 +11,11 @@
 <https://w3id.org/ontouml-models/distribution/51727a95-2d6b-448c-ac1e-e7506bd5174b/> a dcat:Distribution;
     dct:isPartOf <https://w3id.org/ontouml-models/model/d07d44af-d127-4407-8d0f-72b9e17a6479>;
     dct:issued "2018"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of Agriculture Operations Task Ontology"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/abrahao2018agriculture-operations/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T17:33:32.949687929Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:33:32.949687929Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/ahmad2018aviation/metadata-json.ttl
+++ b/models/ahmad2018aviation/metadata-json.ttl
@@ -11,10 +11,11 @@
 <https://w3id.org/ontouml-models/distribution/f74b710c-d8a5-4f95-b9d1-5a2e07327bbd/> a dcat:Distribution;
     dct:isPartOf <https://w3id.org/ontouml-models/model/660ad6c4-dbc1-43e7-b582-d7eb9ec43739>;
     dct:issued "2018"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of Aviation Safety Ontology"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/ahmad2018aviation/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T17:34:12.962539041Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:34:12.962539041Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/aires2022valuenetworks-geo/metadata-json.ttl
+++ b/models/aires2022valuenetworks-geo/metadata-json.ttl
@@ -11,10 +11,11 @@
 <https://w3id.org/ontouml-models/distribution/b49051c3-8f8a-468b-9802-2131a4d9ada9/> a dcat:Distribution;
     dct:isPartOf <https://w3id.org/ontouml-models/model/3886f70e-5a91-411d-a50e-370eb4f93c5a>;
     dct:issued "2022"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of Ontology for Value Networks with Geographic Information"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/aires2022valuenetworks-geo/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T17:34:25.668396365Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:34:25.668396365Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/albuquerque2011ontobio/metadata-json.ttl
+++ b/models/albuquerque2011ontobio/metadata-json.ttl
@@ -11,10 +11,11 @@
 <https://w3id.org/ontouml-models/distribution/faf6213a-d88b-4399-a12b-e6ea29a4ad01/> a dcat:Distribution;
     dct:isPartOf <https://w3id.org/ontouml-models/model/f3d40402-e30d-4bbc-8792-5566bc8c30e9>;
     dct:issued "2011"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of OntoBio"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/albuquerque2011ontobio/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T17:34:38.539952272Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:34:38.539952272Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/alkhalaf2024/metadata-json.ttl
+++ b/models/alkhalaf2024/metadata-json.ttl
@@ -1,0 +1,21 @@
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#>.
+@prefix dct: <http://purl.org/dc/terms/>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
+@prefix owl: <http://www.w3.org/2002/07/owl#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+
+<https://w3id.org/ontouml-models/distribution/81fe8abf-171a-525b-a580-2d2f0b9a23e0/> a dcat:Distribution;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/alkhalaf2024>;
+    dct:issued "2023"^^xsd:gYear;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
+    dct:title "JSON distribution of Ontology to Explain SARS-CoV-2 Variants' Effects"@en;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/alkhalaf2024/ontology.json>;
+    ocmv:isComplete "true"^^xsd:boolean;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/andersson2018value-ascription/metadata-json.ttl
+++ b/models/andersson2018value-ascription/metadata-json.ttl
@@ -11,10 +11,11 @@
 <https://w3id.org/ontouml-models/distribution/9d8ead3b-b161-46e4-8a6a-83bf35d08c02/> a dcat:Distribution;
     dct:isPartOf <https://w3id.org/ontouml-models/model/3df10e52-a7e6-4e42-a5e5-c34495a5826b>;
     dct:issued "2018"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of Value Ascription Ontology"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/andersson2018value-ascription/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T17:36:33.551244162Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:36:33.551244162Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/bank-account2013/metadata-json.ttl
+++ b/models/bank-account2013/metadata-json.ttl
@@ -1,0 +1,21 @@
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#>.
+@prefix dct: <http://purl.org/dc/terms/>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
+@prefix owl: <http://www.w3.org/2002/07/owl#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+
+<https://w3id.org/ontouml-models/distribution/b8eb1f9b-88f7-5a3d-8f96-ffb5317ff7a0/> a dcat:Distribution;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/bank-account2013>;
+    dct:issued "2013"^^xsd:gYear;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
+    dct:title "JSON distribution of Bank Account Ontology"@en;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/bank-account2013/ontology.json>;
+    ocmv:isComplete "true"^^xsd:boolean;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/barcelos2024resiliont/metadata-json.ttl
+++ b/models/barcelos2024resiliont/metadata-json.ttl
@@ -1,0 +1,21 @@
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#>.
+@prefix dct: <http://purl.org/dc/terms/>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
+@prefix owl: <http://www.w3.org/2002/07/owl#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+
+<https://w3id.org/ontouml-models/distribution/dbb11aac-fd89-50cc-85c8-989ba874356d/> a dcat:Distribution;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/barcelos2024resiliont>;
+    dct:issued "2024"^^xsd:gYear;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://www.apache.org/licenses/LICENSE-2.0>;
+    ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
+    dct:title "JSON distribution of Resilience Core Ontology"@en;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/barcelos2024resiliont/ontology.json>;
+    ocmv:isComplete "true"^^xsd:boolean;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/blums2024ccf/metadata-json.ttl
+++ b/models/blums2024ccf/metadata-json.ttl
@@ -1,0 +1,21 @@
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#>.
+@prefix dct: <http://purl.org/dc/terms/>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
+@prefix owl: <http://www.w3.org/2002/07/owl#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+
+<https://w3id.org/ontouml-models/distribution/cb9a8ce9-b5e2-5ea6-836a-6293e01dd40e/> a dcat:Distribution;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/blums2024ccf>;
+    dct:issued "2024"^^xsd:gYear;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
+    dct:title "JSON distribution of Ontology of Converged Conceptual Frameworks for Financial Reporting"@en;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/blums2024ccf/ontology.json>;
+    ocmv:isComplete "true"^^xsd:boolean;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/blums2025cofris/metadata-json.ttl
+++ b/models/blums2025cofris/metadata-json.ttl
@@ -1,0 +1,21 @@
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#>.
+@prefix dct: <http://purl.org/dc/terms/>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
+@prefix owl: <http://www.w3.org/2002/07/owl#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+
+<https://w3id.org/ontouml-models/distribution/fdb093b3-4704-5ca4-bdfc-9ce386c74a8e/> a dcat:Distribution;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/blums2025cofris>;
+    dct:issued "2025"^^xsd:gYear;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
+    dct:title "JSON distribution of Core Ontology for Financial Reporting Information Systems 3.0"@en;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/blums2025cofris/ontology.json>;
+    ocmv:isComplete "true"^^xsd:boolean;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/buchtela2020connection/metadata-json.ttl
+++ b/models/buchtela2020connection/metadata-json.ttl
@@ -11,10 +11,11 @@
 <https://w3id.org/ontouml-models/distribution/f51e72a0-f624-48e3-abd2-af359eea0f23/> a dcat:Distribution;
     dct:isPartOf <https://w3id.org/ontouml-models/model/1b479664-a287-4503-9d2b-7d8cf8bed271>;
     dct:issued "2020"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of Knowledge Representation Model of Students' Activities"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/buchtela2020connection/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T17:43:25.766842967Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:43:25.766842967Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/calhau2024capabilities/metadata-json.ttl
+++ b/models/calhau2024capabilities/metadata-json.ttl
@@ -1,0 +1,21 @@
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#>.
+@prefix dct: <http://purl.org/dc/terms/>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
+@prefix owl: <http://www.w3.org/2002/07/owl#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+
+<https://w3id.org/ontouml-models/distribution/d7b8d2ad-ec1d-5354-a5ff-3100fab7eeaa/> a dcat:Distribution;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/calhau2024capabilities>;
+    dct:issued "2024"^^xsd:gYear;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
+    dct:title "JSON distribution of Capabilities Ontology"@en;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/calhau2024capabilities/ontology.json>;
+    ocmv:isComplete "true"^^xsd:boolean;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/carolla2014campus-management/metadata-json.ttl
+++ b/models/carolla2014campus-management/metadata-json.ttl
@@ -11,10 +11,11 @@
 <https://w3id.org/ontouml-models/distribution/82cd6931-d4d4-43a8-b06f-709890f7c8a1/> a dcat:Distribution;
     dct:isPartOf <https://w3id.org/ontouml-models/model/e58213c9-beec-47f7-ac55-b5530bad3930>;
     dct:issued "2014"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of Campus Management System Reference Data Model"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/carolla2014campus-management/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T17:43:49.975510717Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:43:49.975510717Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/castro2012cloudvulnerability/metadata-json.ttl
+++ b/models/castro2012cloudvulnerability/metadata-json.ttl
@@ -11,10 +11,11 @@
 <https://w3id.org/ontouml-models/distribution/e1cb841b-4437-490c-ac86-4454dd5d65a4/> a dcat:Distribution;
     dct:isPartOf <https://w3id.org/ontouml-models/model/9d3dc47b-2ca8-430e-8e57-c2c0a5ed8015>;
     dct:issued "2012"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of Cloud Vulnerability Ontology"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/castro2012cloudvulnerability/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T17:43:58.841429286Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:43:58.841429286Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/cunha2025soberana/metadata-json.ttl
+++ b/models/cunha2025soberana/metadata-json.ttl
@@ -1,0 +1,21 @@
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#>.
+@prefix dct: <http://purl.org/dc/terms/>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
+@prefix owl: <http://www.w3.org/2002/07/owl#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+
+<https://w3id.org/ontouml-models/distribution/68b011d8-63c9-59bb-9541-8ab303ada95f/> a dcat:Distribution;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/cunha2025soberana>;
+    dct:issued "2023"^^xsd:gYear;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://opensource.org/license/mit>;
+    ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
+    dct:title "JSON distribution of Soberana Domain Reference Ontology for describing an International Data Spaces Ecosystem"@en;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/cunha2025soberana/ontology.json>;
+    ocmv:isComplete "true"^^xsd:boolean;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/demori2023miscon/metadata-json.ttl
+++ b/models/demori2023miscon/metadata-json.ttl
@@ -1,0 +1,21 @@
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#>.
+@prefix dct: <http://purl.org/dc/terms/>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
+@prefix owl: <http://www.w3.org/2002/07/owl#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+
+<https://w3id.org/ontouml-models/distribution/8b74663f-cd21-514c-86ac-4fb6883406f8/> a dcat:Distribution;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/demori2023miscon>;
+    dct:issued "2023"^^xsd:gYear;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
+    dct:title "JSON distribution of Military Scenario Ontology"@en;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/demori2023miscon/ontology.json>;
+    ocmv:isComplete "true"^^xsd:boolean;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/duarte2018osdef/metadata-json.ttl
+++ b/models/duarte2018osdef/metadata-json.ttl
@@ -11,10 +11,11 @@
 <https://w3id.org/ontouml-models/distribution/fae9307b-d1c1-40ac-a5fb-0768a84edf32/> a dcat:Distribution;
     dct:isPartOf <https://w3id.org/ontouml-models/model/bfc2ffb6-b4bb-4f6c-9f8f-cc522d13dc94>;
     dct:issued "2018"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of Ontology of Software Defects, Errors and Failures"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/duarte2018osdef/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T17:47:28.809205461Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:47:28.809205461Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/duarte2018reqon/metadata-json.ttl
+++ b/models/duarte2018reqon/metadata-json.ttl
@@ -11,10 +11,11 @@
 <https://w3id.org/ontouml-models/distribution/d77de162-c9ef-4cdf-afc0-f0e98b23f06e/> a dcat:Distribution;
     dct:isPartOf <https://w3id.org/ontouml-models/model/10c716c3-7da2-4457-9e40-9f847d4cf37d>;
     dct:issued "2018"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of Requirements Engineering Ontology"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/duarte2018reqon/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T17:47:37.953979291Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:47:37.953979291Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/duarte2021ross/metadata-json.ttl
+++ b/models/duarte2021ross/metadata-json.ttl
@@ -11,10 +11,11 @@
 <https://w3id.org/ontouml-models/distribution/42793b9c-2cea-4252-bc24-2124d8405515/> a dcat:Distribution;
     dct:isPartOf <https://w3id.org/ontouml-models/model/3adf4afc-9f96-403d-914a-72e41547f673>;
     dct:issued "2021"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of Reference Ontology of Software Systems"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/duarte2021ross/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T17:48:07.012731319Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:48:07.012731319Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/elghosh2024eucaim/metadata-json.ttl
+++ b/models/elghosh2024eucaim/metadata-json.ttl
@@ -1,0 +1,21 @@
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#>.
+@prefix dct: <http://purl.org/dc/terms/>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
+@prefix owl: <http://www.w3.org/2002/07/owl#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+
+<https://w3id.org/ontouml-models/distribution/ff440f64-061e-5125-93cb-bcd56340107e/> a dcat:Distribution;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/elghosh2024eucaim>;
+    dct:issued "2024"^^xsd:gYear;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
+    dct:title "JSON distribution of EUCAIM's Hyper-Ontology (Core Layer)"@en;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/elghosh2024eucaim/ontology.json>;
+    ocmv:isComplete "true"^^xsd:boolean;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/elghosh2025crimonto/metadata-json.ttl
+++ b/models/elghosh2025crimonto/metadata-json.ttl
@@ -1,0 +1,21 @@
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#>.
+@prefix dct: <http://purl.org/dc/terms/>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
+@prefix owl: <http://www.w3.org/2002/07/owl#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+
+<https://w3id.org/ontouml-models/distribution/6166f93c-0f4d-5d32-bb9b-d8aa20d6480f/> a dcat:Distribution;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/elghosh2025crimonto>;
+    dct:issued "2025"^^xsd:gYear;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
+    dct:title "JSON distribution of Criminal Modular Ontology"@en;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/elghosh2025crimonto/ontology.json>;
+    ocmv:isComplete "true"^^xsd:boolean;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/eu-rent-refactored2022/metadata-json.ttl
+++ b/models/eu-rent-refactored2022/metadata-json.ttl
@@ -11,10 +11,11 @@
 <https://w3id.org/ontouml-models/distribution/5d29593f-7d68-46ad-b8e1-52ae1e461ea9/> a dcat:Distribution;
     dct:isPartOf <https://w3id.org/ontouml-models/model/e4940b3f-a31f-4341-a21d-494423c8d876>;
     dct:issued "2022"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of EU-Rent Car Rentals Refactored"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/eu-rent-refactored2022/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T17:48:44.124073376Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:48:44.124073376Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/ferreira2015ontoemergeplan/metadata-json.ttl
+++ b/models/ferreira2015ontoemergeplan/metadata-json.ttl
@@ -11,10 +11,11 @@
 <https://w3id.org/ontouml-models/distribution/5e0b2be9-5c02-474d-871b-439641499a82/> a dcat:Distribution;
     dct:isPartOf <https://w3id.org/ontouml-models/model/dddeec28-4c7c-4e5f-b22e-b536fa79ac72>;
     dct:issued "2013"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of Ontology for Emergency Plans"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/ferreira2015ontoemergeplan/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T17:49:24.418722586Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:49:24.418722586Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/ferreira2024ontopix/metadata-json.ttl
+++ b/models/ferreira2024ontopix/metadata-json.ttl
@@ -1,0 +1,21 @@
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#>.
+@prefix dct: <http://purl.org/dc/terms/>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
+@prefix owl: <http://www.w3.org/2002/07/owl#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+
+<https://w3id.org/ontouml-models/distribution/5d6edbf8-4dfb-5dfc-92cc-92298edd1121/> a dcat:Distribution;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/ferreira2024ontopix>;
+    dct:issued "2024"^^xsd:gYear;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
+    dct:title "JSON distribution of OntoPIX"@en;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/ferreira2024ontopix/ontology.json>;
+    ocmv:isComplete "true"^^xsd:boolean;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/fischer2018ontorea/metadata-json.ttl
+++ b/models/fischer2018ontorea/metadata-json.ttl
@@ -11,10 +11,11 @@
 <https://w3id.org/ontouml-models/distribution/b80a291e-2808-4e4a-95e0-d6d5a3582ca8/> a dcat:Distribution;
     dct:isPartOf <https://w3id.org/ontouml-models/model/dca91792-d4d7-4233-a62b-50040c242cf0>;
     dct:issued "2017"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of OntoREA© Accounting and Finance Model"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/fischer2018ontorea/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T17:49:59.065164632Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:49:59.065164632Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/formula-one2023/metadata-json.ttl
+++ b/models/formula-one2023/metadata-json.ttl
@@ -1,0 +1,21 @@
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#>.
+@prefix dct: <http://purl.org/dc/terms/>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
+@prefix owl: <http://www.w3.org/2002/07/owl#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+
+<https://w3id.org/ontouml-models/distribution/d224e50e-9d15-570c-9cd5-16d547ceb110/> a dcat:Distribution;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/formula-one2023>;
+    dct:issued "2023"^^xsd:gYear;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
+    dct:title "JSON distribution of Formula One Example Ontology"@en;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/formula-one2023/ontology.json>;
+    ocmv:isComplete "true"^^xsd:boolean;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/fraller2019abc/metadata-json.ttl
+++ b/models/fraller2019abc/metadata-json.ttl
@@ -11,10 +11,11 @@
 <https://w3id.org/ontouml-models/distribution/8741ccfc-4280-498c-8dc7-e5592d52c124/> a dcat:Distribution;
     dct:isPartOf <https://w3id.org/ontouml-models/model/dbd5fed6-8332-458f-90ec-b9270e7b6fdc>;
     dct:issued "2019"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of Capacity-Based Activity-Based Costing System Model"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/fraller2019abc/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T17:50:25.724805462Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:50:25.724805462Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/gailly2016value/metadata-json.ttl
+++ b/models/gailly2016value/metadata-json.ttl
@@ -11,10 +11,11 @@
 <https://w3id.org/ontouml-models/distribution/b63c3030-9de1-4272-bcb6-05ca764001db/> a dcat:Distribution;
     dct:isPartOf <https://w3id.org/ontouml-models/model/27838506-29aa-4445-a1fe-73e710c9c186>;
     dct:issued "2016"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of Core Value Ontology"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/gailly2016value/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T17:51:38.931051931Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:51:38.931051931Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/garcia2022human-genome-events/metadata-json.ttl
+++ b/models/garcia2022human-genome-events/metadata-json.ttl
@@ -11,10 +11,11 @@
 <https://w3id.org/ontouml-models/distribution/c398450e-3de4-4f5e-8504-86ad9977fd22/> a dcat:Distribution;
     dct:isPartOf <https://w3id.org/ontouml-models/model/765516ef-53fe-4933-a0e5-0a38079d25c3>;
     dct:issued "2022"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of Ontologically enriched version of Conceptual Schema of the Human Genome"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/garcia2022human-genome-events/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T17:51:48.424007898Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:51:48.424007898Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/genealogy2013/metadata-json.ttl
+++ b/models/genealogy2013/metadata-json.ttl
@@ -1,0 +1,21 @@
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#>.
+@prefix dct: <http://purl.org/dc/terms/>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
+@prefix owl: <http://www.w3.org/2002/07/owl#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+
+<https://w3id.org/ontouml-models/distribution/9a0317b0-79f8-5249-a721-c60268457238/> a dcat:Distribution;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/genealogy2013>;
+    dct:issued "2013"^^xsd:gYear;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
+    dct:title "JSON distribution of Simple Genealogy Ontology"@en;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/genealogy2013/ontology.json>;
+    ocmv:isComplete "true"^^xsd:boolean;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/grueau2013towards/metadata-json.ttl
+++ b/models/grueau2013towards/metadata-json.ttl
@@ -11,10 +11,11 @@
 <https://w3id.org/ontouml-models/distribution/689fa9dc-a3d2-4626-8b7a-79d771b9abae/> a dcat:Distribution;
     dct:isPartOf <https://w3id.org/ontouml-models/model/12a721da-35ae-460f-9417-a2cf55e0f203>;
     dct:issued "2014"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of MAS/LUCC Domain Ontology (excerpt - the agents' layer)"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/grueau2013towards/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T17:53:10.637596064Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:53:10.637596064Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/haridy2021egyptian-e-government/metadata-json.ttl
+++ b/models/haridy2021egyptian-e-government/metadata-json.ttl
@@ -11,10 +11,11 @@
 <https://w3id.org/ontouml-models/distribution/74deef99-cf3e-43ad-905f-1fb158585e00/> a dcat:Distribution;
     dct:isPartOf <https://w3id.org/ontouml-models/model/5f85d9aa-67ac-4315-b60d-0212ea910320>;
     dct:issued "2021"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of Egyptian E-Government Conceptual Model"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/haridy2021egyptian-e-government/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T17:54:30.276780556Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:54:30.276780556Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/heirbrant2023boekbazaar/metadata-json.ttl
+++ b/models/heirbrant2023boekbazaar/metadata-json.ttl
@@ -1,0 +1,21 @@
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#>.
+@prefix dct: <http://purl.org/dc/terms/>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
+@prefix owl: <http://www.w3.org/2002/07/owl#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+
+<https://w3id.org/ontouml-models/distribution/daa63cfc-6dcb-57f0-bc2b-512bee9aa1fb/> a dcat:Distribution;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/heirbrant2023boekbazaar>;
+    dct:issued "2023"^^xsd:gYear;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
+    dct:title "JSON distribution of Boekbazaar Ontology"@en;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/heirbrant2023boekbazaar/ontology.json>;
+    ocmv:isComplete "true"^^xsd:boolean;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/khantong2020ontology/metadata-json.ttl
+++ b/models/khantong2020ontology/metadata-json.ttl
@@ -11,10 +11,11 @@
 <https://w3id.org/ontouml-models/distribution/094cc3c7-c53a-489a-bf84-207d0283c31a/> a dcat:Distribution;
     dct:isPartOf <https://w3id.org/ontouml-models/model/5a426516-e211-4e7b-abc5-dca6b11d2d6a>;
     dct:issued "2019"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of Disaster Response Ontology - Flood Response Scenarios"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/khantong2020ontology/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T17:56:04.384430212Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:56:04.384430212Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/kostov2017towards/metadata-json.ttl
+++ b/models/kostov2017towards/metadata-json.ttl
@@ -11,10 +11,11 @@
 <https://w3id.org/ontouml-models/distribution/f13f2b9e-ebc9-4694-9618-a67defc9ecca/> a dcat:Distribution;
     dct:isPartOf <https://w3id.org/ontouml-models/model/b8d64beb-327f-4e7c-96a7-a10ab1a9da3e>;
     dct:issued "2016"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of Aviation Safety Ontology"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/kostov2017towards/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T17:56:13.825909408Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:56:13.825909408Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/leao2024ontomed/metadata-json.ttl
+++ b/models/leao2024ontomed/metadata-json.ttl
@@ -1,0 +1,21 @@
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#>.
+@prefix dct: <http://purl.org/dc/terms/>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
+@prefix owl: <http://www.w3.org/2002/07/owl#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+
+<https://w3id.org/ontouml-models/distribution/cb8bcc10-4f4e-53e0-9da5-a35c07ab9667/> a dcat:Distribution;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/leao2024ontomed>;
+    dct:issued "2024"^^xsd:gYear;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
+    dct:title "JSON distribution of Ontology for Medication Interaction Decision Support"@en;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/leao2024ontomed/ontology.json>;
+    ocmv:isComplete "true"^^xsd:boolean;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/lindeberg2022full-ontorights/metadata-json.ttl
+++ b/models/lindeberg2022full-ontorights/metadata-json.ttl
@@ -1,0 +1,21 @@
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#>.
+@prefix dct: <http://purl.org/dc/terms/>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
+@prefix owl: <http://www.w3.org/2002/07/owl#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+
+<https://w3id.org/ontouml-models/distribution/43f53b3a-f2cf-55df-80a5-60ef9ba8ce86/> a dcat:Distribution;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/lindeberg2022full-ontorights>;
+    dct:issued "2022"^^xsd:gYear;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://unlicense.org/>;
+    ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
+    dct:title "JSON distribution of Full OntoRights"@en;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/lindeberg2022full-ontorights/ontology.json>;
+    ocmv:isComplete "true"^^xsd:boolean;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/lindeberg2022simple-ontorights/metadata-json.ttl
+++ b/models/lindeberg2022simple-ontorights/metadata-json.ttl
@@ -1,0 +1,21 @@
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#>.
+@prefix dct: <http://purl.org/dc/terms/>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
+@prefix owl: <http://www.w3.org/2002/07/owl#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+
+<https://w3id.org/ontouml-models/distribution/9e561242-bf85-55e6-bece-7c95beb83be4/> a dcat:Distribution;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/lindeberg2022simple-ontorights>;
+    dct:issued "2022"^^xsd:gYear;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://unlicense.org/>;
+    ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
+    dct:title "JSON distribution of Easy OntoRights"@en;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/lindeberg2022simple-ontorights/ontology.json>;
+    ocmv:isComplete "true"^^xsd:boolean;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/lindeberg2024legal-enforcement/metadata-json.ttl
+++ b/models/lindeberg2024legal-enforcement/metadata-json.ttl
@@ -1,0 +1,21 @@
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#>.
+@prefix dct: <http://purl.org/dc/terms/>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
+@prefix owl: <http://www.w3.org/2002/07/owl#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+
+<https://w3id.org/ontouml-models/distribution/ea91ebcb-4608-5ae9-b109-26a60cdf6916/> a dcat:Distribution;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/lindeberg2024legal-enforcement>;
+    dct:issued "2024"^^xsd:gYear;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
+    dct:title "JSON distribution of Legal Enforcement Meta-Model"@en;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/lindeberg2024legal-enforcement/ontology.json>;
+    ocmv:isComplete "true"^^xsd:boolean;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/machacova2023gym/metadata-json.ttl
+++ b/models/machacova2023gym/metadata-json.ttl
@@ -1,0 +1,21 @@
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#>.
+@prefix dct: <http://purl.org/dc/terms/>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
+@prefix owl: <http://www.w3.org/2002/07/owl#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+
+<https://w3id.org/ontouml-models/distribution/3f5ffaee-0885-5330-a230-bb7309431a94/> a dcat:Distribution;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/machacova2023gym>;
+    dct:issued "2023"^^xsd:gYear;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
+    dct:title "JSON distribution of Example Ontology for Gym Products"@en;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/machacova2023gym/ontology.json>;
+    ocmv:isComplete "true"^^xsd:boolean;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/maddalena2021ontocovid/metadata-json.ttl
+++ b/models/maddalena2021ontocovid/metadata-json.ttl
@@ -11,10 +11,11 @@
 <https://w3id.org/ontouml-models/distribution/1a3c1d2b-679c-47d2-a2b4-59e81e1583e7/> a dcat:Distribution;
     dct:isPartOf <https://w3id.org/ontouml-models/model/731a9856-9d6f-4a07-859c-48ec758fe5ce>;
     dct:issued "2021"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of OntoCovid"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/maddalena2021ontocovid/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T17:58:13.720975425Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:58:13.720975425Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/martinez2013human-genome/metadata-json.ttl
+++ b/models/martinez2013human-genome/metadata-json.ttl
@@ -11,10 +11,11 @@
 <https://w3id.org/ontouml-models/distribution/0a7b8bb6-a311-4806-9ff2-b8c87c5d8e61/> a dcat:Distribution;
     dct:isPartOf <https://w3id.org/ontouml-models/model/7509f026-5e24-48e7-a995-ab2f419ce4d7>;
     dct:issued "2013"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of Conceptual Schema of Human Genome"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/martinez2013human-genome/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T17:58:24.432247449Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T17:58:24.432247449Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/meirelles2024credit-operations/metadata-json.ttl
+++ b/models/meirelles2024credit-operations/metadata-json.ttl
@@ -1,0 +1,21 @@
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#>.
+@prefix dct: <http://purl.org/dc/terms/>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
+@prefix owl: <http://www.w3.org/2002/07/owl#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+
+<https://w3id.org/ontouml-models/distribution/f26625a6-83fb-5a30-9024-3485ddd192a0/> a dcat:Distribution;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/meirelles2024credit-operations>;
+    dct:issued "2024"^^xsd:gYear;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
+    dct:title "JSON distribution of Ontologia de Referência para o Domínio de Operações de Crédito"@en;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/meirelles2024credit-operations/ontology.json>;
+    ocmv:isComplete "true"^^xsd:boolean;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/melo2024onto-educational/metadata-json.ttl
+++ b/models/melo2024onto-educational/metadata-json.ttl
@@ -1,0 +1,21 @@
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#>.
+@prefix dct: <http://purl.org/dc/terms/>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
+@prefix owl: <http://www.w3.org/2002/07/owl#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+
+<https://w3id.org/ontouml-models/distribution/6a3b75aa-63aa-5bed-8eb2-57ffd8da2d89/> a dcat:Distribution;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/melo2024onto-educational>;
+    dct:issued "2024"^^xsd:gYear;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
+    dct:title "JSON distribution of Ontologia para Integração de Dados de Evasão Escolar, Desempenho Acadêmico e Concessão de Auxílios Socioeconômicos"@en;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/melo2024onto-educational/ontology.json>;
+    ocmv:isComplete "true"^^xsd:boolean;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/mgic-antt2011/metadata-json.ttl
+++ b/models/mgic-antt2011/metadata-json.ttl
@@ -1,0 +1,20 @@
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#>.
+@prefix dct: <http://purl.org/dc/terms/>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
+@prefix owl: <http://www.w3.org/2002/07/owl#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+
+<https://w3id.org/ontouml-models/distribution/f5b279d0-b897-50d8-bdca-fda750eec479/> a dcat:Distribution;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/mgic-antt2011>;
+    dct:issued "2011"^^xsd:gYear;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
+    dct:title "JSON distribution of National Agency of Terrestrial Transportation (ANTT) Ontology"@en;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/mgic-antt2011/ontology.json>;
+    ocmv:isComplete "true"^^xsd:boolean;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/nascimento2023spacecon/metadata-json.ttl
+++ b/models/nascimento2023spacecon/metadata-json.ttl
@@ -1,0 +1,21 @@
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#>.
+@prefix dct: <http://purl.org/dc/terms/>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
+@prefix owl: <http://www.w3.org/2002/07/owl#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+
+<https://w3id.org/ontouml-models/distribution/b020eb03-9b02-5733-8362-8c4eaba025b7/> a dcat:Distribution;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/nascimento2023spacecon>;
+    dct:issued "2023"^^xsd:gYear;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://opensource.org/license/mit>;
+    ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
+    dct:title "JSON distribution of Smart Spaces Context Ontology"@en;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/nascimento2023spacecon/ontology.json>;
+    ocmv:isComplete "true"^^xsd:boolean;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/nazar2024marchine-learning/metadata-json.ttl
+++ b/models/nazar2024marchine-learning/metadata-json.ttl
@@ -1,0 +1,21 @@
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#>.
+@prefix dct: <http://purl.org/dc/terms/>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
+@prefix owl: <http://www.w3.org/2002/07/owl#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+
+<https://w3id.org/ontouml-models/distribution/26333a28-08c4-517b-894b-3ae813c68ea6/> a dcat:Distribution;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/nazar2024marchine-learning>;
+    dct:issued "2024"^^xsd:gYear;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
+    dct:title "JSON distribution of Machine Learning Ontology"@en;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/nazar2024marchine-learning/ontology.json>;
+    ocmv:isComplete "true"^^xsd:boolean;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/neves2021grain-production/metadata-json.ttl
+++ b/models/neves2021grain-production/metadata-json.ttl
@@ -11,10 +11,11 @@
 <https://w3id.org/ontouml-models/distribution/38a5d0e0-26f8-4daa-8df1-b9bdd147db31/> a dcat:Distribution;
     dct:isPartOf <https://w3id.org/ontouml-models/model/1d378243-6061-4e3a-b32e-05436601d9d9>;
     dct:issued "2021"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of Grain Production Ontology"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/neves2021grain-production/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T18:07:17.931582397Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:07:17.931582397Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/niederkofler2019dssapple/metadata-json.ttl
+++ b/models/niederkofler2019dssapple/metadata-json.ttl
@@ -11,10 +11,11 @@
 <https://w3id.org/ontouml-models/distribution/36860b97-38e6-472a-9c2b-341eef7e90b0/> a dcat:Distribution;
     dct:isPartOf <https://w3id.org/ontouml-models/model/5f97c733-db8a-44cc-b94d-a28b7d3e85cc>;
     dct:issued "2019"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of DSSApple Ontology"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/niederkofler2019dssapple/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T18:07:27.592456072Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:07:27.592456072Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/o3ontology2015/metadata-json.ttl
+++ b/models/o3ontology2015/metadata-json.ttl
@@ -1,0 +1,21 @@
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#>.
+@prefix dct: <http://purl.org/dc/terms/>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
+@prefix owl: <http://www.w3.org/2002/07/owl#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+
+<https://w3id.org/ontouml-models/distribution/5ab617c8-296b-561c-ac29-f16c584bcf64/> a dcat:Distribution;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/o3ontology2015>;
+    dct:issued "2015"^^xsd:gYear;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
+    dct:title "JSON distribution of O3 Ontology"@en;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/o3ontology2015/ontology.json>;
+    ocmv:isComplete "true"^^xsd:boolean;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/oliveira2024phishing/metadata-json.ttl
+++ b/models/oliveira2024phishing/metadata-json.ttl
@@ -1,0 +1,21 @@
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#>.
+@prefix dct: <http://purl.org/dc/terms/>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
+@prefix owl: <http://www.w3.org/2002/07/owl#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+
+<https://w3id.org/ontouml-models/distribution/5518332a-23dc-5413-bb56-75b53f6e1f5c/> a dcat:Distribution;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/oliveira2024phishing>;
+    dct:issued "2024"^^xsd:gYear;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://www.apache.org/licenses/LICENSE-2.0>;
+    ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
+    dct:title "JSON distribution of Phishing Attack Process Ontology"@en;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/oliveira2024phishing/ontology.json>;
+    ocmv:isComplete "true"^^xsd:boolean;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/parking-business2013/metadata-json.ttl
+++ b/models/parking-business2013/metadata-json.ttl
@@ -1,0 +1,21 @@
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#>.
+@prefix dct: <http://purl.org/dc/terms/>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
+@prefix owl: <http://www.w3.org/2002/07/owl#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+
+<https://w3id.org/ontouml-models/distribution/d55ab2d3-e1df-543a-a8dd-641810abce03/> a dcat:Distribution;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/parking-business2013>;
+    dct:issued "2013"^^xsd:gYear;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
+    dct:title "JSON distribution of Parking Business Ontology"@en;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/parking-business2013/ontology.json>;
+    ocmv:isComplete "true"^^xsd:boolean;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/peixoto2025anchorlogy/metadata-json.ttl
+++ b/models/peixoto2025anchorlogy/metadata-json.ttl
@@ -1,0 +1,21 @@
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#>.
+@prefix dct: <http://purl.org/dc/terms/>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
+@prefix owl: <http://www.w3.org/2002/07/owl#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+
+<https://w3id.org/ontouml-models/distribution/c07cff08-c6c7-503d-bf7f-32f67de39103/> a dcat:Distribution;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/peixoto2025anchorlogy>;
+    dct:issued "2025"^^xsd:gYear;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
+    dct:title "JSON distribution of Anchorlogy Ontology for Anchoring Bias in Forecasting"@en;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/peixoto2025anchorlogy/ontology.json>;
+    ocmv:isComplete "true"^^xsd:boolean;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/pereira2015doacao-orgaos/metadata-json.ttl
+++ b/models/pereira2015doacao-orgaos/metadata-json.ttl
@@ -11,10 +11,11 @@
 <https://w3id.org/ontouml-models/distribution/5a69dd6a-ba39-4a5a-b64e-0647e21862b7/> a dcat:Distribution;
     dct:isPartOf <https://w3id.org/ontouml-models/model/ff633ccf-80c1-4276-b9e2-7bf969b0d05b>;
     dct:issued "2015"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of Ontologia de Doação de Órgão e Tecidos"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/pereira2015doacao-orgaos/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T18:08:28.952183923Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:08:28.952183923Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/pereira2020ontotrans/metadata-json.ttl
+++ b/models/pereira2020ontotrans/metadata-json.ttl
@@ -11,10 +11,11 @@
 <https://w3id.org/ontouml-models/distribution/e4eb323d-5ebe-4ef5-a32a-06f6324d447e/> a dcat:Distribution;
     dct:isPartOf <https://w3id.org/ontouml-models/model/0a01a029-1863-498e-aba5-6e9580f94dc5>;
     dct:issued "2020"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of OntoTrans"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/pereira2020ontotrans/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T18:08:41.692176531Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:08:41.692176531Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/piest2024dsr-kb/metadata-json.ttl
+++ b/models/piest2024dsr-kb/metadata-json.ttl
@@ -1,0 +1,21 @@
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#>.
+@prefix dct: <http://purl.org/dc/terms/>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
+@prefix owl: <http://www.w3.org/2002/07/owl#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+
+<https://w3id.org/ontouml-models/distribution/68663ab2-c789-51f4-9ccb-200d7826d692/> a dcat:Distribution;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/piest2024dsr-kb>;
+    dct:issued "2024"^^xsd:gYear;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://opensource.org/licenses/MIT>;
+    ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
+    dct:title "JSON distribution of Domain Reference Ontology for Design Science Research Knowledge Bases"@en;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/piest2024dsr-kb/ontology.json>;
+    ocmv:isComplete "true"^^xsd:boolean;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/pinheiro2024api/metadata-json.ttl
+++ b/models/pinheiro2024api/metadata-json.ttl
@@ -1,0 +1,21 @@
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#>.
+@prefix dct: <http://purl.org/dc/terms/>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
+@prefix owl: <http://www.w3.org/2002/07/owl#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+
+<https://w3id.org/ontouml-models/distribution/aa257e56-7ee1-5e25-a8e6-f3b371dfdb6e/> a dcat:Distribution;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/pinheiro2024api>;
+    dct:issued "2024"^^xsd:gYear;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
+    dct:title "JSON distribution of Reference Ontology for Enterprise Architecture Mining from APIs"@en;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/pinheiro2024api/ontology.json>;
+    ocmv:isComplete "true"^^xsd:boolean;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/ppo-o2021/metadata-json.ttl
+++ b/models/ppo-o2021/metadata-json.ttl
@@ -11,10 +11,11 @@
 <https://w3id.org/ontouml-models/distribution/207a8ad9-0897-471d-b95a-9924fb8e9664/> a dcat:Distribution;
     dct:isPartOf <https://w3id.org/ontouml-models/model/6c200266-ceb5-4cc6-8c8a-b01038687b72>;
     dct:issued "2021"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of PreProcessing Operators Ontology"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/ppo-o2021/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T18:09:32.895531806Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:09:32.895531806Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/project-assets2013/metadata-json.ttl
+++ b/models/project-assets2013/metadata-json.ttl
@@ -1,0 +1,21 @@
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#>.
+@prefix dct: <http://purl.org/dc/terms/>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
+@prefix owl: <http://www.w3.org/2002/07/owl#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+
+<https://w3id.org/ontouml-models/distribution/0609a1ae-0b81-5e6e-b753-757c1fc6e867/> a dcat:Distribution;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/project-assets2013>;
+    dct:issued "2013"^^xsd:gYear;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
+    dct:title "JSON distribution of Project Assets"@en;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/project-assets2013/ontology.json>;
+    ocmv:isComplete "true"^^xsd:boolean;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/public-expense-ontology2020/metadata-json.ttl
+++ b/models/public-expense-ontology2020/metadata-json.ttl
@@ -11,10 +11,11 @@
 <https://w3id.org/ontouml-models/distribution/c57044ac-f96f-41d7-b01f-5cfc1409d18d/> a dcat:Distribution;
     dct:isPartOf <https://w3id.org/ontouml-models/model/0a044a49-bd7c-4429-8b83-68769b9037ee>;
     dct:issued "2020"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of Public Expense Ontology"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/public-expense-ontology2020/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T18:10:02.09922098Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:10:02.09922098Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/public-organization2013/metadata-json.ttl
+++ b/models/public-organization2013/metadata-json.ttl
@@ -1,0 +1,21 @@
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#>.
+@prefix dct: <http://purl.org/dc/terms/>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
+@prefix owl: <http://www.w3.org/2002/07/owl#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+
+<https://w3id.org/ontouml-models/distribution/38652fd3-ad0d-59d5-9561-137615b7af07/> a dcat:Distribution;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/public-organization2013>;
+    dct:issued "2013"^^xsd:gYear;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
+    dct:title "JSON distribution of Ecology Public Organization"@en;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/public-organization2013/ontology.json>;
+    ocmv:isComplete "true"^^xsd:boolean;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/ramos2021bias/metadata-json.ttl
+++ b/models/ramos2021bias/metadata-json.ttl
@@ -11,10 +11,11 @@
 <https://w3id.org/ontouml-models/distribution/7e275e7a-0431-473f-8b67-ba5f2d2f3cc1/> a dcat:Distribution;
     dct:isPartOf <https://w3id.org/ontouml-models/model/e3e0f697-53e8-45dc-8d32-bf282b5434cb>;
     dct:issued "2021"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of Decision Making Ontology Extended with Intuitive Decision Making"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/ramos2021bias/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T18:11:21.209818584Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:11:21.209818584Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/repa2021public-administration/metadata-json.ttl
+++ b/models/repa2021public-administration/metadata-json.ttl
@@ -11,10 +11,11 @@
 <https://w3id.org/ontouml-models/distribution/e6ccc1da-6edf-43a9-9dc1-5353b40016cc/> a dcat:Distribution;
     dct:isPartOf <https://w3id.org/ontouml-models/model/54af0ca8-e341-4457-b0dc-2594425a6489>;
     dct:issued "2015"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of Public Administration Ontology Model"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/repa2021public-administration/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T18:11:49.285076289Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:11:49.285076289Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/richetti2019tdecision/metadata-json.ttl
+++ b/models/richetti2019tdecision/metadata-json.ttl
@@ -11,10 +11,11 @@
 <https://w3id.org/ontouml-models/distribution/60647cbd-4094-4d38-b893-a4a9719ff13a/> a dcat:Distribution;
     dct:isPartOf <https://w3id.org/ontouml-models/model/a0ce75d5-54d0-4949-b9d0-444bad20573c>;
     dct:issued "2019"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of Decision Making in knowledge intensive process in Value Ascription and Goal processing"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/richetti2019tdecision/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T18:11:58.832970123Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:11:58.832970123Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/road-accident2013/metadata-json.ttl
+++ b/models/road-accident2013/metadata-json.ttl
@@ -1,0 +1,21 @@
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#>.
+@prefix dct: <http://purl.org/dc/terms/>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
+@prefix owl: <http://www.w3.org/2002/07/owl#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+
+<https://w3id.org/ontouml-models/distribution/7e719412-8f28-5d46-9c4a-dea1aba2431e/> a dcat:Distribution;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/road-accident2013>;
+    dct:issued "2013"^^xsd:gYear;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
+    dct:title "JSON distribution of Road Traffic Accident Ontology"@en;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/road-accident2013/ontology.json>;
+    ocmv:isComplete "true"^^xsd:boolean;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/rocha2023ciencia-aberta/metadata-json.ttl
+++ b/models/rocha2023ciencia-aberta/metadata-json.ttl
@@ -1,0 +1,21 @@
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#>.
+@prefix dct: <http://purl.org/dc/terms/>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
+@prefix owl: <http://www.w3.org/2002/07/owl#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+
+<https://w3id.org/ontouml-models/distribution/40628ea2-9bf0-5684-bc70-01627f1e2d7d/> a dcat:Distribution;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/rocha2023ciencia-aberta>;
+    dct:issued "2023"^^xsd:gYear;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
+    dct:title "JSON distribution of Ciência Aberta"@en;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/rocha2023ciencia-aberta/ontology.json>;
+    ocmv:isComplete "true"^^xsd:boolean;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/rodrigues2017urinary-profiles/metadata-json.ttl
+++ b/models/rodrigues2017urinary-profiles/metadata-json.ttl
@@ -11,10 +11,11 @@
 <https://w3id.org/ontouml-models/distribution/fea6bb77-64c0-4d1c-9c6e-ded255d01916/> a dcat:Distribution;
     dct:isPartOf <https://w3id.org/ontouml-models/model/ab12ac77-6476-4b22-9c2b-bb70a9c6f26d>;
     dct:issued "2015"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of Ontological Model for Urinary Profiles and Events"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/rodrigues2017urinary-profiles/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T18:12:11.534182914Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:12:11.534182914Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/santos2020valuenetworks/metadata-json.ttl
+++ b/models/santos2020valuenetworks/metadata-json.ttl
@@ -11,10 +11,11 @@
 <https://w3id.org/ontouml-models/distribution/e76e2bc1-8044-42e9-a8c7-9734069bff0e/> a dcat:Distribution;
     dct:isPartOf <https://w3id.org/ontouml-models/model/87dea242-75d9-4b89-99f3-6f52c0855f3a>;
     dct:issued "2020"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of Ontology for Value Networks with Corporate Responsibility"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/santos2020valuenetworks/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T18:14:43.235008058Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:14:43.235008058Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/sariev2024maritime/metadata-json.ttl
+++ b/models/sariev2024maritime/metadata-json.ttl
@@ -1,0 +1,21 @@
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#>.
+@prefix dct: <http://purl.org/dc/terms/>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
+@prefix owl: <http://www.w3.org/2002/07/owl#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+
+<https://w3id.org/ontouml-models/distribution/f1094463-8d06-5cd1-bf04-6029f7786ca4/> a dcat:Distribution;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/sariev2024maritime>;
+    dct:issued "2024"^^xsd:gYear;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
+    dct:title "JSON distribution of Ontology for Digital Twin Development in Maritime Logistics"@en;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/sariev2024maritime/ontology.json>;
+    ocmv:isComplete "true"^^xsd:boolean;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/schoonderbeek2024eamon/metadata-json.ttl
+++ b/models/schoonderbeek2024eamon/metadata-json.ttl
@@ -1,0 +1,21 @@
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#>.
+@prefix dct: <http://purl.org/dc/terms/>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
+@prefix owl: <http://www.w3.org/2002/07/owl#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+
+<https://w3id.org/ontouml-models/distribution/71bb229e-7bf9-5a81-975b-c6c52cf42bc5/> a dcat:Distribution;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/schoonderbeek2024eamon>;
+    dct:issued "2024"^^xsd:gYear;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
+    dct:title "JSON distribution of Enterprise Architecture Modeling Ontology"@en;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/schoonderbeek2024eamon/ontology.json>;
+    ocmv:isComplete "true"^^xsd:boolean;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/scientific-experiment2013/metadata-json.ttl
+++ b/models/scientific-experiment2013/metadata-json.ttl
@@ -1,0 +1,21 @@
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#>.
+@prefix dct: <http://purl.org/dc/terms/>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
+@prefix owl: <http://www.w3.org/2002/07/owl#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+
+<https://w3id.org/ontouml-models/distribution/dc319b91-ab1a-5bae-a95d-20c66b117978/> a dcat:Distribution;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/scientific-experiment2013>;
+    dct:issued "2013"^^xsd:gYear;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
+    dct:title "JSON distribution of Scientific Experiment Ontology"@en;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/scientific-experiment2013/ontology.json>;
+    ocmv:isComplete "true"^^xsd:boolean;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/scientific-publication2013/metadata-json.ttl
+++ b/models/scientific-publication2013/metadata-json.ttl
@@ -1,0 +1,21 @@
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#>.
+@prefix dct: <http://purl.org/dc/terms/>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
+@prefix owl: <http://www.w3.org/2002/07/owl#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+
+<https://w3id.org/ontouml-models/distribution/12443ea5-471d-5df6-adea-d3835f3130a7/> a dcat:Distribution;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/scientific-publication2013>;
+    dct:issued "2013"^^xsd:gYear;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
+    dct:title "JSON distribution of Scientific Publication Ontology"@en;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/scientific-publication2013/ontology.json>;
+    ocmv:isComplete "true"^^xsd:boolean;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/services2015/metadata-json.ttl
+++ b/models/services2015/metadata-json.ttl
@@ -1,0 +1,21 @@
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#>.
+@prefix dct: <http://purl.org/dc/terms/>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
+@prefix owl: <http://www.w3.org/2002/07/owl#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+
+<https://w3id.org/ontouml-models/distribution/c55006a1-4276-53a4-9039-530a3f5e2969/> a dcat:Distribution;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/services2015>;
+    dct:issued "2015"^^xsd:gYear;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
+    dct:title "JSON distribution of Services Ontology"@en;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/services2015/ontology.json>;
+    ocmv:isComplete "true"^^xsd:boolean;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/short-examples2013/metadata-json.ttl
+++ b/models/short-examples2013/metadata-json.ttl
@@ -1,0 +1,21 @@
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#>.
+@prefix dct: <http://purl.org/dc/terms/>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
+@prefix owl: <http://www.w3.org/2002/07/owl#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+
+<https://w3id.org/ontouml-models/distribution/291fff7f-d84e-561d-9930-2d46bc6ae29a/> a dcat:Distribution;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/short-examples2013>;
+    dct:issued "2013"^^xsd:gYear;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
+    dct:title "JSON distribution of Short Examples of OntoUML Ontologies"@en;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/short-examples2013/ontology.json>;
+    ocmv:isComplete "true"^^xsd:boolean;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/sikora2021online-education/metadata-json.ttl
+++ b/models/sikora2021online-education/metadata-json.ttl
@@ -11,10 +11,11 @@
 <https://w3id.org/ontouml-models/distribution/26661f89-956e-4840-bbae-02503e01e524/> a dcat:Distribution;
     dct:isPartOf <https://w3id.org/ontouml-models/model/c3b6f81b-7d10-4e11-bdf2-4e291d0f8f70>;
     dct:issued "2021"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of Online Education Ontology"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/sikora2021online-education/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T18:14:52.697875961Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:14:52.697875961Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/silva2012itarchitecture/metadata-json.ttl
+++ b/models/silva2012itarchitecture/metadata-json.ttl
@@ -11,10 +11,11 @@
 <https://w3id.org/ontouml-models/distribution/1714ffe3-4a5a-49b9-af35-5b36d2b63b0a/> a dcat:Distribution;
     dct:isPartOf <https://w3id.org/ontouml-models/model/65c6c4c6-a903-48dd-bd28-dcb4f0b8fe6d>;
     dct:issued "2012"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of IT Architecture Ontology (PAS 77:2006 Ontology)"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/silva2012itarchitecture/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T18:15:36.934851761Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:15:36.934851761Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/silva2021sebim/metadata-json.ttl
+++ b/models/silva2021sebim/metadata-json.ttl
@@ -1,0 +1,21 @@
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#>.
+@prefix dct: <http://purl.org/dc/terms/>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
+@prefix owl: <http://www.w3.org/2002/07/owl#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+
+<https://w3id.org/ontouml-models/distribution/301cd87e-b919-5101-aba8-b274b50fc36a/> a dcat:Distribution;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/silva2021sebim>;
+    dct:issued "2021"^^xsd:gYear;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
+    dct:title "JSON distribution of Semantic BIM"@en;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/silva2021sebim/ontology.json>;
+    ocmv:isComplete "true"^^xsd:boolean;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/silva2023onto4caal/metadata-json.ttl
+++ b/models/silva2023onto4caal/metadata-json.ttl
@@ -1,0 +1,21 @@
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#>.
+@prefix dct: <http://purl.org/dc/terms/>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
+@prefix owl: <http://www.w3.org/2002/07/owl#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+
+<https://w3id.org/ontouml-models/distribution/f5b157e5-2141-5a7b-a16a-1cebb0fb84be/> a dcat:Distribution;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/silva2023onto4caal>;
+    dct:issued "2023"^^xsd:gYear;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by-nc-nd/3.0/br/>;
+    ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
+    dct:title "JSON distribution of Requirements Ontology for AAL Systems"@en;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/silva2023onto4caal/ontology.json>;
+    ocmv:isComplete "true"^^xsd:boolean;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/silva2023onto4elev/metadata-json.ttl
+++ b/models/silva2023onto4elev/metadata-json.ttl
@@ -1,0 +1,21 @@
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#>.
+@prefix dct: <http://purl.org/dc/terms/>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
+@prefix owl: <http://www.w3.org/2002/07/owl#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+
+<https://w3id.org/ontouml-models/distribution/714530ed-4a0d-53b3-8e1d-2d0fac3b4270/> a dcat:Distribution;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/silva2023onto4elev>;
+    dct:issued "2023"^^xsd:gYear;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by-nc-nd/3.0/br/>;
+    ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
+    dct:title "JSON distribution of Requirements Ontology for Vertical Lifting Platform"@en;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/silva2023onto4elev/ontology.json>;
+    ocmv:isComplete "true"^^xsd:boolean;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/soares2024fair/metadata-json.ttl
+++ b/models/soares2024fair/metadata-json.ttl
@@ -1,0 +1,21 @@
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#>.
+@prefix dct: <http://purl.org/dc/terms/>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
+@prefix owl: <http://www.w3.org/2002/07/owl#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+
+<https://w3id.org/ontouml-models/distribution/a9533971-2f9e-5030-849a-4420de52ca27/> a dcat:Distribution;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/soares2024fair>;
+    dct:issued "2024"^^xsd:gYear;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
+    dct:title "JSON distribution of Conceptual Model of a FAIR Metadata Schema"@en;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/soares2024fair/ontology.json>;
+    ocmv:isComplete "true"^^xsd:boolean;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/social-contracts2013/metadata-json.ttl
+++ b/models/social-contracts2013/metadata-json.ttl
@@ -1,0 +1,21 @@
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#>.
+@prefix dct: <http://purl.org/dc/terms/>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
+@prefix owl: <http://www.w3.org/2002/07/owl#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+
+<https://w3id.org/ontouml-models/distribution/ae3ca905-a7a1-59eb-99d8-e79d9250e6c7/> a dcat:Distribution;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/social-contracts2013>;
+    dct:issued "2013"^^xsd:gYear;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
+    dct:title "JSON distribution of State and Social Contracts Ontology"@en;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/social-contracts2013/ontology.json>;
+    ocmv:isComplete "true"^^xsd:boolean;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/telecom-equipment2013/metadata-json.ttl
+++ b/models/telecom-equipment2013/metadata-json.ttl
@@ -1,0 +1,21 @@
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#>.
+@prefix dct: <http://purl.org/dc/terms/>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
+@prefix owl: <http://www.w3.org/2002/07/owl#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+
+<https://w3id.org/ontouml-models/distribution/4482a939-3603-5105-9cdf-6e5d3848bb47/> a dcat:Distribution;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/telecom-equipment2013>;
+    dct:issued "2013"^^xsd:gYear;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
+    dct:title "JSON distribution of Telecommunications Equipment"@en;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/telecom-equipment2013/ontology.json>;
+    ocmv:isComplete "true"^^xsd:boolean;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/tender2013/metadata-json.ttl
+++ b/models/tender2013/metadata-json.ttl
@@ -1,0 +1,21 @@
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#>.
+@prefix dct: <http://purl.org/dc/terms/>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
+@prefix owl: <http://www.w3.org/2002/07/owl#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+
+<https://w3id.org/ontouml-models/distribution/0af6be9c-44bf-54c3-9d94-7a9cbe620997/> a dcat:Distribution;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/tender2013>;
+    dct:issued "2013"^^xsd:gYear;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
+    dct:title "JSON distribution of Tender Ontology"@en;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/tender2013/ontology.json>;
+    ocmv:isComplete "true"^^xsd:boolean;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/tesolin2023hint/metadata-json.ttl
+++ b/models/tesolin2023hint/metadata-json.ttl
@@ -1,0 +1,21 @@
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#>.
+@prefix dct: <http://purl.org/dc/terms/>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
+@prefix owl: <http://www.w3.org/2002/07/owl#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+
+<https://w3id.org/ontouml-models/distribution/e5995950-4a50-5b37-9add-6a48c23c95d1/> a dcat:Distribution;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/tesolin2023hint>;
+    dct:issued "2023"^^xsd:gYear;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
+    dct:title "JSON distribution of Heterogeneous wIreless Network onTology"@en;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/tesolin2023hint/ontology.json>;
+    ocmv:isComplete "true"^^xsd:boolean;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/van-ee2021modular/metadata-json.ttl
+++ b/models/van-ee2021modular/metadata-json.ttl
@@ -11,10 +11,11 @@
 <https://w3id.org/ontouml-models/distribution/15762e63-c636-4839-a60e-199fff2c104e/> a dcat:Distribution;
     dct:isPartOf <https://w3id.org/ontouml-models/model/c6ec6f27-cffa-4a38-9927-8e6b921e996a>;
     dct:issued "2021"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of Modular Construction Ontology"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/van-ee2021modular/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T18:19:00.326467876Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:19:00.326467876Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/xhani2023xmlpo/metadata-json.ttl
+++ b/models/xhani2023xmlpo/metadata-json.ttl
@@ -1,0 +1,21 @@
+@prefix fdpo: <https://w3id.org/fdp/fdp-o#>.
+@prefix dcat: <http://www.w3.org/ns/dcat#>.
+@prefix dct: <http://purl.org/dc/terms/>.
+@prefix ocmv: <https://w3id.org/ontouml-models/vocabulary#>.
+@prefix owl: <http://www.w3.org/2002/07/owl#>.
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix skos: <http://www.w3.org/2004/02/skos/core#>.
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#>.
+
+<https://w3id.org/ontouml-models/distribution/e8356d24-46ef-5b53-a48d-080e7b9e9ca8/> a dcat:Distribution;
+    dct:isPartOf <https://w3id.org/ontouml-models/model/xhani2023xmlpo>;
+    dct:issued "2023"^^xsd:gYear;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
+    ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
+    dct:title "JSON distribution of Explainable Machine Learning Pipeline Ontology"@en;
+    dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/xhani2023xmlpo/ontology.json>;
+    ocmv:isComplete "true"^^xsd:boolean;
+    fdpo:metadataIssued "2026-06-24T12:00:00Z"^^xsd:dateTime;
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/zanetti2019orm-o/metadata-json.ttl
+++ b/models/zanetti2019orm-o/metadata-json.ttl
@@ -11,10 +11,11 @@
 <https://w3id.org/ontouml-models/distribution/1fba6c3c-9df4-4f7f-b374-cee0530be3f4/> a dcat:Distribution;
     dct:isPartOf <https://w3id.org/ontouml-models/model/c528d763-ff22-4d52-9e03-e881b41805ce>;
     dct:issued "2019"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of Object/Relational Mapping Ontology"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/zanetti2019orm-o/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T18:20:26.831437244Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:20:26.831437244Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/zhou2017hazard-ontology-robotic-strolling/metadata-json.ttl
+++ b/models/zhou2017hazard-ontology-robotic-strolling/metadata-json.ttl
@@ -11,10 +11,11 @@
 <https://w3id.org/ontouml-models/distribution/c30ed359-c2eb-436b-8958-0596f9a5cc6c/> a dcat:Distribution;
     dct:isPartOf <https://w3id.org/ontouml-models/model/c7dbcd4e-e12a-4f9f-a20c-e08137c36db5>;
     dct:issued "2017"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of Robotic Strolling System"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/zhou2017hazard-ontology-robotic-strolling/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T18:20:42.456540525Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:20:42.456540525Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/zhou2017hazard-ontology-train-control/metadata-json.ttl
+++ b/models/zhou2017hazard-ontology-train-control/metadata-json.ttl
@@ -11,10 +11,11 @@
 <https://w3id.org/ontouml-models/distribution/8ef09e9f-ada6-4952-9e9f-34e0986b6b04/> a dcat:Distribution;
     dct:isPartOf <https://w3id.org/ontouml-models/model/0ea32c8f-85e8-4749-97b9-24b59ae41dbd>;
     dct:issued "2017"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of Train Control System"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/zhou2017hazard-ontology-train-control/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T18:20:52.715361235Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:20:52.715361235Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .

--- a/models/zhou2017hazard/metadata-json.ttl
+++ b/models/zhou2017hazard/metadata-json.ttl
@@ -11,10 +11,11 @@
 <https://w3id.org/ontouml-models/distribution/d9c7230e-3e8b-4be3-a9e9-8be974d68086/> a dcat:Distribution;
     dct:isPartOf <https://w3id.org/ontouml-models/model/e28bed62-0a6b-49a4-a3a9-01c8e4f527e3>;
     dct:issued "2017"^^xsd:gYear;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
+    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of Hazard Ontology"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/zhou2017hazard/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T18:21:05.509815727Z"^^xsd:dateTime;
-    fdpo:metadataModified "2023-04-14T18:21:05.509815727Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .


### PR DESCRIPTION
## Summary

This PR regenerates the JSON distribution metadata files (`metadata-json.ttl`) across the catalog using the updated YAML-based JSON metadata generator.

The regeneration was performed with a deterministic metadata timestamp so that the output is reproducible and does not depend on the local execution time.

## Scope

This PR is limited to generated JSON distribution metadata files under `models/`.

Expected changed files are of the following form:

```text
models/<dataset>/metadata-json.ttl
```

This PR does not modify:

- generator scripts;
- tests;
- documentation;
- GitHub Actions workflows;
- CI configuration;
- source model files such as `ontology.json`;
- model-level `metadata.ttl`;
- metadata files for other distribution types.

## Motivation

The catalog metadata workflow is being reorganized so that distribution-level metadata can be generated before the final model-level `metadata.ttl` aggregation step.

This PR applies that strategy to JSON distribution metadata. The generated files describe each model’s `ontology.json` distribution using the current YAML-based generation logic.

## Generation command

The metadata was generated with a fixed deterministic timestamp:

```bash
python scripts/generate_json_metadata.py --all --models-dir models --allow-missing-license --metadata-timestamp 2026-06-24T12:00:00Z
```

The use of `--allow-missing-license` is intentional because some legacy catalog datasets do not define license metadata in `metadata.yaml`. When license metadata is available, the generator still emits it.

The generation did not use `--validate-ontology-json`, because strict parsing of legacy `ontology.json` files is intentionally opt-in. Normal metadata generation only requires the source distribution file to exist.

## Metadata behavior

The regeneration follows the JSON distribution metadata strategy introduced by the YAML-based generator:

- uses `metadata.yaml` as the source for editable model-level metadata;
- does not depend on model-level `metadata.ttl`;
- preserves existing JSON distribution IRIs where available;
- preserves existing `dct:isPartOf` model IRIs where available;
- preserves existing distribution-level license metadata for legacy missing-license cases when allowed;
- emits `dcat:mediaType` as `application/json`;
- emits `ocmv:conformsToSchema <https://w3id.org/ontouml/schema>`;
- emits `ocmv:isComplete true`;
- updates FDP metadata timestamps deterministically when files change.

## Deterministic timestamp

The fixed timestamp used in this run was:

```text
2026-06-24T12:00:00Z
```

For changed files, `fdpo:metadataModified` is updated to this timestamp. For newly created files, both `fdpo:metadataIssued` and `fdpo:metadataModified` are initialized with this timestamp. Existing `fdpo:metadataIssued` values are preserved when present.

## Verification

Before generation, the generator was checked with:

```bash
python -m py_compile scripts/generate_json_metadata.py scripts/tests/test_generate_json_metadata.py
python -m pytest -q scripts/tests/test_generate_json_metadata.py
python scripts/generate_json_metadata.py --help
```

After generation, check mode was run with:

```bash
python scripts/generate_json_metadata.py --all --models-dir models --allow-missing-license --metadata-timestamp 2026-06-24T12:00:00Z --check
```

## Review notes

Reviewers should mainly verify that:

- changed files are limited to `models/*/metadata-json.ttl`;
- generated JSON metadata keeps stable catalog identifiers;
- no unrelated generated metadata files are included;
- no source model files or workflow files are modified;
- no non-deterministic timestamp such as the current local execution time was introduced.

## Follow-up

This PR only regenerates JSON distribution metadata. Similar regeneration PRs may be prepared separately for other distribution metadata types, such as PNG, Turtle, and VPP, following the same workflow strategy.