### PR TITLE
feat(ci): automate same-repository model submissions

### DIFF
--- a/.github/workflows/process-new-model-submission.yml
+++ b/.github/workflows/process-new-model-submission.yml
@@ -1,0 +1,165 @@
+name: Process new model submission
+
+on:
+  workflow_dispatch:
+    inputs:
+      model_path:
+        description: "Repository-relative model folder to process, for example models/example-model"
+        required: true
+        type: string
+      metadata_timestamp:
+        description: "xsd:dateTime value for FDP timestamps, or 'now'"
+        required: true
+        default: "now"
+        type: string
+      metadata_repository:
+        description: "Repository used in generated storage/download URLs"
+        required: true
+        default: "OntoUML/ontouml-models"
+        type: string
+      metadata_branch:
+        description: "Branch used in generated storage/download URLs"
+        required: true
+        default: "master"
+        type: string
+      allow_missing_license:
+        description: "Allow missing license metadata; intended only for legacy datasets"
+        required: true
+        default: false
+        type: boolean
+      dry_run:
+        description: "Validate and report without writing generated metadata"
+        required: true
+        default: false
+        type: boolean
+      commit_changes:
+        description: "Commit generated/updated files back to the same branch"
+        required: true
+        default: true
+        type: boolean
+
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - "models/**"
+
+permissions:
+  contents: write
+  pull-requests: read
+
+concurrency:
+  group: process-new-model-submission-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  reject-fork-pr:
+    name: Reject fork PR
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Explain unsupported PR source
+        run: |
+          cat <<'EOF'
+          Automated metadata generation is currently supported only for pull requests
+          opened from branches inside this repository. Fork-based PR automation will
+          be considered later.
+          EOF
+          exit 1
+
+  process:
+    name: Process model submission
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref_name }}
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install script dependencies
+        run: python -m pip install -r scripts/requirements.txt
+
+      - name: Resolve model folder
+        id: model
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_MODEL_PATH: ${{ inputs.model_path }}
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            git fetch origin "$BASE_REF" --depth=1
+            model_path="$(python scripts/process_new_model_submission.py --detect-model-folder "origin/${BASE_REF}" HEAD)"
+          else
+            model_path="$INPUT_MODEL_PATH"
+          fi
+
+          echo "model_path=${model_path}" >> "$GITHUB_OUTPUT"
+          echo "Resolved model folder: ${model_path}"
+
+      - name: Process model submission
+        env:
+          MODEL_PATH: ${{ steps.model.outputs.model_path }}
+          METADATA_TIMESTAMP: ${{ github.event_name == 'workflow_dispatch' && inputs.metadata_timestamp || 'now' }}
+          METADATA_REPOSITORY: ${{ github.event_name == 'workflow_dispatch' && inputs.metadata_repository || 'OntoUML/ontouml-models' }}
+          METADATA_BRANCH: ${{ github.event_name == 'workflow_dispatch' && inputs.metadata_branch || github.base_ref }}
+          ALLOW_MISSING_LICENSE: ${{ github.event_name == 'workflow_dispatch' && inputs.allow_missing_license || false }}
+          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}
+        run: |
+          set -euo pipefail
+
+          cmd=(
+            python
+            scripts/process_new_model_submission.py
+            "$MODEL_PATH"
+            --metadata-timestamp "$METADATA_TIMESTAMP"
+            --repository "$METADATA_REPOSITORY"
+            --branch "$METADATA_BRANCH"
+          )
+
+          if [ "$ALLOW_MISSING_LICENSE" = "true" ]; then
+            cmd+=(--allow-missing-license)
+          fi
+
+          if [ "$DRY_RUN" = "true" ]; then
+            cmd+=(--dry-run)
+          fi
+
+          "${cmd[@]}"
+
+      - name: Commit generated files
+        if: ${{ success() && ((github.event_name == 'pull_request') || (github.event_name == 'workflow_dispatch' && !inputs.dry_run && inputs.commit_changes)) }}
+        env:
+          MODEL_PATH: ${{ steps.model.outputs.model_path }}
+          EVENT_NAME: ${{ github.event_name }}
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          set -euo pipefail
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git add -- "$MODEL_PATH"
+
+          if git diff --cached --quiet -- "$MODEL_PATH"; then
+            echo "No generated changes to commit."
+            exit 0
+          fi
+
+          model_slug="$(basename "$MODEL_PATH")"
+          git commit -m "chore(metadata): process model submission ${model_slug}"
+
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            git push origin "HEAD:${HEAD_REF}"
+          else
+            git push
+          fi

