### PR TITLE
feat(scripts): add references.bib validator

### DIFF
--- a/scripts/tests/test_validate_references_bib.py
+++ b/scripts/tests/test_validate_references_bib.py
@@ -1,0 +1,1019 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+
+def load_module():
+    script = None
+    for parent in Path(__file__).resolve().parents:
+        for candidate in (
+            parent / "validate_references_bib.py",
+            parent / "scripts" / "validate_references_bib.py",
+        ):
+            if candidate.exists():
+                script = candidate
+                break
+        if script is not None:
+            break
+    assert script is not None
+    spec = importlib.util.spec_from_file_location("validate_references_bib", script)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+VALID_BIB = """% Dataset references
+@article{sales2023catalog,
+  author = {Sales, Tiago Prince and Barcelos, Pedro Paulo F.},
+  title = {A FAIR catalog of ontology-driven conceptual models},
+  journal = {Data & Knowledge Engineering},
+  year = {2023},
+  doi = {10.1016/j.datak.2023.102210}
+}
+
+@inproceedings{guizzardi2022example,
+  title = "Example title",
+  booktitle = {Proceedings of an Example Conference},
+  year = 2022,
+  month = jan # " " # feb
+}
+"""
+
+
+def make_dataset(tmp_path: Path, bib_text: str | None = VALID_BIB) -> Path:
+    dataset = tmp_path / "models" / "example-model"
+    dataset.mkdir(parents=True)
+    (dataset / "metadata.yaml").write_text("title: Example\n", encoding="utf-8")
+    if bib_text is not None:
+        (dataset / "references.bib").write_text(bib_text, encoding="utf-8")
+    return dataset
+
+
+def test_valid_references_bib_is_accepted(tmp_path: Path):
+    module = load_module()
+    dataset = make_dataset(tmp_path)
+    validator = module.ReferencesBibValidator(module.Config())
+
+    result = validator.validate_target(dataset)
+
+    assert result.valid
+    assert result.entries_checked == 2
+    assert result.errors == []
+
+
+def test_missing_references_bib_is_skipped_by_default(tmp_path: Path):
+    module = load_module()
+    dataset = make_dataset(tmp_path, bib_text=None)
+    validator = module.ReferencesBibValidator(module.Config())
+
+    result = validator.validate_target(dataset)
+
+    assert result.valid
+    assert not result.present
+    assert result.errors == []
+
+
+def test_missing_references_bib_can_be_required(tmp_path: Path):
+    module = load_module()
+    dataset = make_dataset(tmp_path, bib_text=None)
+    validator = module.ReferencesBibValidator(module.Config(require=True))
+
+    result = validator.validate_target(dataset)
+
+    assert not result.valid
+    assert result.errors[0].code == "missing_references_bib"
+
+
+def test_empty_references_bib_is_rejected(tmp_path: Path):
+    module = load_module()
+    dataset = make_dataset(tmp_path, bib_text=" \n\t\n")
+    validator = module.ReferencesBibValidator(module.Config())
+
+    result = validator.validate_target(dataset)
+
+    assert not result.valid
+    assert result.errors[0].code == "empty_file"
+
+
+def test_unclosed_entry_is_rejected(tmp_path: Path):
+    module = load_module()
+    dataset = make_dataset(
+        tmp_path,
+        bib_text="""@article{broken,
+  title = {Missing closing brace}
+""",
+    )
+    validator = module.ReferencesBibValidator(module.Config())
+
+    result = validator.validate_target(dataset)
+
+    assert not result.valid
+    assert result.errors[0].code == "unclosed_entry"
+
+
+def test_entry_without_at_sign_is_rejected(tmp_path: Path):
+    module = load_module()
+    dataset = make_dataset(
+        tmp_path,
+        bib_text="""article{broken,
+  title = {Wrong start}
+}
+""",
+    )
+    validator = module.ReferencesBibValidator(module.Config())
+
+    result = validator.validate_target(dataset)
+
+    assert not result.valid
+    assert any(issue.code == "unexpected_text" for issue in result.errors)
+
+
+def test_missing_citation_key_is_rejected(tmp_path: Path):
+    module = load_module()
+    dataset = make_dataset(
+        tmp_path,
+        bib_text="""@article{,
+  title = {Missing key}
+}
+""",
+    )
+    validator = module.ReferencesBibValidator(module.Config())
+
+    result = validator.validate_target(dataset)
+
+    assert not result.valid
+    assert any(issue.code == "missing_citation_key" for issue in result.errors)
+
+
+def test_invalid_field_assignment_is_rejected(tmp_path: Path):
+    module = load_module()
+    dataset = make_dataset(
+        tmp_path,
+        bib_text="""@article{broken,
+  title {Missing equals},
+  year = {2024}
+}
+""",
+    )
+    validator = module.ReferencesBibValidator(module.Config())
+
+    result = validator.validate_target(dataset)
+
+    assert not result.valid
+    assert any(issue.code == "missing_field_assignment" for issue in result.errors)
+
+
+def test_duplicate_citation_key_is_rejected(tmp_path: Path):
+    module = load_module()
+    dataset = make_dataset(
+        tmp_path,
+        bib_text="""@article{same,
+  title = {First}
+}
+@book{same,
+  title = {Second}
+}
+""",
+    )
+    validator = module.ReferencesBibValidator(module.Config())
+
+    result = validator.validate_target(dataset)
+
+    assert not result.valid
+    assert any(issue.code == "duplicate_key" for issue in result.errors)
+
+
+def test_unknown_entry_type_is_warning_by_default(tmp_path: Path):
+    module = load_module()
+    dataset = make_dataset(
+        tmp_path,
+        bib_text="""@customtype{key,
+  title = {Unknown type but syntactically valid}
+}
+""",
+    )
+    validator = module.ReferencesBibValidator(module.Config())
+
+    result = validator.validate_target(dataset)
+
+    assert result.valid
+    assert any(issue.code == "unknown_entry_type" for issue in result.warnings)
+
+
+def test_strict_promotes_unknown_entry_type_warning_to_error(tmp_path: Path):
+    module = load_module()
+    dataset = make_dataset(
+        tmp_path,
+        bib_text="""@customtype{key,
+  title = {Unknown type but syntactically valid}
+}
+""",
+    )
+    validator = module.ReferencesBibValidator(module.Config(strict=True))
+
+    result = validator.validate_target(dataset)
+
+    assert not result.valid
+    assert any(issue.code == "unknown_entry_type" for issue in result.errors)
+
+
+def test_string_preamble_and_comment_entries_are_accepted_with_regular_entry(
+    tmp_path: Path,
+):
+    module = load_module()
+    dataset = make_dataset(
+        tmp_path,
+        bib_text="""@string{JWS = "Journal of Web Semantics"}
+@preamble{"Generated bibliography"}
+@comment{This comment is allowed}
+@article{key,
+  title = {Uses macro},
+  journal = JWS,
+  year = 2024
+}
+""",
+    )
+    validator = module.ReferencesBibValidator(module.Config())
+
+    result = validator.validate_target(dataset)
+
+    assert result.valid
+    assert result.entries_checked == 1
+
+
+def test_file_target_is_supported(tmp_path: Path):
+    module = load_module()
+    dataset = make_dataset(tmp_path)
+    validator = module.ReferencesBibValidator(module.Config())
+
+    result = validator.validate_target(dataset / "references.bib")
+
+    assert result.valid
+    assert result.dataset_path == dataset
+
+
+def test_top_level_comments_between_fields_are_accepted(tmp_path: Path):
+    module = load_module()
+    dataset = make_dataset(
+        tmp_path,
+        bib_text="""@article{key,
+  title = {Commented entry}, % comment after field
+  % full-line comment between fields
+  year = {2024},
+  note = {100\\% coverage}
+}
+""",
+    )
+    validator = module.ReferencesBibValidator(module.Config())
+
+    result = validator.validate_target(dataset)
+
+    assert result.valid
+    assert result.entries_checked == 1
+
+
+def test_unescaped_quote_inside_quoted_value_is_rejected(tmp_path: Path):
+    module = load_module()
+    dataset = make_dataset(
+        tmp_path,
+        bib_text="""@article{broken,
+  title = "A "broken" quoted value",
+  year = {2024}
+}
+""",
+    )
+    validator = module.ReferencesBibValidator(module.Config())
+
+    result = validator.validate_target(dataset)
+
+    assert not result.valid
+    assert any(issue.code == "invalid_field_value" for issue in result.errors)
+
+
+def test_cli_returns_two_for_missing_explicit_target(tmp_path: Path, capsys):
+    module = load_module()
+    missing = tmp_path / "models" / "missing-model"
+
+    exit_code = module.main([str(missing)])
+    captured = capsys.readouterr()
+
+    assert exit_code == 2
+    assert "Input path does not exist" in captured.err
+
+
+def test_json_output_shape_from_main(tmp_path: Path, capsys):
+    module = load_module()
+    dataset = make_dataset(tmp_path)
+
+    exit_code = module.main([str(dataset), "--format", "json"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    payload = json.loads(captured.out)
+    assert payload[0]["valid"] is True
+    assert payload[0]["entries_checked"] == 2
+
+
+def test_cli_returns_one_for_invalid_file(tmp_path: Path, capsys):
+    module = load_module()
+    dataset = make_dataset(tmp_path, bib_text="@article{broken")
+
+    exit_code = module.main([str(dataset)])
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    assert "INVALID" in captured.out
+
+
+def test_parenthesized_entries_are_supported(tmp_path: Path):
+    module = load_module()
+    dataset = make_dataset(
+        tmp_path,
+        bib_text="""@book(smith2024,
+  title = {Parenthesized Entry},
+  publisher = {Example Press},
+  year = {2024}
+)
+""",
+    )
+    validator = module.ReferencesBibValidator(module.Config())
+
+    result = validator.validate_target(dataset)
+
+    assert result.valid
+    assert result.entries_checked == 1
+
+
+def test_nested_braces_and_escaped_quotes_are_accepted(tmp_path: Path):
+    module = load_module()
+    dataset = make_dataset(
+        tmp_path,
+        bib_text=r"""@article{latex2024,
+  title = {A {Nested} Title with {\LaTeX} and "quotes"},
+  note = "A \"quoted\" note",
+  year = {2024}
+}
+""",
+    )
+    validator = module.ReferencesBibValidator(module.Config())
+
+    result = validator.validate_target(dataset)
+
+    assert result.valid
+    assert result.entries_checked == 1
+
+
+def test_at_signs_inside_values_are_accepted(tmp_path: Path):
+    module = load_module()
+    dataset = make_dataset(
+        tmp_path,
+        bib_text="""@online{web2024,
+  title = {Project page @ GitHub},
+  url = {https://example.org/contact?a=b&c=d},
+  note = "email@example.org",
+  year = {2024}
+}
+""",
+    )
+    validator = module.ReferencesBibValidator(module.Config())
+
+    result = validator.validate_target(dataset)
+
+    assert result.valid
+    assert result.entries_checked == 1
+
+
+def test_only_special_entries_is_rejected_as_no_bibliographic_entries(tmp_path: Path):
+    module = load_module()
+    dataset = make_dataset(
+        tmp_path,
+        bib_text="""@string{JWS = "Journal of Web Semantics"}
+@comment{No regular bibliographic entry here}
+@preamble{"Preamble only"}
+""",
+    )
+    validator = module.ReferencesBibValidator(module.Config())
+
+    result = validator.validate_target(dataset)
+
+    assert not result.valid
+    assert any(issue.code == "no_bibliographic_entries" for issue in result.errors)
+    assert result.entries_checked == 0
+
+
+def test_comment_only_file_is_rejected_as_no_bibliographic_entries(tmp_path: Path):
+    module = load_module()
+    dataset = make_dataset(
+        tmp_path,
+        bib_text="""% comment one
+% comment two
+""",
+    )
+    validator = module.ReferencesBibValidator(module.Config())
+
+    result = validator.validate_target(dataset)
+
+    assert not result.valid
+    assert any(issue.code == "no_bibliographic_entries" for issue in result.errors)
+
+
+def test_invalid_utf8_file_is_rejected(tmp_path: Path):
+    module = load_module()
+    dataset = make_dataset(tmp_path, bib_text=None)
+    (dataset / "references.bib").write_bytes(b"\xff\xfe\x00")
+    validator = module.ReferencesBibValidator(module.Config())
+
+    result = validator.validate_target(dataset)
+
+    assert not result.valid
+    assert result.errors[0].code == "invalid_utf8"
+
+
+def test_references_bib_directory_is_rejected(tmp_path: Path):
+    module = load_module()
+    dataset = make_dataset(tmp_path, bib_text=None)
+    (dataset / "references.bib").mkdir()
+    validator = module.ReferencesBibValidator(module.Config())
+
+    result = validator.validate_target(dataset)
+
+    assert not result.valid
+    assert result.errors[0].code == "not_a_file"
+
+
+def test_missing_entry_type_after_at_is_rejected(tmp_path: Path):
+    module = load_module()
+    dataset = make_dataset(
+        tmp_path,
+        bib_text="""@{broken,
+  title = {Missing entry type}
+}
+""",
+    )
+    validator = module.ReferencesBibValidator(module.Config())
+
+    result = validator.validate_target(dataset)
+
+    assert not result.valid
+    assert any(issue.code == "missing_entry_type" for issue in result.errors)
+
+
+def test_missing_entry_body_is_rejected(tmp_path: Path):
+    module = load_module()
+    dataset = make_dataset(
+        tmp_path,
+        bib_text="""@article broken,
+  title = {Missing braces}
+""",
+    )
+    validator = module.ReferencesBibValidator(module.Config())
+
+    result = validator.validate_target(dataset)
+
+    assert not result.valid
+    assert any(issue.code == "missing_entry_body" for issue in result.errors)
+
+
+def test_invalid_citation_key_is_rejected(tmp_path: Path):
+    module = load_module()
+    dataset = make_dataset(
+        tmp_path,
+        bib_text="""@article{bad key,
+  title = {Invalid key}
+}
+""",
+    )
+    validator = module.ReferencesBibValidator(module.Config())
+
+    result = validator.validate_target(dataset)
+
+    assert not result.valid
+    assert any(issue.code == "invalid_citation_key" for issue in result.errors)
+
+
+def test_invalid_field_name_is_rejected(tmp_path: Path):
+    module = load_module()
+    dataset = make_dataset(
+        tmp_path,
+        bib_text="""@article{key,
+  1title = {Invalid field name},
+  year = {2024}
+}
+""",
+    )
+    validator = module.ReferencesBibValidator(module.Config())
+
+    result = validator.validate_target(dataset)
+
+    assert not result.valid
+    assert any(issue.code == "invalid_field_name" for issue in result.errors)
+
+
+def test_empty_field_value_is_rejected(tmp_path: Path):
+    module = load_module()
+    dataset = make_dataset(
+        tmp_path,
+        bib_text="""@article{key,
+  title = ,
+  year = {2024}
+}
+""",
+    )
+    validator = module.ReferencesBibValidator(module.Config())
+
+    result = validator.validate_target(dataset)
+
+    assert not result.valid
+    assert any(issue.code == "empty_field_value" for issue in result.errors)
+
+
+def test_unclosed_braced_field_value_is_rejected(tmp_path: Path):
+    module = load_module()
+    dataset = make_dataset(
+        tmp_path,
+        bib_text="""@article{key,
+  title = {Unclosed value,
+  year = {2024}
+}
+""",
+    )
+    validator = module.ReferencesBibValidator(module.Config())
+
+    result = validator.validate_target(dataset)
+
+    assert not result.valid
+    assert any(
+        issue.code in {"unclosed_entry", "invalid_field_value"}
+        for issue in result.errors
+    )
+
+
+def test_empty_concatenation_part_is_rejected(tmp_path: Path):
+    module = load_module()
+    dataset = make_dataset(
+        tmp_path,
+        bib_text="""@article{key,
+  title = {First} # ,
+  year = {2024}
+}
+""",
+    )
+    validator = module.ReferencesBibValidator(module.Config())
+
+    result = validator.validate_target(dataset)
+
+    assert not result.valid
+    assert any(issue.code == "invalid_field_value" for issue in result.errors)
+
+
+def test_duplicate_field_warns_by_default(tmp_path: Path):
+    module = load_module()
+    dataset = make_dataset(
+        tmp_path,
+        bib_text="""@article{key,
+  title = {First},
+  title = {Second},
+  year = {2024}
+}
+""",
+    )
+    validator = module.ReferencesBibValidator(module.Config())
+
+    result = validator.validate_target(dataset)
+
+    assert result.valid
+    assert any(issue.code == "duplicate_field" for issue in result.warnings)
+
+
+def test_strict_promotes_duplicate_field_warning_to_error(tmp_path: Path):
+    module = load_module()
+    dataset = make_dataset(
+        tmp_path,
+        bib_text="""@article{key,
+  title = {First},
+  title = {Second},
+  year = {2024}
+}
+""",
+    )
+    validator = module.ReferencesBibValidator(module.Config(strict=True))
+
+    result = validator.validate_target(dataset)
+
+    assert not result.valid
+    assert any(issue.code == "duplicate_field" for issue in result.errors)
+
+
+def test_empty_special_entry_warns_by_default(tmp_path: Path):
+    module = load_module()
+    dataset = make_dataset(
+        tmp_path,
+        bib_text="""@comment{}
+@article{key,
+  title = {Valid},
+  year = {2024}
+}
+""",
+    )
+    validator = module.ReferencesBibValidator(module.Config())
+
+    result = validator.validate_target(dataset)
+
+    assert result.valid
+    assert any(issue.code == "empty_special_entry" for issue in result.warnings)
+
+
+def test_string_entry_without_equals_is_rejected(tmp_path: Path):
+    module = load_module()
+    dataset = make_dataset(
+        tmp_path,
+        bib_text="""@string{Journal of Web Semantics}
+@article{key,
+  title = {Valid},
+  year = {2024}
+}
+""",
+    )
+    validator = module.ReferencesBibValidator(module.Config())
+
+    result = validator.validate_target(dataset)
+
+    assert not result.valid
+    assert any(issue.code == "invalid_string_entry" for issue in result.errors)
+
+
+def test_invalid_string_macro_name_is_rejected(tmp_path: Path):
+    module = load_module()
+    dataset = make_dataset(
+        tmp_path,
+        bib_text="""@string{1JWS = "Journal of Web Semantics"}
+@article{key,
+  title = {Valid},
+  year = {2024}
+}
+""",
+    )
+    validator = module.ReferencesBibValidator(module.Config())
+
+    result = validator.validate_target(dataset)
+
+    assert not result.valid
+    assert any(issue.code == "invalid_string_macro" for issue in result.errors)
+
+
+def test_invalid_string_value_is_rejected(tmp_path: Path):
+    module = load_module()
+    dataset = make_dataset(
+        tmp_path,
+        bib_text="""@string{JWS = [Journal of Web Semantics]}
+@article{key,
+  title = {Valid},
+  year = {2024}
+}
+""",
+    )
+    validator = module.ReferencesBibValidator(module.Config())
+
+    result = validator.validate_target(dataset)
+
+    assert not result.valid
+    assert any(issue.code == "invalid_string_value" for issue in result.errors)
+
+
+def test_fail_on_warning_returns_one_without_promoting_warning(tmp_path: Path, capsys):
+    module = load_module()
+    dataset = make_dataset(
+        tmp_path,
+        bib_text="""@customtype{key,
+  title = {Unknown type but syntactically valid}
+}
+""",
+    )
+
+    exit_code = module.main([str(dataset), "--fail-on-warning"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    assert "WARNING" in captured.out
+    assert "ERROR" not in captured.out
+
+
+def test_all_discovers_direct_dataset_folders(tmp_path: Path, capsys):
+    module = load_module()
+    dataset_a = make_dataset(tmp_path, VALID_BIB)
+    dataset_b = tmp_path / "models" / "without-bib"
+    dataset_b.mkdir(parents=True)
+    (dataset_b / "metadata.yaml").write_text("title: Without Bib\n", encoding="utf-8")
+
+    exit_code = module.main(["--all", "--models-dir", str(tmp_path / "models")])
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert "example-model" in captured.out
+    assert "without-bib" in captured.out
+    assert "SKIPPED" in captured.out
+    assert dataset_a.name in captured.out
+
+
+def test_all_and_explicit_targets_are_mutually_exclusive(tmp_path: Path, capsys):
+    module = load_module()
+    dataset = make_dataset(tmp_path)
+
+    exit_code = module.main(
+        [str(dataset), "--all", "--models-dir", str(tmp_path / "models")]
+    )
+    captured = capsys.readouterr()
+
+    assert exit_code == 2
+    assert "Use either --all or explicit" in captured.err
+
+
+def test_json_output_reports_warnings_separately(tmp_path: Path, capsys):
+    module = load_module()
+    dataset = make_dataset(
+        tmp_path,
+        bib_text="""@customtype{key,
+  title = {Unknown type but syntactically valid}
+}
+""",
+    )
+
+    exit_code = module.main([str(dataset), "--format", "json"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    payload = json.loads(captured.out)
+    assert payload[0]["errors"] == []
+    assert payload[0]["warnings"][0]["code"] == "unknown_entry_type"
+
+
+def test_issue_locations_are_reported_for_field_errors(tmp_path: Path):
+    module = load_module()
+    dataset = make_dataset(
+        tmp_path,
+        bib_text="""@article{key,
+  title {Missing equals},
+  year = {2024}
+}
+""",
+    )
+    validator = module.ReferencesBibValidator(module.Config())
+
+    result = validator.validate_target(dataset)
+    issue = next(
+        issue for issue in result.errors if issue.code == "missing_field_assignment"
+    )
+
+    assert issue.line is not None and issue.line >= 2
+    assert issue.column is not None and issue.column >= 1
+
+
+def test_current_directory_dataset_is_used_when_no_target_is_given(
+    tmp_path: Path, monkeypatch, capsys
+):
+    module = load_module()
+    dataset = make_dataset(tmp_path)
+    monkeypatch.chdir(dataset)
+
+    exit_code = module.main([])
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert "VALID" in captured.out
+    assert "references.bib" in captured.out
+
+
+def test_current_directory_without_target_is_reported_as_usage_error(
+    tmp_path: Path, monkeypatch, capsys
+):
+    module = load_module()
+    monkeypatch.chdir(tmp_path)
+
+    exit_code = module.main([])
+    captured = capsys.readouterr()
+
+    assert exit_code == 2
+    assert "No target provided" in captured.err
+
+
+def test_bachelorsthesis_and_masterthesis_are_known_entry_types(tmp_path: Path):
+    module = load_module()
+    dataset = make_dataset(
+        tmp_path,
+        bib_text="""@bachelorsthesis{bsc2024,
+  author = {Example, Alice},
+  title = {Bachelor thesis example},
+  school = {Example University},
+  year = {2024}
+}
+
+@masterthesis{msc2024,
+  author = {Example, Bob},
+  title = {Master thesis example},
+  school = {Example University},
+  year = {2024}
+}
+""",
+    )
+    validator = module.ReferencesBibValidator(module.Config())
+
+    result = validator.validate_target(dataset)
+
+    assert result.valid
+    assert result.entries_checked == 2
+    assert not any(issue.code == "unknown_entry_type" for issue in result.warnings)
+
+
+def test_braced_value_accepts_literal_quotes_and_latex_macros(tmp_path: Path):
+    module = load_module()
+    dataset = make_dataset(
+        tmp_path,
+        bib_text=r"""@phdthesis{moreira2019semiotics,
+  title = {SEMIoTICS: Semantic Model-driven Development for IoT Interoperability of Emergency Services},
+  author = {Moreira, {Jo{\~a}o Luiz}},
+  year = {2019},
+  abstract = {This abstract contains "quoted text", drivers{\textquoteright} vital signs, JSON-LD examples, and contributions:{\textbullet{} Improved IoT Semantic Interoperability;\textbullet{} Improved Situation Identification}.},
+  language = {English}
+}
+""",
+    )
+    validator = module.ReferencesBibValidator(module.Config())
+
+    result = validator.validate_target(dataset)
+
+    assert result.valid
+    assert result.entries_checked == 1
+    assert result.errors == []
+
+
+def test_braced_value_accepts_repository_style_long_abstract_regression(tmp_path: Path):
+    module = load_module()
+    dataset = make_dataset(
+        tmp_path,
+        bib_text=r"""@phdthesis{moreira2019semiotics,
+  title        = {SEMIoTICS: Semantic Model-driven Development for IoT Interoperability of Emergency Services: Improving the Semantic Interoperability of IoT Early Warning Systems},
+  author       = {Moreira, {Jo{\~a}o Luiz}},
+  year         = 2019,
+  abstract     = {Disaster Risk Reduction (DRR) is a systematic approach to analyze potential disasters and reduce their occurrence rate and possible impact. The main DRR component is an Early Warning System (EWS), which is a distributed information system that is able to monitor the physical world and issue warnings if abnormal situations occur. In this case study, accident risks are assessed by monitoring two types of data, namely (1) the drivers{\textquoteright} vital signs with electrocardiogram (ECG), and (2) the trucks{\textquoteright} position, speed and acceleration. The most important contributions of this thesis are:\textbullet{} Improved IoT Semantic Interoperability;\textbullet{} Improved Situation Identification;\textbullet{} Interoperability reference for disaster services.},
+  language     = {English}
+}
+""",
+    )
+    validator = module.ReferencesBibValidator(module.Config())
+
+    result = validator.validate_target(dataset)
+
+    assert result.valid
+    assert result.entries_checked == 1
+    assert result.errors == []
+
+
+def test_extra_closing_brace_in_field_value_is_still_rejected(tmp_path: Path):
+    module = load_module()
+    dataset = make_dataset(
+        tmp_path,
+        bib_text=r"""@inproceedings{andrade2023integracao,
+  title = {Integra\c{c}\~{a}o de Dados de Publica\c{c}\~{o}es Cient\'{\i}ficas usando uma Abordagem baseada em Ontologias}},
+  author = {Example, Alice},
+  year = 2023
+}
+""",
+    )
+    validator = module.ReferencesBibValidator(module.Config())
+
+    result = validator.validate_target(dataset)
+
+    assert not result.valid
+    assert any(
+        issue.code in {"unexpected_text", "invalid_field_value"}
+        for issue in result.errors
+    )
+
+
+def test_trailing_dot_in_field_name_is_still_rejected(tmp_path: Path):
+    module = load_module()
+    dataset = make_dataset(
+        tmp_path,
+        bib_text="""@article{silva2012architecture,
+  title = {IT architecture from the service continuity perspective},
+  author. = {Example, Alice},
+  journal. = {Journal of Information Security Research},
+  year. = 2012
+}
+""",
+    )
+    validator = module.ReferencesBibValidator(module.Config())
+
+    result = validator.validate_target(dataset)
+
+    assert not result.valid
+    assert sum(issue.code == "invalid_field_name" for issue in result.errors) == 3
+
+
+def test_at_sign_inside_full_line_comment_is_ignored(tmp_path: Path):
+    module = load_module()
+    dataset = make_dataset(
+        tmp_path,
+        bib_text="""% See also @not_an_entry in this comment.
+@article{commentcase,
+  title = {A valid title},
+  author = {Example, Alice},
+  year = 2024
+}
+% Another comment mentioning @misc{ignored}.
+""",
+    )
+    validator = module.ReferencesBibValidator(module.Config())
+
+    result = validator.validate_target(dataset)
+
+    assert result.valid
+    assert result.entries_checked == 1
+    assert result.errors == []
+
+
+def test_literal_unpaired_double_quote_inside_braced_value_before_comment_is_valid(
+    tmp_path: Path,
+):
+    module = load_module()
+    dataset = make_dataset(
+        tmp_path,
+        bib_text="""@article{quotedbrace,
+  title = {A title with a literal " character}, % top-level field comment
+  author = {Example, Alice},
+  year = 2024
+}
+""",
+    )
+    validator = module.ReferencesBibValidator(module.Config())
+
+    result = validator.validate_target(dataset)
+
+    assert result.valid
+    assert result.entries_checked == 1
+    assert result.errors == []
+
+
+def test_escaped_literal_braces_inside_braced_value_are_accepted(tmp_path: Path):
+    module = load_module()
+    dataset = make_dataset(
+        tmp_path,
+        bib_text=r"""@masterthesis{ferreira2013ontologia,
+  title = {{Ontologia de Emerg{\^{e}}ncia no Apoio {\`{a}} Gera{\c{c}}{\{a}}o de Solu{\c{c}}{\{o}}es de Variabilidade de Planos de Emerg{\^{e}}ncia}},
+  author = {Ferreira, Maria In{\^{e}}s Garcia Bosc{\'{a}}},
+  year = 2013,
+  school = {Universidade Federal do Rio De Janeiro}
+}
+""",
+    )
+    validator = module.ReferencesBibValidator(module.Config())
+
+    result = validator.validate_target(dataset)
+
+    assert result.valid
+    assert result.entries_checked == 1
+    assert result.errors == []
+
+
+def test_repository_ferreira_regression_with_escaped_literal_braces_is_valid(
+    tmp_path: Path,
+):
+    module = load_module()
+    dataset = make_dataset(
+        tmp_path,
+        bib_text=r"""@inproceedings{ferreira2015ontoemergeplan,
+  title        = {OntoEmergePlan: variability of emergency plans supported by a domain ontology},
+  author       = {Maria I. G. B. Ferreira and Jo{\~{a}}o L. R. Moreira and Maria Luiza Machado Campos and Bernardo F. B. Braga and Tiago Prince Sales and others},
+  year         = 2015,
+  booktitle    = {12th Proceedings of the International Conference on Information Systems for Crisis Response and Management, Krystiansand, Norway, May 24-27, 2015},
+  publisher    = {{ISCRAM} Association},
+  url          = {http://idl.iscram.org/files/mariaigbferreira/2015/1184\%5FMariaI.G.B.Ferreira\%5Fetal2015.pdf},
+  editor       = {Leysia Palen and Monika B{\"{u}}scher and Tina Comes and Amanda Lee Hughes},
+  timestamp    = {Thu, 12 Mar 2020 11:29:43 +0100},
+  biburl       = {https://dblp.org/rec/conf/iscram/FerreiraMCBSCB15.bib},
+  bibsource    = {dblp computer science bibliography, https://dblp.org}
+}
+@masterthesis{ferreira2013ontologia,
+  title        = {{Ontologia de Emerg{\^{e}}ncia no Apoio {\`{a}} Gera{\c{c}}{\{a}}o de Solu{\c{c}}{\{o}}es de Variabilidade de Planos de Emerg{\^{e}}ncia}},
+  author       = {Ferreira, Maria In{\^{e}}s Garcia Bosc{\'{a}}},
+  year         = 2013,
+  pages        = 175,
+  url          = {http://objdig.ufrj.br/15/teses/867022.pdf},
+  institution  = {Universidade Federal do Rio De Janeiro},
+  type         = {M.Sc. Dissertation}
+}
+""",
+    )
+    validator = module.ReferencesBibValidator(module.Config())
+
+    result = validator.validate_target(dataset)
+
+    assert result.valid
+    assert result.entries_checked == 2
+    assert result.errors == []

--- a/scripts/validate-references-bib.md
+++ b/scripts/validate-references-bib.md
@@ -1,0 +1,188 @@
+# references.bib validation
+
+This document describes `scripts/validate_references_bib.py`, a lightweight validator for optional `references.bib` files in OntoUML/UFO Catalog model folders.
+
+The validator is intended for repository maintenance and CI/workflow preflight checks before metadata generation. It provides a basic BibTeX/BibLaTeX syntax check without introducing a new dependency.
+
+## Why this validator exists
+
+`references.bib` is optional in the catalog submission process. When present, however, it should at least be readable and structurally valid enough to avoid broken bibliographic metadata or failing downstream processing.
+
+The validator is deliberately conservative in scope:
+
+- it checks basic BibTeX/BibLaTeX structure;
+- it detects common syntax errors;
+- it accepts missing `references.bib` files by default because the file is optional;
+- it does not enforce complete bibliographic semantics per entry type.
+
+## Typical usage
+
+Validate one dataset folder:
+
+```bash
+python scripts/validate_references_bib.py models/example-model
+```
+
+Validate several dataset folders:
+
+```bash
+python scripts/validate_references_bib.py models/example-a models/example-b
+```
+
+Validate a `references.bib` file directly:
+
+```bash
+python scripts/validate_references_bib.py models/example-model/references.bib
+```
+
+Validate all direct dataset folders under `models/`:
+
+```bash
+python scripts/validate_references_bib.py --all --models-dir models
+```
+
+Return machine-readable JSON:
+
+```bash
+python scripts/validate_references_bib.py models/example-model --format json
+```
+
+Require `references.bib` to exist:
+
+```bash
+python scripts/validate_references_bib.py models/example-model --require
+```
+
+Promote warnings to errors:
+
+```bash
+python scripts/validate_references_bib.py models/example-model --strict
+```
+
+Fail on warnings without changing their displayed severity:
+
+```bash
+python scripts/validate_references_bib.py models/example-model --fail-on-warning
+```
+
+## Exit codes
+
+```text
+0  no validation errors were found
+1  validation errors were found
+2  command-line or discovery problem prevented normal execution
+```
+
+Warnings do not affect the exit code unless `--strict` or `--fail-on-warning` is used.
+
+## What is checked
+
+The validator checks that a present `references.bib` file:
+
+- is a regular file;
+- is valid UTF-8 text;
+- is not empty;
+- contains at least one regular bibliographic entry;
+- uses entries starting with `@`;
+- has an entry type followed by `{...}` or `(...)`;
+- has balanced entry delimiters;
+- has citation keys for regular entries;
+- has valid citation-key lexical form;
+- has at least one field per regular entry;
+- uses field assignments in the form `field = value`;
+- has non-empty field values;
+- accepts top-level `%` comments between fields;
+- ignores `@` markers inside full-line `%` comments outside entries;
+- accepts backslash-escaped literal braces such as `\{` and `\}` inside braced LaTeX values;
+- does not reuse the same citation key twice.
+
+The validator also recognizes `@string`, `@preamble`, and `@comment` as special entries. `@string` assignments are checked for a valid macro name and a basic value shape.
+
+## Warning-level checks
+
+The following are warnings by default:
+
+- unknown entry types;
+- duplicate fields inside the same entry;
+- empty special entries.
+
+Use `--strict` to promote these warnings to errors.
+
+## What is intentionally not checked
+
+The validator does not require specific mandatory fields per entry type. For example, it does not require every `@article` to include `author`, `title`, `journal`, and `year`.
+
+This is intentional. Such semantic validation would require stronger policy decisions and might incorrectly reject existing or acceptable bibliography styles. The current validator is meant as a basic compliance check, not as a full BibTeX processor.
+
+## Examples
+
+Valid minimal entry:
+
+```bibtex
+@article{sales2023catalog,
+  author = {Sales, Tiago Prince and Barcelos, Pedro Paulo F.},
+  title = {A FAIR catalog of ontology-driven conceptual models},
+  journal = {Data & Knowledge Engineering},
+  year = {2023},
+  doi = {10.1016/j.datak.2023.102210}
+}
+```
+
+Valid entry with comments between fields:
+
+```bibtex
+@article{commented,
+  title = {Commented entry}, % comment after a field
+  % full-line comment between fields
+  year = {2024}
+}
+```
+
+Valid full-line comment outside entries:
+
+```bibtex
+% See also @not-an-entry in a comment.
+@article{commented-outside,
+  title = {Commented outside},
+  year = {2024}
+}
+```
+
+Invalid: missing `@`:
+
+```bibtex
+article{broken,
+  title = {Wrong start}
+}
+```
+
+Invalid: unclosed entry:
+
+```bibtex
+@article{broken,
+  title = {Missing closing brace}
+```
+
+Invalid: missing field assignment:
+
+```bibtex
+@article{broken,
+  title {Missing equals}
+}
+```
+
+## Suggested use in future automation
+
+Before running metadata generation for a new model folder, call:
+
+```bash
+python scripts/validate_references_bib.py models/example-model
+```
+
+This treats `references.bib` as optional but validates it when present.
+
+For a stricter future mode in which new submissions must always include references:
+
+```bash
+python scripts/validate_references_bib.py models/example-model --require
+```

--- a/scripts/validate_references_bib.py
+++ b/scripts/validate_references_bib.py
@@ -1,0 +1,1165 @@
+"""Validate optional references.bib files for OntoUML/UFO Catalog datasets.
+
+The validator is intentionally lightweight and dependency-free. It performs a
+basic BibTeX/BibLaTeX syntax check suitable for repository maintenance and
+CI/workflow preflight checks. It does not try to replace a full BibTeX processor.
+
+Typical usage from the repository root:
+
+    python scripts/validate_references_bib.py models/amaral2019rot
+    python scripts/validate_references_bib.py models/a models/b
+    python scripts/validate_references_bib.py --all --models-dir models
+    python scripts/validate_references_bib.py models/example/references.bib
+    python scripts/validate_references_bib.py --all --format json
+
+Exit codes:
+
+    0  no validation errors were found
+    1  validation errors were found
+    2  command-line or discovery problem prevented normal execution
+
+Missing references.bib files are accepted by default because references.bib is an
+optional catalog input file. Use --require to report missing files as errors.
+Warnings do not affect the exit code unless --fail-on-warning or --strict is used.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Literal, Optional, Sequence
+
+
+Severity = Literal["error", "warning"]
+
+
+class ReferencesBibError(RuntimeError):
+    """Raised when validation cannot continue because of a tool/setup problem."""
+
+
+@dataclass(frozen=True)
+class Issue:
+    """One validation or lint issue."""
+
+    severity: Severity
+    code: str
+    dataset_path: str
+    references_path: Optional[str]
+    entry_key: Optional[str]
+    message: str
+    suggestion: Optional[str] = None
+    line: Optional[int] = None
+    column: Optional[int] = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass
+class ValidationResult:
+    """Validation result for one dataset folder or references.bib file."""
+
+    dataset_path: Path
+    references_path: Path
+    present: bool
+    issues: list[Issue] = field(default_factory=list)
+    entries_checked: int = 0
+
+    @property
+    def errors(self) -> list[Issue]:
+        return [issue for issue in self.issues if issue.severity == "error"]
+
+    @property
+    def warnings(self) -> list[Issue]:
+        return [issue for issue in self.issues if issue.severity == "warning"]
+
+    @property
+    def valid(self) -> bool:
+        return not self.errors
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "dataset_path": str(self.dataset_path),
+            "references_path": str(self.references_path),
+            "present": self.present,
+            "valid": self.valid,
+            "entries_checked": self.entries_checked,
+            "errors": [issue.to_dict() for issue in self.errors],
+            "warnings": [issue.to_dict() for issue in self.warnings],
+        }
+
+
+@dataclass(frozen=True)
+class Config:
+    """Runtime configuration."""
+
+    require: bool = False
+    strict: bool = False
+    fail_on_warning: bool = False
+
+
+@dataclass(frozen=True)
+class ParsedEntry:
+    """A single parsed BibTeX entry."""
+
+    entry_type: str
+    body: str
+    start_index: int
+    start_line: int
+    start_column: int
+    body_start_index: int
+    body_start_line: int
+    body_start_column: int
+    key: Optional[str] = None
+
+
+# Standard BibTeX plus common BibLaTeX entry types. Unknown types are warnings by
+# default, not errors, so the validator remains compatible with future or local
+# entry-type extensions.
+KNOWN_ENTRY_TYPES: set[str] = {
+    "article",
+    "artwork",
+    "audio",
+    "bibnote",
+    "book",
+    "bookinbook",
+    "booklet",
+    "collection",
+    "conference",
+    "dataset",
+    "electronic",
+    "image",
+    "inbook",
+    "incollection",
+    "inproceedings",
+    "inreference",
+    "manual",
+    "bachelorsthesis",
+    "mastersthesis",
+    "masterthesis",
+    "misc",
+    "movie",
+    "music",
+    "mvbook",
+    "mvcollection",
+    "mvproceedings",
+    "mvreference",
+    "online",
+    "patent",
+    "periodical",
+    "phdthesis",
+    "proceedings",
+    "reference",
+    "report",
+    "set",
+    "software",
+    "suppbook",
+    "suppcollection",
+    "suppperiodical",
+    "techreport",
+    "thesis",
+    "unpublished",
+    "video",
+    "www",
+    "xdata",
+}
+
+SPECIAL_ENTRY_TYPES: set[str] = {"comment", "preamble", "string"}
+
+ENTRY_TYPE_RE = re.compile(r"[A-Za-z][A-Za-z0-9_-]*")
+FIELD_NAME_RE = re.compile(r"[A-Za-z][A-Za-z0-9_-]*")
+CITATION_KEY_RE = re.compile(r"^[^,\s{}()=\"]+$")
+
+
+def line_col(text: str, index: int) -> tuple[int, int]:
+    """Return one-based line and column for a zero-based text index."""
+
+    line = text.count("\n", 0, index) + 1
+    line_start = text.rfind("\n", 0, index) + 1
+    return line, index - line_start + 1
+
+
+def line_col_in_entry_body(entry: ParsedEntry, body_index: int) -> tuple[int, int]:
+    """Return one-based file line/column for an offset in an entry body."""
+
+    bounded_index = max(0, min(body_index, len(entry.body)))
+    relative_line, relative_column = line_col(entry.body, bounded_index)
+    if relative_line == 1:
+        return entry.body_start_line, entry.body_start_column + relative_column - 1
+    return entry.body_start_line + relative_line - 1, relative_column
+
+
+def remove_top_level_line_comments(text: str) -> tuple[str, list[int]]:
+    """Remove top-level BibTeX comments while preserving an offset map.
+
+    The validator accepts comments between fields, e.g. after a comma. It does
+    not strip percent signs inside braced or quoted values, where they may be
+    intentional content such as ``title = {100\\% coverage}``.
+
+    Backslash-escaped braces are treated as brace-like LaTeX content for
+    balancing purposes. This accepts common constructs such as ``{\\{a}}`` in
+    exported BibTeX while still preserving original offsets.
+    """
+
+    output: list[str] = []
+    original_offsets: list[int] = []
+    depth_brace = 0
+    depth_paren = 0
+    in_quote = False
+    escaped = False
+    index = 0
+
+    while index < len(text):
+        char = text[index]
+
+        if escaped:
+            output.append(char)
+            original_offsets.append(index)
+            escaped = False
+            index += 1
+            continue
+
+        if char == "\\":
+            output.append(char)
+            original_offsets.append(index)
+            next_char = text[index + 1] if index + 1 < len(text) else ""
+            if not in_quote and next_char in "{}":
+                output.append(next_char)
+                original_offsets.append(index + 1)
+                if next_char == "{":
+                    depth_brace += 1
+                elif next_char == "}" and depth_brace > 0:
+                    depth_brace -= 1
+                index += 2
+                continue
+            escaped = True
+            index += 1
+            continue
+
+        if not in_quote and depth_brace == 0 and depth_paren == 0 and char == "%":
+            while index < len(text) and text[index] != "\n":
+                index += 1
+            continue
+
+        if char == '"' and depth_brace == 0 and depth_paren == 0:
+            in_quote = not in_quote
+        elif not in_quote:
+            if char == "{":
+                depth_brace += 1
+            elif char == "}" and depth_brace > 0:
+                depth_brace -= 1
+            elif char == "(":
+                depth_paren += 1
+            elif char == ")" and depth_paren > 0:
+                depth_paren -= 1
+
+        output.append(char)
+        original_offsets.append(index)
+        index += 1
+
+    return "".join(output), original_offsets
+
+
+def original_offset_from_cleaned(
+    cleaned_offset: int, original_offsets: list[int]
+) -> int:
+    """Map an offset in comment-stripped text back to the original body."""
+
+    if not original_offsets:
+        return 0
+    if cleaned_offset >= len(original_offsets):
+        return original_offsets[-1] + 1
+    return original_offsets[cleaned_offset]
+
+
+def is_outside_segment_ignorable(segment: str) -> bool:
+    """Return whether text outside entries is whitespace or full-line comments."""
+
+    for line in segment.splitlines():
+        stripped = line.strip()
+        if stripped and not stripped.startswith("%"):
+            return False
+    return True
+
+
+def is_at_in_full_line_comment(text: str, at_index: int) -> bool:
+    """Return whether an @ marker occurs inside an outside full-line comment."""
+
+    line_start = text.rfind("\n", 0, at_index) + 1
+    prefix = text[line_start:at_index].lstrip()
+    return prefix.startswith("%")
+
+
+def find_next_entry_marker(text: str, start: int) -> int:
+    """Return the next @ marker that is not inside a full-line comment."""
+
+    index = start
+    while True:
+        at_index = text.find("@", index)
+        if at_index == -1:
+            return -1
+        if not is_at_in_full_line_comment(text, at_index):
+            return at_index
+        index = at_index + 1
+
+
+def split_top_level(text: str, separator: str = ",") -> list[tuple[str, int]]:
+    """Split text on top-level separators, preserving segment start offsets.
+
+    In BibTeX, quoted strings and braced values are both valid value forms. A
+    double quote inside a braced value is literal text, not the start of a quoted
+    string. Therefore, quote tracking is only activated at top level. This avoids
+    false positives for long abstracts containing ordinary quotation marks.
+
+    Backslash-escaped braces are treated as brace-like LaTeX content so values
+    such as ``{\\{a}}`` remain balanced during top-level splitting.
+    """
+
+    parts: list[tuple[str, int]] = []
+    depth_brace = 0
+    depth_paren = 0
+    in_quote = False
+    escaped = False
+    start = 0
+    index = 0
+
+    while index < len(text):
+        char = text[index]
+        if escaped:
+            escaped = False
+            index += 1
+            continue
+        if char == "\\":
+            next_char = text[index + 1] if index + 1 < len(text) else ""
+            if not in_quote and next_char in "{}":
+                if next_char == "{":
+                    depth_brace += 1
+                elif next_char == "}" and depth_brace > 0:
+                    depth_brace -= 1
+                index += 2
+                continue
+            escaped = True
+            index += 1
+            continue
+        if char == '"' and depth_brace == 0 and depth_paren == 0:
+            in_quote = not in_quote
+            index += 1
+            continue
+        if in_quote:
+            index += 1
+            continue
+        if char == "{":
+            depth_brace += 1
+        elif char == "}" and depth_brace > 0:
+            depth_brace -= 1
+        elif char == "(":
+            depth_paren += 1
+        elif char == ")" and depth_paren > 0:
+            depth_paren -= 1
+        elif (
+            char == separator and depth_brace == 0 and depth_paren == 0 and not in_quote
+        ):
+            parts.append((text[start:index], start))
+            start = index + 1
+        index += 1
+
+    parts.append((text[start:], start))
+    return parts
+
+
+def find_matching_delimiter(
+    text: str, opener_index: int, opener: str, closer: str
+) -> int:
+    """Return the index of the closing delimiter for a BibTeX entry body.
+
+    Quote tracking is only activated at the first nesting level of the entry.
+    Literal quotation marks inside braced field values must not hide the closing
+    brace of that field or of the entry.
+
+    Backslash-escaped braces are treated as brace-like LaTeX content for
+    balancing purposes. This avoids prematurely closing entries that contain
+    exported fragments such as ``{\\{o}}`` in a braced title.
+    """
+
+    depth = 1
+    in_quote = False
+    escaped = False
+    index = opener_index + 1
+
+    while index < len(text):
+        char = text[index]
+        if escaped:
+            escaped = False
+            index += 1
+            continue
+        if char == "\\":
+            next_char = text[index + 1] if index + 1 < len(text) else ""
+            if not in_quote and next_char in "{}":
+                if next_char == opener:
+                    depth += 1
+                elif next_char == closer:
+                    depth -= 1
+                    if depth == 0:
+                        return index + 1
+                index += 2
+                continue
+            escaped = True
+            index += 1
+            continue
+        if char == '"' and depth == 1:
+            in_quote = not in_quote
+            index += 1
+            continue
+        if in_quote:
+            index += 1
+            continue
+        if char == opener:
+            depth += 1
+        elif char == closer:
+            depth -= 1
+            if depth == 0:
+                return index
+        index += 1
+
+    raise ValueError("Unclosed BibTeX entry.")
+
+
+def braced_value_has_valid_shape(token: str) -> bool:
+    """Return whether a braced BibTeX value is balanced and fully enclosed.
+
+    Quotation marks inside a braced value are literal text. Backslash-escaped
+    braces are treated as brace-like LaTeX content for balancing purposes, so
+    exported constructs such as ``{\\{a}}`` do not prematurely close the value.
+    """
+
+    if not (token.startswith("{") and token.endswith("}") and len(token) >= 2):
+        return False
+
+    depth = 0
+    escaped = False
+    index = 0
+    while index < len(token):
+        char = token[index]
+        if escaped:
+            escaped = False
+            index += 1
+            continue
+        if char == "\\":
+            next_char = token[index + 1] if index + 1 < len(token) else ""
+            if next_char in "{}":
+                if next_char == "{":
+                    depth += 1
+                elif next_char == "}":
+                    depth -= 1
+                    if depth == 0 and index + 1 != len(token) - 1:
+                        return False
+                    if depth < 0:
+                        return False
+                index += 2
+                continue
+            escaped = True
+            index += 1
+            continue
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0 and index != len(token) - 1:
+                return False
+            if depth < 0:
+                return False
+        index += 1
+    return depth == 0 and not escaped
+
+
+class ReferencesBibValidator:
+    """Validate references.bib files using a lightweight BibTeX parser."""
+
+    def __init__(self, config: Config) -> None:
+        self.config = config
+
+    def validate_target(self, target: Path) -> ValidationResult:
+        dataset_path, references_path = self.references_path_for_target(target)
+        result = ValidationResult(
+            dataset_path=dataset_path,
+            references_path=references_path,
+            present=references_path.exists(),
+        )
+
+        if not references_path.exists():
+            if self.config.require:
+                self.add_issue(
+                    result,
+                    "error",
+                    "missing_references_bib",
+                    None,
+                    "Missing required references.bib file.",
+                    "Create references.bib or run without --require when bibliography data is optional.",
+                )
+            return result
+
+        if not references_path.is_file():
+            self.add_issue(
+                result,
+                "error",
+                "not_a_file",
+                None,
+                "references.bib path exists but is not a file.",
+                "Replace it with a UTF-8 BibTeX file.",
+            )
+            return result
+
+        try:
+            text = references_path.read_text(encoding="utf-8")
+        except UnicodeDecodeError as exc:
+            self.add_issue(
+                result,
+                "error",
+                "invalid_utf8",
+                None,
+                f"references.bib is not valid UTF-8 text: {exc}.",
+                "Save the file as UTF-8.",
+            )
+            return result
+        except OSError as exc:
+            raise ReferencesBibError(
+                f"Could not read {references_path}: {exc}"
+            ) from exc
+
+        self.validate_text(text, result)
+        return result
+
+    def references_path_for_target(self, target: Path) -> tuple[Path, Path]:
+        if target.is_dir():
+            return target, target / "references.bib"
+
+        if target.name == "references.bib":
+            return target.parent, target
+
+        if target.exists():
+            raise ReferencesBibError(
+                f"Expected a dataset folder or references.bib file, got: {target}"
+            )
+
+        # If the path does not exist and looks like a file path, report it through
+        # the normal missing-file path; otherwise treat it as a dataset folder.
+        if target.suffix:
+            return target.parent, target
+        return target, target / "references.bib"
+
+    def validate_text(self, text: str, result: ValidationResult) -> None:
+        if not text.strip():
+            self.add_issue(
+                result,
+                "error",
+                "empty_file",
+                None,
+                "references.bib is empty.",
+                "Remove the optional file or add at least one bibliographic entry.",
+            )
+            return
+
+        try:
+            entries = self.parse_entries(text, result)
+        except ValueError as exc:
+            line, column = line_col(text, len(text))
+            self.add_issue(
+                result,
+                "error",
+                "unclosed_entry",
+                None,
+                str(exc),
+                "Check that every @entry{...} or @entry(...) has a matching closing delimiter.",
+                line=line,
+                column=column,
+            )
+            return
+
+        seen_keys: dict[str, ParsedEntry] = {}
+        regular_entries = 0
+
+        for entry in entries:
+            if entry.entry_type in SPECIAL_ENTRY_TYPES:
+                self.validate_special_entry(entry, result)
+                continue
+
+            regular_entries += 1
+            self.validate_regular_entry(entry, result)
+
+            if entry.key:
+                lowered_key = entry.key.lower()
+                previous = seen_keys.get(lowered_key)
+                if previous is not None:
+                    self.add_issue(
+                        result,
+                        "error",
+                        "duplicate_key",
+                        entry.key,
+                        f"Duplicate BibTeX citation key {entry.key!r}.",
+                        "Use unique citation keys within references.bib.",
+                        line=entry.start_line,
+                        column=entry.start_column,
+                    )
+                else:
+                    seen_keys[lowered_key] = entry
+
+        result.entries_checked = regular_entries
+
+        if regular_entries == 0:
+            self.add_issue(
+                result,
+                "error",
+                "no_bibliographic_entries",
+                None,
+                "references.bib does not contain any bibliographic entry.",
+                "Add at least one regular entry such as @article, @book, @inproceedings, or @misc.",
+            )
+
+    def parse_entries(self, text: str, result: ValidationResult) -> list[ParsedEntry]:
+        entries: list[ParsedEntry] = []
+        index = 0
+
+        while True:
+            at_index = find_next_entry_marker(text, index)
+            if at_index == -1:
+                trailing = text[index:]
+                if not is_outside_segment_ignorable(trailing):
+                    line, column = line_col(text, index)
+                    self.add_issue(
+                        result,
+                        "error",
+                        "unexpected_text",
+                        None,
+                        "Unexpected text outside a BibTeX entry.",
+                        "Keep only whitespace or full-line comments outside @entry blocks.",
+                        line=line,
+                        column=column,
+                    )
+                break
+
+            leading = text[index:at_index]
+            if not is_outside_segment_ignorable(leading):
+                line, column = line_col(text, index)
+                self.add_issue(
+                    result,
+                    "error",
+                    "unexpected_text",
+                    None,
+                    "Unexpected text outside a BibTeX entry.",
+                    "Keep only whitespace or full-line comments outside @entry blocks.",
+                    line=line,
+                    column=column,
+                )
+
+            type_start = at_index + 1
+            match = ENTRY_TYPE_RE.match(text, type_start)
+            if match is None:
+                line, column = line_col(text, at_index)
+                self.add_issue(
+                    result,
+                    "error",
+                    "missing_entry_type",
+                    None,
+                    "Expected an entry type after '@'.",
+                    "Use syntax such as @article{key, ...}.",
+                    line=line,
+                    column=column,
+                )
+                index = at_index + 1
+                continue
+
+            entry_type = match.group(0).lower()
+            cursor = match.end()
+            while cursor < len(text) and text[cursor].isspace():
+                cursor += 1
+
+            if cursor >= len(text) or text[cursor] not in "{(":
+                line, column = line_col(text, cursor)
+                self.add_issue(
+                    result,
+                    "error",
+                    "missing_entry_body",
+                    None,
+                    f"Expected '{{' or '(' after @{entry_type}.",
+                    "Use syntax such as @article{key, ...}.",
+                    line=line,
+                    column=column,
+                )
+                index = cursor + 1
+                continue
+
+            opener = text[cursor]
+            closer = "}" if opener == "{" else ")"
+            try:
+                closing_index = find_matching_delimiter(text, cursor, opener, closer)
+            except ValueError:
+                raise ValueError(
+                    f"Unclosed @{entry_type} entry starting at line {line_col(text, at_index)[0]}."
+                )
+
+            body = text[cursor + 1 : closing_index]
+            line, column = line_col(text, at_index)
+            body_line, body_column = line_col(text, cursor + 1)
+            entry = ParsedEntry(
+                entry_type=entry_type,
+                body=body,
+                start_index=at_index,
+                start_line=line,
+                start_column=column,
+                body_start_index=cursor + 1,
+                body_start_line=body_line,
+                body_start_column=body_column,
+            )
+            entries.append(entry)
+            index = closing_index + 1
+
+        return entries
+
+    def validate_special_entry(
+        self, entry: ParsedEntry, result: ValidationResult
+    ) -> None:
+        body = entry.body.strip()
+        if not body:
+            self.add_issue(
+                result,
+                "warning",
+                "empty_special_entry",
+                None,
+                f"@{entry.entry_type} entry is empty.",
+                "Remove the empty entry or provide content.",
+                line=entry.start_line,
+                column=entry.start_column,
+            )
+            return
+
+        if entry.entry_type == "string":
+            if "=" not in body:
+                self.add_issue(
+                    result,
+                    "error",
+                    "invalid_string_entry",
+                    None,
+                    "@string must contain a macro assignment.",
+                    'Use syntax such as @string{JWS = "Journal of Web Semantics"}.',
+                    line=entry.start_line,
+                    column=entry.start_column,
+                )
+                return
+            name = body.split("=", 1)[0].strip()
+            if FIELD_NAME_RE.fullmatch(name) is None:
+                self.add_issue(
+                    result,
+                    "error",
+                    "invalid_string_macro",
+                    None,
+                    f"Invalid @string macro name {name!r}.",
+                    "Use a macro name starting with a letter.",
+                    line=entry.start_line,
+                    column=entry.start_column,
+                )
+            value = body.split("=", 1)[1].strip()
+            if value and not self.value_has_valid_shape(value):
+                self.add_issue(
+                    result,
+                    "error",
+                    "invalid_string_value",
+                    None,
+                    f"@string macro {name!r} has a malformed value {value!r}.",
+                    "Use a braced value, quoted value, number, or BibTeX macro.",
+                    line=entry.start_line,
+                    column=entry.start_column,
+                )
+
+    def validate_regular_entry(
+        self, entry: ParsedEntry, result: ValidationResult
+    ) -> None:
+        if entry.entry_type not in KNOWN_ENTRY_TYPES:
+            self.add_issue(
+                result,
+                "warning",
+                "unknown_entry_type",
+                None,
+                f"Unknown BibTeX/BibLaTeX entry type @{entry.entry_type}.",
+                "Check for typos or extend the validator if this entry type is intentionally supported.",
+                line=entry.start_line,
+                column=entry.start_column,
+            )
+
+        cleaned_body, original_offsets = remove_top_level_line_comments(entry.body)
+        cleaned_parts = split_top_level(cleaned_body, ",")
+        body_parts = [
+            (part, original_offset_from_cleaned(offset, original_offsets))
+            for part, offset in cleaned_parts
+        ]
+        key = body_parts[0][0].strip() if body_parts else ""
+        object.__setattr__(entry, "key", key)
+
+        if not key:
+            self.add_issue(
+                result,
+                "error",
+                "missing_citation_key",
+                None,
+                f"@{entry.entry_type} entry is missing a citation key.",
+                "Use syntax such as @article{citation-key, field = value}.",
+                line=entry.start_line,
+                column=entry.start_column,
+            )
+        elif CITATION_KEY_RE.fullmatch(key) is None:
+            self.add_issue(
+                result,
+                "error",
+                "invalid_citation_key",
+                key,
+                f"Invalid citation key {key!r}.",
+                "Use a non-empty key without spaces, commas, braces, parentheses, quotes, or '='.",
+                line=entry.start_line,
+                column=entry.start_column,
+            )
+
+        fields = body_parts[1:]
+        non_empty_fields = [(part, offset) for part, offset in fields if part.strip()]
+        if not non_empty_fields:
+            self.add_issue(
+                result,
+                "error",
+                "missing_fields",
+                key or None,
+                f"@{entry.entry_type} entry {key!r} has no fields.",
+                "Add at least one field such as title, author, year, doi, or url.",
+                line=entry.start_line,
+                column=entry.start_column,
+            )
+            return
+
+        seen_fields: set[str] = set()
+        for raw_field, offset in non_empty_fields:
+            self.validate_field(
+                raw_field, offset, entry, result, key or None, seen_fields
+            )
+
+    def validate_field(
+        self,
+        raw_field: str,
+        offset: int,
+        entry: ParsedEntry,
+        result: ValidationResult,
+        key: Optional[str],
+        seen_fields: set[str],
+    ) -> None:
+        field_text = raw_field.strip()
+        leading_whitespace = len(raw_field) - len(raw_field.lstrip())
+        field_line, field_column = line_col_in_entry_body(
+            entry, offset + leading_whitespace
+        )
+
+        if "=" not in field_text:
+            self.add_issue(
+                result,
+                "error",
+                "missing_field_assignment",
+                key,
+                f"Invalid field fragment {field_text!r}; expected name = value.",
+                "Separate fields with top-level commas and assign each field with '='.",
+                line=field_line,
+                column=field_column,
+            )
+            return
+
+        name, value = field_text.split("=", 1)
+        name = name.strip()
+        value = value.strip()
+
+        if FIELD_NAME_RE.fullmatch(name) is None:
+            name_offset = raw_field.find(name) if name else leading_whitespace
+            line, column = line_col_in_entry_body(entry, offset + max(0, name_offset))
+            self.add_issue(
+                result,
+                "error",
+                "invalid_field_name",
+                key,
+                f"Invalid field name {name!r}.",
+                "Use a field name starting with a letter and containing only letters, digits, underscores, or hyphens.",
+                line=line,
+                column=column,
+            )
+            return
+
+        normalized_name = name.lower()
+        if normalized_name in seen_fields:
+            self.add_issue(
+                result,
+                "warning",
+                "duplicate_field",
+                key,
+                f"Duplicate field {name!r} in entry {key!r}.",
+                "Keep one value per field.",
+                line=field_line,
+                column=field_column,
+            )
+        seen_fields.add(normalized_name)
+
+        if not value:
+            self.add_issue(
+                result,
+                "error",
+                "empty_field_value",
+                key,
+                f"Field {name!r} has an empty value.",
+                "Provide a value or remove the field.",
+                line=field_line,
+                column=field_column,
+            )
+            return
+
+        if not self.value_has_valid_shape(value):
+            self.add_issue(
+                result,
+                "error",
+                "invalid_field_value",
+                key,
+                f"Field {name!r} has a malformed value {value!r}.",
+                "Use a braced value, quoted value, number, or BibTeX macro.",
+                line=field_line,
+                column=field_column,
+            )
+
+    def value_has_valid_shape(self, value: str) -> bool:
+        """Check the basic lexical form of a BibTeX field value."""
+
+        # Values may be concatenated with #, e.g. month = jan # " " # feb.
+        for part, _offset in split_top_level(value, "#"):
+            token = part.strip()
+            if not token:
+                return False
+            if token.startswith("{"):
+                if not braced_value_has_valid_shape(token):
+                    return False
+                continue
+            if token.startswith('"'):
+                if not self.quoted_value_has_valid_shape(token):
+                    return False
+                continue
+            if token.isdigit():
+                continue
+            if FIELD_NAME_RE.fullmatch(token):
+                continue
+            return False
+        return True
+
+    def quoted_value_has_valid_shape(self, token: str) -> bool:
+        """Return whether a quoted BibTeX value has a balanced quote shape."""
+
+        if not (token.startswith('"') and token.endswith('"') and len(token) >= 2):
+            return False
+
+        escaped = False
+        for char in token[1:-1]:
+            if escaped:
+                escaped = False
+                continue
+            if char == "\\":
+                escaped = True
+                continue
+            if char == '"':
+                return False
+        return not escaped
+
+    def add_issue(
+        self,
+        result: ValidationResult,
+        severity: Severity,
+        code: str,
+        entry_key: Optional[str],
+        message: str,
+        suggestion: Optional[str] = None,
+        *,
+        line: Optional[int] = None,
+        column: Optional[int] = None,
+    ) -> None:
+        if severity == "warning" and self.config.strict:
+            severity = "error"
+        result.issues.append(
+            Issue(
+                severity=severity,
+                code=code,
+                dataset_path=str(result.dataset_path),
+                references_path=str(result.references_path) if result.present else None,
+                entry_key=entry_key,
+                message=message,
+                suggestion=suggestion,
+                line=line,
+                column=column,
+            )
+        )
+
+
+def discover_datasets(models_dir: Path) -> list[Path]:
+    models_dir = models_dir.resolve()
+    if not models_dir.exists():
+        raise ReferencesBibError(f"Models directory does not exist: {models_dir}")
+    if not models_dir.is_dir():
+        raise ReferencesBibError(f"Models path is not a directory: {models_dir}")
+    return sorted(path for path in models_dir.iterdir() if path.is_dir())
+
+
+def resolve_targets(args: argparse.Namespace) -> list[Path]:
+    if args.all:
+        if args.targets:
+            raise ReferencesBibError(
+                "Use either --all or explicit dataset folders/files, not both."
+            )
+        return discover_datasets(args.models_dir)
+
+    if args.targets:
+        targets = [Path(path) for path in args.targets]
+        missing = [path for path in targets if not path.exists()]
+        if missing:
+            joined = ", ".join(str(path) for path in missing)
+            raise ReferencesBibError(f"Input path does not exist: {joined}")
+        return targets
+
+    cwd = Path.cwd()
+    if (cwd / "references.bib").exists():
+        return [cwd / "references.bib"]
+    if (cwd / "metadata.yaml").exists():
+        return [cwd]
+
+    raise ReferencesBibError(
+        "No target provided. Pass one or more dataset folders/references.bib files, use --all, or run from a dataset folder."
+    )
+
+
+def format_text(results: Sequence[ValidationResult]) -> str:
+    lines: list[str] = []
+    for result in results:
+        if not result.present and result.valid:
+            status = "SKIPPED"
+        else:
+            status = "VALID" if result.valid else "INVALID"
+        lines.append(f"{status}: {result.dataset_path}")
+        lines.append(f"  references: {result.references_path}")
+        if result.present:
+            lines.append(f"  entries checked: {result.entries_checked}")
+        else:
+            lines.append("  optional file not present")
+        for issue in result.errors:
+            location = format_location(issue)
+            lines.append(f"  ERROR   {location}{issue.code}: {issue.message}")
+            if issue.suggestion:
+                lines.append(f"          fix: {issue.suggestion}")
+        for issue in result.warnings:
+            location = format_location(issue)
+            lines.append(f"  WARNING {location}{issue.code}: {issue.message}")
+            if issue.suggestion:
+                lines.append(f"          fix: {issue.suggestion}")
+
+    total = len(results)
+    present = sum(1 for result in results if result.present)
+    errors = sum(len(result.errors) for result in results)
+    warnings = sum(len(result.warnings) for result in results)
+    entries = sum(result.entries_checked for result in results)
+    lines.append(
+        f"Summary: {total} checked, {present} file(s) present, {entries} bibliographic entries, {errors} error(s), {warnings} warning(s)."
+    )
+    return "\n".join(lines)
+
+
+def format_location(issue: Issue) -> str:
+    parts: list[str] = []
+    if issue.entry_key:
+        parts.append(f"{issue.entry_key}")
+    if issue.line is not None:
+        location = f"line {issue.line}"
+        if issue.column is not None:
+            location += f", column {issue.column}"
+        parts.append(location)
+    return f"{' @ '.join(parts)} [{issue.code}] " if parts else f"[{issue.code}] "
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Validate optional references.bib files for OntoUML/UFO Catalog datasets.",
+    )
+    parser.add_argument(
+        "targets",
+        nargs="*",
+        type=Path,
+        help="Dataset folder(s) or references.bib file(s) to validate. If omitted, the current directory is used when it contains references.bib or metadata.yaml.",
+    )
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Validate references.bib files for all direct dataset folders below --models-dir.",
+    )
+    parser.add_argument(
+        "--models-dir",
+        type=Path,
+        default=Path("models"),
+        help="Models directory used with --all. Default: models.",
+    )
+    parser.add_argument(
+        "--require",
+        action="store_true",
+        help="Report missing references.bib files as errors. By default, missing references.bib files are accepted because the file is optional.",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("text", "json"),
+        default="text",
+        help="Output format. Default: text.",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Promote warnings to errors.",
+    )
+    parser.add_argument(
+        "--fail-on-warning",
+        action="store_true",
+        help="Return exit code 1 when warnings are present, without changing their reported severity.",
+    )
+    return parser
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        targets = resolve_targets(args)
+        config = Config(
+            require=args.require,
+            strict=args.strict,
+            fail_on_warning=args.fail_on_warning,
+        )
+        validator = ReferencesBibValidator(config)
+        results = [validator.validate_target(target) for target in targets]
+    except ReferencesBibError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    if args.format == "json":
+        print(
+            json.dumps(
+                [result.to_dict() for result in results],
+                indent=2,
+                ensure_ascii=False,
+            )
+        )
+    else:
+        print(format_text(results))
+
+    has_errors = any(result.errors for result in results)
+    has_warnings = any(result.warnings for result in results)
+    if has_errors or (args.fail_on_warning and has_warnings):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

This PR adds a lightweight validator for optional `references.bib` files in OntoUML/UFO Catalog model folders.

The validator is intended as a preflight check for repository maintenance and future catalog automation. It verifies that a present `references.bib` file is structurally valid enough to avoid common BibTeX/BibLaTeX syntax problems before metadata generation or automated model-submission processing.

## Motivation

The catalog automation workflow will eventually process new model submissions from a minimal set of source files. Since `references.bib` is optional but may be provided by contributors, it should be checked when present.

This PR adds that check before introducing the broader GitHub Actions automation. It keeps the scope narrow and avoids mixing BibTeX validation with the later new-model submission workflow.

## Added files

```text
scripts/validate_references_bib.py
scripts/validate-references-bib.md
scripts/tests/test_validate_references_bib.py
```

## Validator behavior

The new script accepts dataset folders and direct `references.bib` files.

Examples:

```bash
python scripts/validate_references_bib.py models/example-model
python scripts/validate_references_bib.py models/example-model/references.bib
python scripts/validate_references_bib.py --all --models-dir models
```

By default, missing `references.bib` files are accepted because the file is optional.

To make the file mandatory:

```bash
python scripts/validate_references_bib.py models/example-model --require
```

To return JSON output:

```bash
python scripts/validate_references_bib.py models/example-model --format json
```

## What is checked

For present `references.bib` files, the validator checks:

* UTF-8 encoding;
* non-empty file content;
* basic BibTeX/BibLaTeX entry structure;
* entries starting with `@`;
* valid entry type syntax;
* balanced braces or parentheses;
* citation keys;
* duplicate citation keys;
* field assignments in the form `field = value`;
* empty or malformed field values;
* duplicate fields inside an entry;
* full-line `%` comments outside entries;
* `@` markers inside comments;
* escaped literal braces such as `\{` and `\}` inside braced values;
* basic `@string`, `@preamble`, and `@comment` handling.

The validator recognizes common BibTeX and BibLaTeX entry types, including thesis-related types such as `mastersthesis`, `phdthesis`, `masterthesis`, and `bachelorsthesis`.

Unknown entry types are reported as warnings by default, not errors, to avoid rejecting valid local or future BibLaTeX extensions unnecessarily.

## What is intentionally not checked

The validator does not enforce mandatory fields per entry type. For example, it does not require every `@article` entry to contain `author`, `title`, `journal`, and `year`.

This is intentional. Full semantic BibTeX validation would require stronger policy decisions and might incorrectly reject acceptable bibliography styles. The current validator is intended as a lightweight structural compliance and preflight check.

## Automation readiness

The script is suitable for use in future automation because it provides:

```text
0  no validation errors were found
1  validation errors were found
2  command-line or discovery problem prevented normal execution
```

It also supports machine-readable output through:

```bash
python scripts/validate_references_bib.py models/example-model --format json
```

This allows future workflows to either use the exit code directly or parse structured validation results.

## CLI options

```text
--all
--models-dir
--require
--format text|json
--strict
--fail-on-warning
```

Warnings do not affect the exit code unless `--strict` or `--fail-on-warning` is used.

## Tests

This PR adds a comprehensive pytest suite covering:

* valid BibTeX entries;
* parenthesized entries;
* nested braces;
* escaped literal braces;
* escaped quotes;
* URLs and `@` signs inside values;
* `@` signs inside comments;
* missing optional files;
* required missing files;
* empty files;
* invalid UTF-8;
* malformed entries;
* missing entry bodies;
* missing or invalid citation keys;
* duplicate citation keys;
* invalid field assignments;
* invalid field names;
* empty field values;
* malformed concatenated values;
* duplicate fields;
* unknown entry types;
* strict mode;
* fail-on-warning mode;
* `@string`, `@preamble`, and `@comment`;
* `--all` dataset discovery;
* JSON output;
* no-target current-directory behavior;
* repository-derived regression cases.

## Validation performed

```bash
python -m py_compile scripts/validate_references_bib.py scripts/tests/test_validate_references_bib.py
python -m pytest scripts/tests/test_validate_references_bib.py -q
```

Result:

```text
54 passed
```

I also validated the script against all model folders in the catalog. The final run checked 190 datasets, found 138 present `references.bib` files, checked 229 bibliographic entries, and reported 7 errors and 0 warnings. The remaining errors correspond to real syntax problems in existing dataset files, not validator false positives.

## Dependency impact

No new dependency is introduced.

The validator uses only the Python standard library and pytest for tests, consistent with the repository’s existing script dependency approach.

## Scope

This PR does not modify existing model files, generated metadata files, workflow files, or catalog datasets.

It only adds the BibTeX validator, its documentation, and its tests.