--- a/scripts/process-new-model-submission.md
+++ b/scripts/process-new-model-submission.md
@@ -1,0 +1,285 @@
+# New model submission workflow
+
+This document describes the automation for processing a single OntoUML/UFO Catalog model folder from its basic source files into the catalog-ready metadata structure.
+
+The workflow is implemented by:
+
+- `.github/workflows/process-new-model-submission.yml`
+- `scripts/process_new_model_submission.py`
+
+It also expects the repository's metadata-related validation/generation scripts to be available, including:
+
+- `scripts/validate_metadata_yaml.py`
+- `scripts/validate_references_bib.py`
+- `scripts/generate_png_metadata.py`
+- `scripts/generate_json_metadata.py`
+- `scripts/generate_turtle_metadata.py`
+- `scripts/generate_vpp_metadata.py`
+- `scripts/metadata_yaml_to_ttl.py`
+
+The helper script is intentionally an orchestrator. It does not duplicate metadata-generation or BibTeX-validation logic. It validates/fixes `metadata.yaml`, validates the submission envelope, detects the target model folder for same-repository pull requests, runs the existing metadata scripts in the intended order, and performs final Turtle/RDF checks.
+
+## Supported submission mode
+
+The first automatic implementation supports **pull requests opened from branches inside the catalog repository**.
+
+The intended flow is:
+
+```text
+Trusted contributor creates a branch in OntoUML/ontouml-models
+        ↓
+Contributor adds the basic source files for one model folder
+        ↓
+Contributor opens a PR to master
+        ↓
+The workflow detects the model folder, validates/fixes inputs, generates metadata, and commits generated files back to the PR branch
+        ↓
+A curator reviews the complete PR and merges it manually
+```
+
+Fork-based PR write-back is intentionally not supported in this first phase. If a PR is opened from a fork, the workflow fails with an explicit message explaining that automatic metadata generation currently requires a same-repository PR branch.
+
+## Triggers
+
+The workflow supports two triggers.
+
+### Automatic same-repository pull request trigger
+
+```yaml
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - "models/**"
+```
+
+For PRs, the workflow:
+
+1. rejects fork-based PRs;
+2. detects the unique changed model folder under `models/`;
+3. rejects PRs that modify files outside the target model folder;
+4. processes that model folder;
+5. commits generated files back to the PR branch when changes exist.
+
+### Manual trigger
+
+The manual `workflow_dispatch` trigger remains available for controlled testing, recovery, and fork-side experimentation.
+
+Manual inputs include:
+
+- `model_path`
+- `metadata_timestamp`
+- `metadata_repository`
+- `metadata_branch`
+- `allow_missing_license`
+- `dry_run`
+- `commit_changes`
+
+## Required source files
+
+A new model folder must be a direct child of `models/`, for example:
+
+```text
+models/example-model/
+```
+
+The folder must contain:
+
+```text
+metadata.yaml
+ontology.json
+ontology.ttl
+ontology.vpp
+```
+
+The folder must also contain at least one `.png` diagram image directly inside one of the repository’s accepted image folders:
+
+```text
+original-diagrams/
+new-diagrams/
+```
+
+The optional file is:
+
+```text
+references.bib
+```
+
+## What the helper checks before generation
+
+After validating/fixing `metadata.yaml` and before running the metadata generators, `scripts/process_new_model_submission.py` checks that:
+
+- the target folder is a direct child of `models/`;
+- `metadata.yaml`, `ontology.json`, `ontology.ttl`, and `ontology.vpp` exist as files;
+- `ontology.json` is UTF-8 JSON with a top-level object;
+- `ontology.ttl` parses as Turtle/RDF with RDFLib;
+- `ontology.vpp` exists, is non-empty, and has a valid filename shape;
+- at least one `.png` diagram exists in `original-diagrams/` or `new-diagrams/`;
+- each `.png` diagram has a PNG signature and IHDR header;
+- `references.bib`, when present, is a file rather than a directory.
+
+Full basic BibTeX/BibLaTeX validation is delegated to `scripts/validate_references_bib.py`. The workflow calls this validator without `--require`, because `references.bib` is optional for catalog datasets. The workflow fails when `references.bib` exists and the validator reports errors, but it does not fail when the file is absent.
+
+The BibTeX/BibLaTeX validator checks structural compliance, including UTF-8 encoding, non-empty existing files, entry starts, entry types, balanced delimiters, citation keys, duplicate keys, field assignments, malformed values, duplicate fields, and special entries such as `@string`, `@preamble`, and `@comment`. It deliberately does not enforce mandatory fields per entry type.
+
+The existing PNG generator still performs its own PNG validation during generation.
+
+## Processing order
+
+The helper runs the existing repository scripts in this order:
+
+```text
+1. python scripts/validate_metadata_yaml.py [MODEL_FOLDER] --fix
+2. Helper-level source preflight checks for ontology.json, ontology.ttl, ontology.vpp, PNG diagrams, and optional references.bib path shape
+3. python scripts/validate_references_bib.py [MODEL_FOLDER]
+4. python scripts/generate_png_metadata.py [MODEL_FOLDER]
+5. python scripts/generate_json_metadata.py [MODEL_FOLDER] --validate-ontology-json
+6. python scripts/generate_turtle_metadata.py [MODEL_FOLDER]
+7. python scripts/generate_vpp_metadata.py [MODEL_FOLDER]
+8. python scripts/metadata_yaml_to_ttl.py [MODEL_FOLDER]
+9. Final RDFLib parse validation over all .ttl files in the model folder
+```
+
+The distribution-specific metadata files are generated before `metadata.ttl` so that the model-level metadata can aggregate the distribution IRIs discovered from `metadata-*.ttl`.
+
+## Generated files
+
+For a valid complete submission, the generated or updated files are expected to include:
+
+```text
+metadata-json.ttl
+metadata-turtle.ttl
+metadata-vpp.ttl
+metadata-png-o-*.ttl
+metadata-png-n-*.ttl
+metadata.ttl
+```
+
+The exact PNG metadata filenames depend on the diagram folder and the PNG filename stem:
+
+```text
+original-diagrams/example.png -> metadata-png-o-example.ttl
+new-diagrams/example.png      -> metadata-png-n-example.ttl
+```
+
+## Local usage
+
+Install dependencies first:
+
+```bash
+python -m pip install -r scripts/requirements.txt
+```
+
+Run the full processing pipeline with a deterministic timestamp:
+
+```bash
+python scripts/process_new_model_submission.py models/example-model \
+  --metadata-timestamp 2026-06-24T12:00:00Z
+```
+
+Run the same command using the current timestamp:
+
+```bash
+python scripts/process_new_model_submission.py models/example-model \
+  --metadata-timestamp now
+```
+
+Run a dry run without writing generated files:
+
+```bash
+python scripts/process_new_model_submission.py models/example-model \
+  --metadata-timestamp 2026-06-24T12:00:00Z \
+  --dry-run
+```
+
+Detect the changed model folder between two refs, as the PR workflow does:
+
+```bash
+python scripts/process_new_model_submission.py --detect-model-folder origin/master HEAD
+```
+
+For fork-only URL testing, override the repository used in generated storage/download URLs:
+
+```bash
+python scripts/process_new_model_submission.py models/example-model \
+  --metadata-timestamp 2026-06-24T12:00:00Z \
+  --repository pedropaulofb/ontouml-models-dev \
+  --branch master
+```
+
+For PR-ready metadata intended for the main repository, keep the default:
+
+```text
+--repository OntoUML/ontouml-models
+--branch master
+```
+
+## Testing in GitHub Actions in the fork
+
+1. Extract the patch into the root of `pedropaulofb/ontouml-models-dev`.
+2. Commit and push the workflow/helper-script changes.
+3. Create a branch inside the fork repository.
+4. Add or update one model folder under `models/` with the required source files.
+5. Open a PR from that branch to the fork repository’s `master` branch.
+6. Confirm that the workflow detects the changed model folder and commits generated metadata back to the PR branch.
+7. Inspect the workflow logs and the generated commit.
+
+To test the same workflow manually, use **Actions** → **Process new model submission** → **Run workflow**.
+
+## Automatic commits
+
+For same-repository PRs, the workflow automatically commits generated metadata back to the PR branch after all validation and generation steps succeed.
+
+For manual runs, commits occur only when `commit_changes` is `true` and `dry_run` is `false`.
+
+The workflow:
+
+1. runs all validation and generation steps;
+2. stops immediately if any step fails;
+3. stages only the requested model folder with:
+
+```bash
+git add -- "$MODEL_PATH"
+```
+
+4. commits only when staged changes exist;
+5. pushes the commit to the PR branch or, for manual runs, to the checked-out branch.
+
+The commit message has this form:
+
+```text
+chore(metadata): process model submission example-model
+```
+
+The workflow requires:
+
+```yaml
+permissions:
+  contents: write
+  pull-requests: read
+```
+
+## Failure behavior
+
+If validation or generation fails:
+
+- the helper exits with a non-zero status;
+- GitHub Actions marks the run as failed;
+- the commit step is skipped;
+- partial generated changes are not committed by the workflow.
+
+For pull requests, the workflow also fails when:
+
+- the PR comes from a fork;
+- files outside `models/<model-folder>/` are changed;
+- more than one model folder is changed;
+- changed paths under `models/` are not inside a direct model folder.
+
+## Current limitations
+
+- Automatic write-back is limited to same-repository PR branches.
+- Fork-based PR automation is intentionally deferred.
+- One model folder is processed per PR/run.
+- `references.bib` is optional and is validated only when present; the workflow does not pass `--require` to `scripts/validate_references_bib.py`.
+- `references.bib` receives structural BibTeX/BibLaTeX validation only, not semantic validation of mandatory fields per entry type.
+- `ontology.vpp` is checked at file level only; no Visual Paradigm parser is introduced.

--- a/scripts/process_new_model_submission.py
+++ b/scripts/process_new_model_submission.py
@@ -1,0 +1,741 @@
+"""Process a new OntoUML/UFO Catalog model submission.
+
+This script orchestrates the repository's existing metadata, bibliography, and
+generation tools for a single model folder. It intentionally delegates metadata
+and BibTeX/BibLaTeX semantics to those tools and only adds workflow-level
+safeguards:
+
+- source-file preflight checks for a new model submission;
+- same-repository pull request model-folder detection;
+- deterministic command ordering, including optional references.bib validation;
+- final Turtle/RDF parse validation;
+- narrow, model-folder-scoped processing.
+
+Run from the repository root, for example:
+
+    python scripts/process_new_model_submission.py models/example \
+      --metadata-timestamp 2026-06-24T12:00:00Z
+
+Use ``--dry-run`` to validate inputs and exercise the existing generators without
+writing generated metadata files.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Optional, Sequence
+
+try:
+    from rdflib import Graph
+except ImportError as exc:  # pragma: no cover - dependency failure only
+    raise SystemExit(
+        "RDFLib is required. Install it with: python -m pip install -r scripts/requirements.txt"
+    ) from exc
+
+
+REQUIRED_SOURCE_FILES = (
+    "metadata.yaml",
+    "ontology.json",
+    "ontology.ttl",
+    "ontology.vpp",
+)
+OPTIONAL_SOURCE_FILES = ("references.bib",)
+ACCEPTED_IMAGE_FOLDERS = ("original-diagrams", "new-diagrams")
+PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
+CONTROL_CHARS = re.compile(r"[\x00-\x1f\x7f]")
+
+
+class SubmissionProcessingError(RuntimeError):
+    """Raised when submission processing should stop with a clear message."""
+
+    def __init__(self, message: str, exit_code: int = 1) -> None:
+        super().__init__(message)
+        self.exit_code = exit_code
+
+
+@dataclass(frozen=True)
+class CommandStep:
+    """A named subprocess command to execute from the repository root."""
+
+    name: str
+    command: tuple[str, ...]
+
+
+def repository_root(start: Optional[Path] = None) -> Path:
+    """Return the repository root inferred from ``start`` or the current directory."""
+
+    current = (start or Path.cwd()).resolve()
+    candidates = (current, *current.parents)
+    for candidate in candidates:
+        if (candidate / "scripts").is_dir() and (candidate / "models").is_dir():
+            return candidate
+    raise SubmissionProcessingError(
+        "Could not determine the repository root. Run this command from inside the repository.",
+        exit_code=2,
+    )
+
+
+def path_for_display(path: Path, root: Path) -> str:
+    """Return a readable repository-relative path when possible."""
+
+    try:
+        return path.resolve().relative_to(root.resolve()).as_posix()
+    except ValueError:
+        return str(path)
+
+
+def resolve_model_folder(raw_path: str, root: Path, models_dir: str = "models") -> Path:
+    """Resolve and validate the target model folder.
+
+    Catalog model folders are expected to be direct children of ``models/``. This
+    keeps the workflow narrowly scoped and prevents accidental processing outside
+    the catalog dataset tree.
+    """
+
+    if not raw_path or not raw_path.strip():
+        raise SubmissionProcessingError("A model folder path is required.", exit_code=2)
+
+    raw = Path(raw_path.strip())
+    candidate = raw if raw.is_absolute() else root / raw
+    model_folder = candidate.resolve()
+    models_root = (root / models_dir).resolve()
+
+    try:
+        relative = model_folder.relative_to(models_root)
+    except ValueError as exc:
+        raise SubmissionProcessingError(
+            f"Model folder must be inside {models_root}: {model_folder}",
+            exit_code=2,
+        ) from exc
+
+    if len(relative.parts) != 1:
+        raise SubmissionProcessingError(
+            "Model folder must be a direct child of the models directory, "
+            f"for example models/example-model; got {path_for_display(model_folder, root)}.",
+            exit_code=2,
+        )
+
+    if not model_folder.exists():
+        raise SubmissionProcessingError(
+            f"Model folder does not exist: {path_for_display(model_folder, root)}",
+            exit_code=2,
+        )
+    if not model_folder.is_dir():
+        raise SubmissionProcessingError(
+            f"Model path is not a directory: {path_for_display(model_folder, root)}",
+            exit_code=2,
+        )
+
+    return model_folder
+
+
+def require_regular_file(path: Path, label: str, root: Path) -> None:
+    """Require ``path`` to exist as a regular file."""
+
+    if not path.exists():
+        raise SubmissionProcessingError(
+            f"Missing required {label}: {path_for_display(path, root)}"
+        )
+    if not path.is_file():
+        raise SubmissionProcessingError(
+            f"{label} path is not a file: {path_for_display(path, root)}"
+        )
+
+
+def validate_ontology_json(path: Path, root: Path) -> None:
+    """Parse ontology.json as UTF-8 JSON and require a top-level object."""
+
+    require_regular_file(path, "ontology.json", root)
+    try:
+        with path.open("r", encoding="utf-8") as stream:
+            data = json.load(stream)
+    except UnicodeDecodeError as exc:
+        raise SubmissionProcessingError(
+            f"ontology.json is not valid UTF-8 JSON text: {path_for_display(path, root)}: {exc}"
+        ) from exc
+    except json.JSONDecodeError as exc:
+        raise SubmissionProcessingError(
+            f"ontology.json is not valid JSON: {path_for_display(path, root)}: {exc}"
+        ) from exc
+    except OSError as exc:
+        raise SubmissionProcessingError(
+            f"Could not read ontology.json: {path_for_display(path, root)}: {exc}"
+        ) from exc
+
+    if not isinstance(data, dict):
+        raise SubmissionProcessingError(
+            f"ontology.json must contain a JSON object at the top level: {path_for_display(path, root)}"
+        )
+
+
+def validate_turtle_file(path: Path, root: Path, label: str) -> None:
+    """Parse a Turtle file with RDFLib."""
+
+    require_regular_file(path, label, root)
+    graph = Graph()
+    try:
+        graph.parse(path, format="turtle")
+    except Exception as exc:  # noqa: BLE001 - RDFLib raises several exception types
+        raise SubmissionProcessingError(
+            f"{label} is not valid Turtle/RDF: {path_for_display(path, root)}: {exc}"
+        ) from exc
+
+
+def validate_vpp_source(path: Path, root: Path) -> None:
+    """Validate the required Visual Paradigm project source at file level."""
+
+    require_regular_file(path, "ontology.vpp", root)
+    if CONTROL_CHARS.search(path.name):
+        raise SubmissionProcessingError(
+            f"ontology.vpp filename contains control characters: {path_for_display(path, root)}"
+        )
+    try:
+        if path.stat().st_size <= 0:
+            raise SubmissionProcessingError(
+                f"ontology.vpp is empty: {path_for_display(path, root)}"
+            )
+    except OSError as exc:
+        raise SubmissionProcessingError(
+            f"Could not inspect ontology.vpp: {path_for_display(path, root)}: {exc}"
+        ) from exc
+
+
+def discover_png_diagrams(model_folder: Path) -> list[Path]:
+    """Return PNG diagrams found directly in the accepted image folders."""
+
+    diagrams: list[Path] = []
+    for folder_name in ACCEPTED_IMAGE_FOLDERS:
+        folder = model_folder / folder_name
+        if folder.is_dir():
+            diagrams.extend(
+                sorted(path for path in folder.glob("*.png") if path.is_file())
+            )
+    return sorted(diagrams)
+
+
+def validate_png_file(path: Path, root: Path) -> None:
+    """Perform a lightweight PNG signature and IHDR preflight check."""
+
+    if CONTROL_CHARS.search(path.name):
+        raise SubmissionProcessingError(
+            f"PNG filename contains control characters: {path_for_display(path, root)}"
+        )
+    try:
+        data = path.read_bytes()
+    except OSError as exc:
+        raise SubmissionProcessingError(
+            f"Could not read PNG diagram: {path_for_display(path, root)}: {exc}"
+        ) from exc
+
+    if not data.startswith(PNG_SIGNATURE):
+        raise SubmissionProcessingError(
+            f"Diagram is not a PNG file: {path_for_display(path, root)}"
+        )
+    if len(data) < 24 or data[12:16] != b"IHDR":
+        raise SubmissionProcessingError(
+            f"PNG diagram is missing a valid IHDR header: {path_for_display(path, root)}"
+        )
+
+
+def validate_optional_references_bib_path(path: Path, root: Path) -> None:
+    """Validate only the optional references.bib path shape before orchestration.
+
+    Full basic BibTeX/BibLaTeX validation is delegated to
+    scripts/validate_references_bib.py in the command sequence. This keeps this
+    helper as an orchestrator instead of duplicating bibliography-validation
+    logic.
+    """
+
+    if path.exists() and not path.is_file():
+        raise SubmissionProcessingError(
+            f"references.bib path is not a file: {path_for_display(path, root)}"
+        )
+
+
+def validate_required_sources(model_folder: Path, root: Path) -> list[Path]:
+    """Validate source files expected from a new model submission."""
+
+    for file_name in REQUIRED_SOURCE_FILES:
+        require_regular_file(model_folder / file_name, file_name, root)
+
+    validate_ontology_json(model_folder / "ontology.json", root)
+    validate_turtle_file(model_folder / "ontology.ttl", root, "ontology.ttl")
+    validate_vpp_source(model_folder / "ontology.vpp", root)
+
+    diagrams = discover_png_diagrams(model_folder)
+    if not diagrams:
+        folders = ", ".join(ACCEPTED_IMAGE_FOLDERS)
+        raise SubmissionProcessingError(
+            f"At least one .png diagram is required in one of: {folders}."
+        )
+    for diagram in diagrams:
+        validate_png_file(diagram, root)
+
+    validate_optional_references_bib_path(model_folder / "references.bib", root)
+    return diagrams
+
+
+def expected_png_metadata_paths(
+    diagrams: Iterable[Path], model_folder: Path
+) -> list[Path]:
+    """Return the metadata-png-*.ttl paths expected for the discovered diagrams."""
+
+    paths: list[Path] = []
+    for diagram in diagrams:
+        source_folder = diagram.parent.name
+        if source_folder == "original-diagrams":
+            prefix = "o"
+        elif source_folder == "new-diagrams":
+            prefix = "n"
+        else:  # pragma: no cover - discover_png_diagrams limits this
+            continue
+        paths.append(model_folder / f"metadata-png-{prefix}-{diagram.stem}.ttl")
+    return sorted(paths)
+
+
+def expected_generated_metadata_paths(
+    model_folder: Path, diagrams: Iterable[Path]
+) -> list[Path]:
+    """Return metadata files expected after a successful non-dry-run execution."""
+
+    paths = [
+        model_folder / "metadata-json.ttl",
+        model_folder / "metadata-turtle.ttl",
+        model_folder / "metadata-vpp.ttl",
+        model_folder / "metadata.ttl",
+    ]
+    paths.extend(expected_png_metadata_paths(diagrams, model_folder))
+    return sorted(paths)
+
+
+def ensure_expected_outputs_exist(paths: Iterable[Path], root: Path) -> None:
+    """Fail when an expected generated metadata file is absent."""
+
+    missing = [path for path in paths if not path.exists()]
+    if missing:
+        joined = "\n".join(f"- {path_for_display(path, root)}" for path in missing)
+        raise SubmissionProcessingError(
+            "Expected generated metadata file(s) were not created:\n" + joined
+        )
+
+
+def validate_all_turtle_files(model_folder: Path, root: Path) -> None:
+    """Parse every Turtle file in the model folder after generation."""
+
+    ttl_paths = sorted(model_folder.glob("*.ttl"))
+    if not ttl_paths:
+        raise SubmissionProcessingError(
+            f"No Turtle files were found in {path_for_display(model_folder, root)} after generation."
+        )
+
+    for ttl_path in ttl_paths:
+        validate_turtle_file(ttl_path, root, ttl_path.name)
+
+
+def add_common_generation_flags(
+    command: list[str],
+    *,
+    repository: str,
+    branch: str,
+    models_dir_name: str,
+    metadata_timestamp: str,
+    allow_missing_license: bool,
+    dry_run: bool,
+) -> list[str]:
+    """Add CLI flags common to distribution metadata generators."""
+
+    command.extend(
+        [
+            "--repository",
+            repository,
+            "--branch",
+            branch,
+            "--models-dir-name",
+            models_dir_name,
+            "--metadata-timestamp",
+            metadata_timestamp,
+        ]
+    )
+    if allow_missing_license:
+        command.append("--allow-missing-license")
+    if dry_run:
+        command.append("--dry-run")
+    return command
+
+
+def build_steps(
+    args: argparse.Namespace, root: Path, model_folder: Path
+) -> list[CommandStep]:
+    """Build the ordered command sequence for existing repository tools."""
+
+    python = sys.executable
+    model_arg = model_folder.relative_to(root).as_posix()
+    models_dir_arg = Path(args.models_dir).as_posix().strip("/") or "models"
+    steps: list[CommandStep] = []
+
+    validate_command = [
+        python,
+        "scripts/validate_metadata_yaml.py",
+        model_arg,
+    ]
+    if not args.no_fix_metadata_yaml:
+        validate_command.append("--fix")
+        if args.dry_run:
+            validate_command.append("--dry-run")
+    if args.allow_missing_license:
+        validate_command.append("--allow-missing-license")
+    steps.append(CommandStep("Validate/fix metadata.yaml", tuple(validate_command)))
+
+    steps.append(
+        CommandStep(
+            "Validate optional references.bib",
+            (
+                python,
+                "scripts/validate_references_bib.py",
+                model_arg,
+            ),
+        )
+    )
+
+    common = {
+        "repository": args.repository,
+        "branch": args.branch,
+        "models_dir_name": models_dir_arg,
+        "metadata_timestamp": args.metadata_timestamp,
+        "allow_missing_license": args.allow_missing_license,
+        "dry_run": args.dry_run,
+    }
+
+    steps.append(
+        CommandStep(
+            "Generate PNG distribution metadata",
+            tuple(
+                add_common_generation_flags(
+                    [python, "scripts/generate_png_metadata.py", model_arg],
+                    **common,
+                )
+            ),
+        )
+    )
+
+    json_command = add_common_generation_flags(
+        [python, "scripts/generate_json_metadata.py", model_arg],
+        **common,
+    )
+    if not args.no_validate_ontology_json:
+        json_command.append("--validate-ontology-json")
+    steps.append(
+        CommandStep("Generate JSON distribution metadata", tuple(json_command))
+    )
+
+    steps.append(
+        CommandStep(
+            "Generate Turtle distribution metadata",
+            tuple(
+                add_common_generation_flags(
+                    [python, "scripts/generate_turtle_metadata.py", model_arg],
+                    **common,
+                )
+            ),
+        )
+    )
+
+    steps.append(
+        CommandStep(
+            "Generate VPP distribution metadata",
+            tuple(
+                add_common_generation_flags(
+                    [python, "scripts/generate_vpp_metadata.py", model_arg],
+                    **common,
+                )
+            ),
+        )
+    )
+
+    model_metadata_command = [
+        python,
+        "scripts/metadata_yaml_to_ttl.py",
+        model_arg,
+        "--repository",
+        args.repository,
+        "--branch",
+        args.branch,
+        "--models-dir",
+        models_dir_arg,
+        "--metadata-timestamp",
+        args.metadata_timestamp,
+    ]
+    if args.allow_missing_license:
+        model_metadata_command.append("--allow-missing-license")
+    if args.dry_run:
+        model_metadata_command.append("--dry-run")
+    steps.append(
+        CommandStep("Generate model-level metadata.ttl", tuple(model_metadata_command))
+    )
+
+    return steps
+
+
+def github_group_start(name: str) -> None:
+    if os.environ.get("GITHUB_ACTIONS") == "true":
+        print(f"::group::{name}")
+
+
+def github_group_end() -> None:
+    if os.environ.get("GITHUB_ACTIONS") == "true":
+        print("::endgroup::")
+
+
+def run_step(step: CommandStep, root: Path) -> None:
+    """Run one command step and surface readable failure information."""
+
+    print(f"\n==> {step.name}")
+    print("+ " + " ".join(step.command))
+    github_group_start(step.name)
+    try:
+        completed = subprocess.run(step.command, cwd=root, check=False)
+    finally:
+        github_group_end()
+
+    if completed.returncode != 0:
+        raise SubmissionProcessingError(
+            f"Step failed with exit code {completed.returncode}: {step.name}"
+        )
+
+
+def normalize_changed_path(path_text: str) -> str:
+    """Normalize a Git path for repository-relative checks."""
+
+    return path_text.strip().replace("\\", "/").strip("/")
+
+
+def detect_model_folder_from_changed_files(
+    changed_files: Iterable[str], *, models_dir: str = "models"
+) -> str:
+    """Return the unique model folder affected by a model-submission PR.
+
+    The first automatic phase intentionally supports only one model folder and no
+    files outside that folder. Generated metadata files inside the same folder are
+    allowed because the workflow may commit them back to the PR branch.
+    """
+
+    normalized_files = [
+        normalize_changed_path(path)
+        for path in changed_files
+        if normalize_changed_path(path)
+    ]
+    if not normalized_files:
+        raise SubmissionProcessingError("No changed files were detected.", exit_code=2)
+
+    models_prefix = models_dir.strip("/") + "/"
+    model_folders: set[str] = set()
+    outside_files: list[str] = []
+    invalid_model_paths: list[str] = []
+
+    for path in normalized_files:
+        if not path.startswith(models_prefix):
+            outside_files.append(path)
+            continue
+        parts = path.split("/")
+        if len(parts) < 3:
+            invalid_model_paths.append(path)
+            continue
+        model_folders.add("/".join(parts[:2]))
+
+    if outside_files:
+        joined = "\n".join(f"- {path}" for path in outside_files)
+        raise SubmissionProcessingError(
+            "Model-submission PRs must not change files outside the target model folder.\n"
+            + joined
+        )
+    if invalid_model_paths:
+        joined = "\n".join(f"- {path}" for path in invalid_model_paths)
+        raise SubmissionProcessingError(
+            "Changed model paths must be inside a direct model folder, such as models/example-model/.\n"
+            + joined
+        )
+    if len(model_folders) != 1:
+        joined = ", ".join(sorted(model_folders)) or "none"
+        raise SubmissionProcessingError(
+            "Exactly one model folder must be changed by this workflow; detected: "
+            + joined
+        )
+
+    return next(iter(model_folders))
+
+
+def changed_files_between_refs(base_ref: str, head_ref: str, root: Path) -> list[str]:
+    """Return files changed between two Git refs."""
+
+    if not base_ref or not head_ref:
+        raise SubmissionProcessingError(
+            "Both base and head refs are required for changed-file detection.",
+            exit_code=2,
+        )
+    completed = subprocess.run(
+        ["git", "diff", "--name-only", f"{base_ref}...{head_ref}"],
+        cwd=root,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if completed.returncode != 0:
+        raise SubmissionProcessingError(
+            "Could not detect changed files with git diff: " + completed.stderr.strip(),
+            exit_code=2,
+        )
+    return [line for line in completed.stdout.splitlines() if line.strip()]
+
+
+def detect_model_folder_from_git(base_ref: str, head_ref: str, models_dir: str) -> str:
+    """Detect the unique changed model folder from a Git diff."""
+
+    root = repository_root()
+    changed_files = changed_files_between_refs(base_ref, head_ref, root)
+    return detect_model_folder_from_changed_files(changed_files, models_dir=models_dir)
+
+
+def process_submission(args: argparse.Namespace) -> int:
+    """Run the complete submission processing pipeline."""
+
+    root = repository_root()
+    model_folder = resolve_model_folder(args.model_folder, root, args.models_dir)
+    print(f"Repository root: {root}")
+    print(f"Target model folder: {path_for_display(model_folder, root)}")
+
+    steps = build_steps(args, root, model_folder)
+    metadata_yaml_step = steps[0]
+    if metadata_yaml_step.name != "Validate/fix metadata.yaml":
+        raise SubmissionProcessingError(
+            "Internal workflow ordering error: metadata.yaml validation must be the first step.",
+            exit_code=2,
+        )
+    run_step(metadata_yaml_step, root)
+
+    print("\n==> Validate required source files")
+    diagrams = validate_required_sources(model_folder, root)
+    print(f"Found {len(diagrams)} PNG diagram(s).")
+
+    for step in steps[1:]:
+        run_step(step, root)
+
+    if args.dry_run:
+        print("\nDry run completed. Generated metadata files were not written.")
+        return 0
+
+    print("\n==> Validate generated output files")
+    expected_outputs = expected_generated_metadata_paths(model_folder, diagrams)
+    ensure_expected_outputs_exist(expected_outputs, root)
+    validate_all_turtle_files(model_folder, root)
+
+    print("\nSubmission processing completed successfully.")
+    print("Generated/validated metadata files:")
+    for path in expected_outputs:
+        print(f"- {path_for_display(path, root)}")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Process a single new OntoUML/UFO Catalog model submission by running "
+            "the existing metadata validation and generation scripts."
+        )
+    )
+    parser.add_argument(
+        "model_folder",
+        nargs="?",
+        help="Repository-relative model folder to process, for example models/example-model.",
+    )
+    parser.add_argument(
+        "--detect-model-folder",
+        nargs=2,
+        metavar=("BASE_REF", "HEAD_REF"),
+        help=(
+            "Print the unique changed model folder between BASE_REF and HEAD_REF, "
+            "then exit. Intended for same-repository pull request workflows."
+        ),
+    )
+    parser.add_argument(
+        "--models-dir",
+        default="models",
+        help="Repository-relative models directory. Default: models.",
+    )
+    parser.add_argument(
+        "--metadata-timestamp",
+        default="now",
+        help=(
+            "xsd:dateTime value passed to metadata generators, or 'now'. "
+            "Use a fixed value for deterministic local tests. Default: now."
+        ),
+    )
+    parser.add_argument(
+        "--repository",
+        default="OntoUML/ontouml-models",
+        help=(
+            "Repository used in generated storage/download URLs. "
+            "Default: OntoUML/ontouml-models."
+        ),
+    )
+    parser.add_argument(
+        "--branch",
+        default="master",
+        help="Branch used in generated storage/download URLs. Default: master.",
+    )
+    parser.add_argument(
+        "--allow-missing-license",
+        action="store_true",
+        help=(
+            "Allow missing license metadata. Intended only for legacy datasets; "
+            "new submissions should normally provide a license."
+        ),
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Validate inputs and run generators in dry-run mode without writing metadata files.",
+    )
+    parser.add_argument(
+        "--no-fix-metadata-yaml",
+        action="store_true",
+        help="Do not pass --fix to scripts/validate_metadata_yaml.py.",
+    )
+    parser.add_argument(
+        "--no-validate-ontology-json",
+        action="store_true",
+        help=(
+            "Do not pass --validate-ontology-json to the JSON metadata generator. "
+            "Not recommended for new submissions."
+        ),
+    )
+    return parser
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        if args.detect_model_folder:
+            base_ref, head_ref = args.detect_model_folder
+            print(detect_model_folder_from_git(base_ref, head_ref, args.models_dir))
+            return 0
+        if not args.model_folder:
+            parser.error(
+                "model_folder is required unless --detect-model-folder is used."
+            )
+        return process_submission(args)
+    except SubmissionProcessingError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return exc.exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_process_new_model_submission.py
+++ b/scripts/tests/test_process_new_model_submission.py
@@ -1,0 +1,435 @@
+from __future__ import annotations
+
+import base64
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def load_module():
+    script = None
+    for parent in Path(__file__).resolve().parents:
+        for candidate in (
+            parent / "process_new_model_submission.py",
+            parent / "scripts" / "process_new_model_submission.py",
+        ):
+            if candidate.exists():
+                script = candidate
+                break
+        if script is not None:
+            break
+    assert script is not None
+    spec = importlib.util.spec_from_file_location(
+        "process_new_model_submission", script
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+PNG_1X1 = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII="
+)
+
+
+def make_repo(tmp_path: Path) -> Path:
+    root = tmp_path / "repo"
+    (root / "scripts").mkdir(parents=True)
+    (root / "models").mkdir()
+    return root
+
+
+def make_model(root: Path, name: str = "example-model") -> Path:
+    model = root / "models" / name
+    model.mkdir()
+    (model / "metadata.yaml").write_text(
+        "\n".join(
+            [
+                "title: Example Model",
+                "issued: 2026",
+                "license: https://creativecommons.org/licenses/by/4.0/",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (model / "ontology.json").write_text(
+        json.dumps({"id": "project_1", "type": "Project"}),
+        encoding="utf-8",
+    )
+    (model / "ontology.ttl").write_text(
+        "@prefix ex: <https://example.org/> .\nex:model ex:predicate ex:object .\n",
+        encoding="utf-8",
+    )
+    (model / "ontology.vpp").write_bytes(b"vpp-placeholder")
+    (model / "new-diagrams").mkdir()
+    (model / "new-diagrams" / "main.png").write_bytes(PNG_1X1)
+    return model
+
+
+def parsed_args(module, *extra: str):
+    parser = module.build_parser()
+    return parser.parse_args(
+        [
+            "models/example-model",
+            "--metadata-timestamp",
+            "2026-06-24T12:00:00Z",
+            *extra,
+        ]
+    )
+
+
+def command_by_name(steps, name: str) -> tuple[str, ...]:
+    for step in steps:
+        if step.name == name:
+            return step.command
+    raise AssertionError(f"Step not found: {name}")
+
+
+def test_resolve_model_folder_accepts_direct_child(tmp_path: Path):
+    module = load_module()
+    root = make_repo(tmp_path)
+    model = make_model(root)
+
+    resolved = module.resolve_model_folder("models/example-model", root)
+
+    assert resolved == model.resolve()
+
+
+def test_resolve_model_folder_rejects_nested_model_path(tmp_path: Path):
+    module = load_module()
+    root = make_repo(tmp_path)
+    nested = root / "models" / "group" / "example-model"
+    nested.mkdir(parents=True)
+
+    with pytest.raises(module.SubmissionProcessingError, match="direct child"):
+        module.resolve_model_folder("models/group/example-model", root)
+
+
+def test_resolve_model_folder_rejects_path_outside_models(tmp_path: Path):
+    module = load_module()
+    root = make_repo(tmp_path)
+    outside = root / "example-model"
+    outside.mkdir()
+
+    with pytest.raises(module.SubmissionProcessingError, match="inside"):
+        module.resolve_model_folder("example-model", root)
+
+
+def test_validate_required_sources_accepts_complete_submission_without_references(
+    tmp_path: Path,
+):
+    module = load_module()
+    root = make_repo(tmp_path)
+    model = make_model(root)
+
+    diagrams = module.validate_required_sources(model, root)
+
+    assert [path.name for path in diagrams] == ["main.png"]
+
+
+def test_validate_required_sources_rejects_missing_required_file(tmp_path: Path):
+    module = load_module()
+    root = make_repo(tmp_path)
+    model = make_model(root)
+    (model / "ontology.vpp").unlink()
+
+    with pytest.raises(module.SubmissionProcessingError, match="ontology.vpp"):
+        module.validate_required_sources(model, root)
+
+
+def test_validate_required_sources_rejects_missing_png_diagram(tmp_path: Path):
+    module = load_module()
+    root = make_repo(tmp_path)
+    model = make_model(root)
+    (model / "new-diagrams" / "main.png").unlink()
+
+    with pytest.raises(module.SubmissionProcessingError, match="At least one .png"):
+        module.validate_required_sources(model, root)
+
+
+def test_validate_required_sources_rejects_invalid_ontology_json(tmp_path: Path):
+    module = load_module()
+    root = make_repo(tmp_path)
+    model = make_model(root)
+    (model / "ontology.json").write_text("not-json", encoding="utf-8")
+
+    with pytest.raises(module.SubmissionProcessingError, match="not valid JSON"):
+        module.validate_required_sources(model, root)
+
+
+def test_validate_required_sources_rejects_non_object_ontology_json(tmp_path: Path):
+    module = load_module()
+    root = make_repo(tmp_path)
+    model = make_model(root)
+    (model / "ontology.json").write_text("[]", encoding="utf-8")
+
+    with pytest.raises(module.SubmissionProcessingError, match="top level"):
+        module.validate_required_sources(model, root)
+
+
+def test_validate_required_sources_rejects_invalid_ontology_ttl(tmp_path: Path):
+    module = load_module()
+    root = make_repo(tmp_path)
+    model = make_model(root)
+    (model / "ontology.ttl").write_text("this is not turtle", encoding="utf-8")
+
+    with pytest.raises(module.SubmissionProcessingError, match="ontology.ttl"):
+        module.validate_required_sources(model, root)
+
+
+def test_validate_required_sources_rejects_empty_vpp(tmp_path: Path):
+    module = load_module()
+    root = make_repo(tmp_path)
+    model = make_model(root)
+    (model / "ontology.vpp").write_bytes(b"")
+
+    with pytest.raises(module.SubmissionProcessingError, match="ontology.vpp is empty"):
+        module.validate_required_sources(model, root)
+
+
+def test_validate_required_sources_rejects_invalid_png_signature(tmp_path: Path):
+    module = load_module()
+    root = make_repo(tmp_path)
+    model = make_model(root)
+    (model / "new-diagrams" / "main.png").write_bytes(b"not-a-png")
+
+    with pytest.raises(module.SubmissionProcessingError, match="not a PNG"):
+        module.validate_required_sources(model, root)
+
+
+def test_references_bib_is_delegated_to_external_validator(tmp_path: Path):
+    module = load_module()
+    root = make_repo(tmp_path)
+    model = make_model(root)
+    # The helper only checks that the optional path is a file. Syntax and UTF-8
+    # validation are delegated to scripts/validate_references_bib.py.
+    (model / "references.bib").write_bytes(b"\xff\xfe\x00")
+
+    diagrams = module.validate_required_sources(model, root)
+
+    assert [path.name for path in diagrams] == ["main.png"]
+
+
+def test_references_bib_directory_is_rejected_during_preflight(tmp_path: Path):
+    module = load_module()
+    root = make_repo(tmp_path)
+    model = make_model(root)
+    (model / "references.bib").mkdir()
+
+    with pytest.raises(module.SubmissionProcessingError, match="references.bib path"):
+        module.validate_required_sources(model, root)
+
+
+def test_expected_generated_metadata_paths_include_png_metadata(tmp_path: Path):
+    module = load_module()
+    root = make_repo(tmp_path)
+    model = make_model(root)
+    diagrams = module.discover_png_diagrams(model)
+
+    expected = {
+        path.name for path in module.expected_generated_metadata_paths(model, diagrams)
+    }
+
+    assert {
+        "metadata-json.ttl",
+        "metadata-turtle.ttl",
+        "metadata-vpp.ttl",
+        "metadata.ttl",
+        "metadata-png-n-main.ttl",
+    } <= expected
+
+
+def test_expected_generated_metadata_paths_include_original_and_new_diagrams(
+    tmp_path: Path,
+):
+    module = load_module()
+    root = make_repo(tmp_path)
+    model = make_model(root)
+    (model / "original-diagrams").mkdir()
+    (model / "original-diagrams" / "source.png").write_bytes(PNG_1X1)
+    diagrams = module.discover_png_diagrams(model)
+
+    expected = {
+        path.name for path in module.expected_generated_metadata_paths(model, diagrams)
+    }
+
+    assert "metadata-png-n-main.ttl" in expected
+    assert "metadata-png-o-source.ttl" in expected
+
+
+def test_build_steps_uses_existing_repository_scripts(tmp_path: Path):
+    module = load_module()
+    root = make_repo(tmp_path)
+    model = make_model(root)
+    args = parsed_args(module)
+
+    steps = module.build_steps(args, root, model)
+    commands = [" ".join(step.command) for step in steps]
+
+    assert any("scripts/validate_metadata_yaml.py" in command for command in commands)
+    assert any("scripts/validate_references_bib.py" in command for command in commands)
+    assert any("scripts/generate_png_metadata.py" in command for command in commands)
+    assert any("scripts/generate_json_metadata.py" in command for command in commands)
+    assert any("scripts/generate_turtle_metadata.py" in command for command in commands)
+    assert any("scripts/generate_vpp_metadata.py" in command for command in commands)
+    assert any("scripts/metadata_yaml_to_ttl.py" in command for command in commands)
+
+
+def test_build_steps_validates_references_before_metadata_generation(tmp_path: Path):
+    module = load_module()
+    root = make_repo(tmp_path)
+    model = make_model(root)
+    args = parsed_args(module)
+
+    step_names = [step.name for step in module.build_steps(args, root, model)]
+
+    assert step_names.index("Validate/fix metadata.yaml") < step_names.index(
+        "Validate optional references.bib"
+    )
+    assert step_names.index("Validate optional references.bib") < step_names.index(
+        "Generate PNG distribution metadata"
+    )
+
+
+def test_references_validator_runs_without_require_strict_or_dry_run_flags(
+    tmp_path: Path,
+):
+    module = load_module()
+    root = make_repo(tmp_path)
+    model = make_model(root)
+    args = parsed_args(module, "--allow-missing-license", "--dry-run")
+
+    command = command_by_name(
+        module.build_steps(args, root, model), "Validate optional references.bib"
+    )
+
+    assert command[0] == sys.executable
+    assert command[1] == "scripts/validate_references_bib.py"
+    assert "--require" not in command
+    assert "--strict" not in command
+    assert "--fail-on-warning" not in command
+    assert "--dry-run" not in command
+
+
+def test_dry_run_passes_dry_run_to_metadata_yaml_validator(tmp_path: Path):
+    module = load_module()
+    root = make_repo(tmp_path)
+    model = make_model(root)
+    args = parsed_args(module, "--dry-run")
+
+    command = command_by_name(
+        module.build_steps(args, root, model), "Validate/fix metadata.yaml"
+    )
+
+    assert "--fix" in command
+    assert "--dry-run" in command
+
+
+def test_no_fix_metadata_yaml_dry_run_does_not_pass_validator_dry_run(tmp_path: Path):
+    module = load_module()
+    root = make_repo(tmp_path)
+    model = make_model(root)
+    args = parsed_args(module, "--dry-run", "--no-fix-metadata-yaml")
+
+    command = command_by_name(
+        module.build_steps(args, root, model), "Validate/fix metadata.yaml"
+    )
+
+    assert "--fix" not in command
+    assert "--dry-run" not in command
+
+
+def test_no_fix_metadata_yaml_removes_fix_flag(tmp_path: Path):
+    module = load_module()
+    root = make_repo(tmp_path)
+    model = make_model(root)
+    args = parsed_args(module, "--no-fix-metadata-yaml")
+
+    command = command_by_name(
+        module.build_steps(args, root, model), "Validate/fix metadata.yaml"
+    )
+
+    assert "--fix" not in command
+
+
+def test_no_validate_ontology_json_removes_generator_validation_flag(tmp_path: Path):
+    module = load_module()
+    root = make_repo(tmp_path)
+    model = make_model(root)
+    args = parsed_args(module, "--no-validate-ontology-json")
+
+    command = command_by_name(
+        module.build_steps(args, root, model), "Generate JSON distribution metadata"
+    )
+
+    assert "--validate-ontology-json" not in command
+
+
+def test_ensure_expected_outputs_exist_reports_missing_files(tmp_path: Path):
+    module = load_module()
+    root = make_repo(tmp_path)
+    missing = root / "models" / "example-model" / "metadata.ttl"
+
+    with pytest.raises(module.SubmissionProcessingError, match="metadata.ttl"):
+        module.ensure_expected_outputs_exist([missing], root)
+
+
+def test_validate_all_turtle_files_rejects_invalid_generated_turtle(tmp_path: Path):
+    module = load_module()
+    root = make_repo(tmp_path)
+    model = make_model(root)
+    (model / "metadata-json.ttl").write_text("not turtle", encoding="utf-8")
+
+    with pytest.raises(module.SubmissionProcessingError, match="metadata-json.ttl"):
+        module.validate_all_turtle_files(model, root)
+
+
+def test_detect_model_folder_from_changed_files_accepts_single_model_folder():
+    module = load_module()
+
+    detected = module.detect_model_folder_from_changed_files(
+        [
+            "models/example-model/metadata.yaml",
+            "models/example-model/ontology.json",
+            "models/example-model/metadata.ttl",
+        ]
+    )
+
+    assert detected == "models/example-model"
+
+
+def test_detect_model_folder_from_changed_files_rejects_outside_file():
+    module = load_module()
+
+    with pytest.raises(module.SubmissionProcessingError, match="outside the target"):
+        module.detect_model_folder_from_changed_files(
+            ["models/example-model/metadata.yaml", "README.md"]
+        )
+
+
+def test_detect_model_folder_from_changed_files_rejects_multiple_model_folders():
+    module = load_module()
+
+    with pytest.raises(
+        module.SubmissionProcessingError, match="Exactly one model folder"
+    ):
+        module.detect_model_folder_from_changed_files(
+            [
+                "models/example-a/metadata.yaml",
+                "models/example-b/ontology.json",
+            ]
+        )
+
+
+def test_detect_model_folder_from_changed_files_rejects_direct_models_file():
+    module = load_module()
+
+    with pytest.raises(module.SubmissionProcessingError, match="direct model folder"):
+        module.detect_model_folder_from_changed_files(["models/metadata.yaml"])


### PR DESCRIPTION
## Summary

This PR adds a GitHub Actions-based automation workflow for processing new OntoUML/UFO Catalog model submissions from a minimal set of contributor-provided source files into a catalog-ready metadata structure.

The first supported mode is intentionally restricted to **same-repository pull requests**, meaning PRs opened from branches inside `OntoUML/ontouml-models`. This keeps the initial implementation simpler and safer because the workflow can commit generated metadata back to the PR branch without handling fork write-back permissions or `pull_request_target` security concerns.

The automation is designed to reduce curator workload while preserving manual curator review before merge.

## Motivation

Currently, contributors or curators need to run several metadata validation and generation steps manually when adding or updating a model dataset. This PR introduces an orchestration workflow that:

* verifies that a submitted model folder contains the required basic source files;
* validates and safely fixes `metadata.yaml`;
* validates optional `references.bib` files using the existing BibTeX/BibLaTeX validator;
* runs the existing distribution metadata generators;
* generates model-level `metadata.ttl`;
* validates generated Turtle/RDF files;
* commits generated metadata files back to the same PR branch when all checks pass.

The intended user experience for the first automation phase is:

```text
Contributor with repository write access creates a branch
        ↓
Contributor adds a new model folder with only the basic source files
        ↓
Contributor opens a same-repository PR
        ↓
Workflow validates, fixes, and generates metadata
        ↓
Workflow commits generated files back to the PR branch
        ↓
Curator reviews the complete PR manually
        ↓
Curator approves and merges
```

## Scope

This PR adds four files:

```text
.github/workflows/process-new-model-submission.yml
scripts/process_new_model_submission.py
scripts/process-new-model-submission.md
scripts/tests/test_process_new_model_submission.py
```

It uses the existing metadata and validation scripts already present in the repository, including:

```text
scripts/validate_metadata_yaml.py
scripts/validate_references_bib.py
scripts/generate_png_metadata.py
scripts/generate_json_metadata.py
scripts/generate_turtle_metadata.py
scripts/generate_vpp_metadata.py
scripts/metadata_yaml_to_ttl.py
```

No dataset/model files are intentionally changed by this PR.

## Workflow behavior

The new workflow is defined in:

```text
.github/workflows/process-new-model-submission.yml
```

It supports two triggers:

### 1. Manual testing with `workflow_dispatch`

The workflow can be run manually with inputs for:

* target model folder;
* metadata timestamp;
* repository/branch used in generated download and storage URLs;
* missing-license compatibility mode;
* dry-run mode;
* whether generated files should be committed.

This supports controlled testing and recovery.

### 2. Same-repository pull requests

For same-repository PRs affecting `models/**`, the workflow:

1. checks out the PR branch;
2. detects the unique changed model folder;
3. rejects fork-based PRs for now;
4. rejects PRs that modify files outside the target model folder;
5. runs the model-submission processor;
6. commits generated metadata files back to the PR branch when processing succeeds.

The first implementation intentionally supports **one model folder per PR**.

## Required contributor-provided files

A new model submission must provide:

```text
metadata.yaml
ontology.json
ontology.ttl
ontology.vpp
```

It must also include at least one `.png` diagram image in one of the accepted diagram folders:

```text
original-diagrams/
new-diagrams/
```

The following file remains optional:

```text
references.bib
```

If `references.bib` exists, it is validated. If it is absent, the workflow does not fail.

## Processing order

The helper script runs the existing repository tooling in this order:

```text
1. Validate/fix metadata.yaml
2. Validate required source artifacts
3. Validate optional references.bib
4. Generate PNG distribution metadata
5. Generate JSON distribution metadata
6. Generate Turtle distribution metadata
7. Generate VPP distribution metadata
8. Generate model-level metadata.ttl
9. Validate generated Turtle/RDF output files
```

This order ensures that model-level `metadata.ttl` is generated only after distribution-level metadata files exist.

## Safety constraints

The automation is intentionally conservative.

It:

* only processes folders under `models/`;
* requires the target model folder to be a direct child of `models/`;
* supports only one changed model folder per automatic PR run;
* rejects files changed outside the target model folder;
* requires a license for new submissions by default;
* does not require `references.bib`;
* validates `ontology.json` as UTF-8 JSON with a top-level object;
* validates `ontology.ttl` and generated Turtle files with RDFLib;
* performs basic PNG file validation;
* checks `ontology.vpp` at file level only;
* commits only the target model folder;
* skips the commit step when no generated changes exist.

Fork-based PR automation is explicitly rejected for now. This avoids unsafe write-back patterns and keeps this first phase restricted to trusted same-repository branches.

## Documentation

The new documentation file:

```text
scripts/process-new-model-submission.md
```

explains:

* supported triggers;
* expected input files;
* same-repository PR workflow;
* manual `workflow_dispatch` testing;
* local command-line testing;
* generated outputs;
* commit behavior;
* assumptions and limitations.

## Tests

This PR adds tests for the new orchestration helper in:

```text
scripts/tests/test_process_new_model_submission.py
```

The tests cover, among other cases:

* repository root discovery;
* model-folder path validation;
* required source-file validation;
* PNG discovery and validation;
* optional `references.bib` path handling;
* expected generated metadata paths;
* command construction and ordering;
* BibTeX validator integration;
* dry-run handling;
* changed-folder detection for PRs;
* rejection of unrelated changed files;
* rejection of multiple model folders in one automatic run;
* final generated Turtle validation;
* missing generated-output failures.

## Validation performed

The workflow was tested in a fork repository using a temporary branch.

Local validation confirmed that the helper can process a model folder end-to-end:

```text
python scripts/process_new_model_submission.py models/abrahao2018agriculture-operations --metadata-timestamp 2026-06-24T12:00:00Z
```

The command successfully:

* validated `metadata.yaml`;
* validated required source files;
* validated optional `references.bib`;
* generated PNG, JSON, Turtle, and VPP distribution metadata;
* generated model-level `metadata.ttl`;
* validated generated Turtle output.

Manual `workflow_dispatch` tests were also run in the fork. The tested runs confirmed that:

* dry-run execution succeeds and skips the commit step;
* non-dry-run execution generates metadata;
* the workflow can commit generated metadata back to the selected branch;
* generated `metadata.ttl` files contain distribution links after generation.

The test branch used for this validation was temporary and is not part of this PR.

## Known limitations

This PR intentionally does not yet support automatic write-back for fork-based PRs.

The current implementation supports:

```text
same-repository PRs only
one model folder per automatic PR run
```

Fork-based workflows can be added later with a separate security design, likely using a validation-only PR workflow plus a curator-triggered write-back workflow.

The workflow also does not semantically validate Visual Paradigm `.vpp` contents. It only checks that `ontology.vpp` exists as a non-empty file. This is intentional and avoids introducing a Visual Paradigm parser.

The `references.bib` validator checks basic BibTeX/BibLaTeX structure but does not enforce mandatory fields per entry type, such as requiring every `@article` to have `author`, `title`, `journal`, and `year`.

## Review notes

Curators should mainly review:

* whether the same-repository-only workflow policy is acceptable for the first phase;
* whether the strict one-model-folder-per-PR rule is appropriate;
* whether the generated commit behavior should be enabled by default for same-repository PRs;
* whether the workflow documentation is clear enough for catalog contributors and maintainers.
