### PR TITLE
Add catalog release file generator

### DIFF
--- a/scripts/generate_release_file.py
+++ b/scripts/generate_release_file.py
@@ -1,0 +1,236 @@
+"""Generate an OntoUML/UFO Catalog release Turtle file.
+
+This script reconstructs the historical release-generation behavior from
+OntoUML/ontouml-models-tools: it aggregates catalog Turtle files into a single
+release file named ``ontouml-models-YYYYMMDD.ttl``.
+
+Run from the repository root, for example:
+
+    python scripts/generate_release_file.py . --release-tag 20260702
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional, Sequence
+
+from rdflib import Graph
+
+
+RELEASE_TAG_PATTERN = re.compile(r"^\d{8}$")
+
+
+class ReleaseGenerationError(RuntimeError):
+    """Raised when release generation should stop with a clear message."""
+
+
+@dataclass(frozen=True)
+class ReleaseConfig:
+    """Configuration for release-file generation."""
+
+    catalog_path: Path
+    output_dir: Path
+    release_tag: str
+    list_files: bool = False
+
+
+def default_release_tag() -> str:
+    """Return the default release tag using the current UTC date."""
+
+    return datetime.now(timezone.utc).strftime("%Y%m%d")
+
+
+def validate_release_tag(release_tag: str) -> str:
+    """Validate and return a release tag in the documented YYYYMMDD format."""
+
+    normalized = release_tag.strip()
+    if not RELEASE_TAG_PATTERN.fullmatch(normalized):
+        raise ReleaseGenerationError(
+            f"Release tag must use the documented YYYYMMDD format; got: {release_tag!r}"
+        )
+    try:
+        datetime.strptime(normalized, "%Y%m%d")
+    except ValueError as exc:
+        raise ReleaseGenerationError(
+            f"Release tag must be a valid calendar date in YYYYMMDD format; got: {release_tag!r}"
+        ) from exc
+    return normalized
+
+
+def repository_relative_path(path: Path, root: Path) -> str:
+    """Return a POSIX repository-relative path for display and sorting."""
+
+    return path.resolve().relative_to(root.resolve()).as_posix()
+
+
+def should_include_ttl_file(path: Path, catalog_path: Path) -> bool:
+    """Return whether a Turtle file should be part of the catalog release.
+
+    The historical tool included all catalog .ttl files except shape files and
+    intended to exclude vocabulary.ttl. This implementation keeps that behavior
+    while also excluding generated release outputs if a local results directory
+    already exists.
+    """
+
+    relative = repository_relative_path(path, catalog_path)
+    relative_parts = Path(relative).parts
+
+    if any(part.startswith(".") for part in relative_parts):
+        return False
+    if relative.startswith("shapes/"):
+        return False
+    if path.name.endswith("-shape.ttl"):
+        return False
+    if path.name == "vocabulary.ttl":
+        return False
+    if relative.startswith("results/"):
+        return False
+    if path.name == "catalog-release.ttl":
+        return False
+    if path.name.startswith("ontouml-models-") and path.name.endswith(".ttl"):
+        return False
+
+    return True
+
+
+def list_release_ttl_files(catalog_path: Path) -> list[Path]:
+    """List Turtle files included in the release, sorted deterministically."""
+
+    catalog_path = catalog_path.resolve()
+    files = [
+        path
+        for path in catalog_path.rglob("*.ttl")
+        if path.is_file() and should_include_ttl_file(path, catalog_path)
+    ]
+    return sorted(files, key=lambda path: repository_relative_path(path, catalog_path))
+
+
+def bind_release_prefixes(graph: Graph) -> None:
+    """Bind the prefixes used by the historical release-generation tool."""
+
+    graph.bind("ontouml", "https://w3id.org/ontouml#")
+    graph.bind("dcat", "http://www.w3.org/ns/dcat#")
+    graph.bind("dct", "http://purl.org/dc/terms/")
+    graph.bind("ocmv", "https://w3id.org/ontouml-models/vocabulary#")
+    graph.bind("skos", "http://www.w3.org/2004/02/skos/core#")
+    graph.bind("mod", "https://w3id.org/mod#")
+    graph.bind("vcard", "http://www.w3.org/2006/vcard/ns#")
+    graph.bind("vann", "http://purl.org/vocab/vann/")
+
+
+def generate_release_file(config: ReleaseConfig) -> Path:
+    """Generate and return the release Turtle file path."""
+
+    catalog_path = config.catalog_path.resolve()
+    if not catalog_path.exists():
+        raise ReleaseGenerationError(f"Catalog path does not exist: {catalog_path}")
+    if not catalog_path.is_dir():
+        raise ReleaseGenerationError(f"Catalog path is not a directory: {catalog_path}")
+    if not (catalog_path / "models").is_dir():
+        raise ReleaseGenerationError(
+            f"Catalog path must contain a models/ directory: {catalog_path}"
+        )
+
+    release_tag = validate_release_tag(config.release_tag)
+    ttl_files = list_release_ttl_files(catalog_path)
+    if not ttl_files:
+        raise ReleaseGenerationError(
+            f"No Turtle files found for release generation under: {catalog_path}"
+        )
+
+    if config.list_files:
+        print("Included Turtle files:")
+        for ttl_file in ttl_files:
+            print(f"- {repository_relative_path(ttl_file, catalog_path)}")
+
+    aggregated_graph = Graph()
+    for ttl_file in ttl_files:
+        try:
+            aggregated_graph.parse(ttl_file, format="turtle")
+        except Exception as exc:  # noqa: BLE001 - RDFLib raises several exception types
+            relative = repository_relative_path(ttl_file, catalog_path)
+            raise ReleaseGenerationError(
+                f"Could not parse Turtle file {relative}: {exc}"
+            ) from exc
+
+    bind_release_prefixes(aggregated_graph)
+
+    output_dir = config.output_dir
+    if not output_dir.is_absolute():
+        output_dir = catalog_path / output_dir
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    output_file = output_dir / f"ontouml-models-{release_tag}.ttl"
+    try:
+        aggregated_graph.serialize(destination=output_file, format="turtle")
+    except OSError as exc:
+        raise ReleaseGenerationError(
+            f"Could not write release file {output_file}: {exc}"
+        ) from exc
+
+    print(f"Release file generated: {output_file}")
+    print(f"Included Turtle files: {len(ttl_files)}")
+    print(f"Aggregated triples: {len(aggregated_graph)}")
+
+    return output_file
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build the command-line parser."""
+
+    parser = argparse.ArgumentParser(
+        description="Generate a single Turtle release file for the OntoUML/UFO Catalog."
+    )
+    parser.add_argument(
+        "catalog_path",
+        nargs="?",
+        default=".",
+        help="Path to the ontouml-models repository checkout. Default: current directory.",
+    )
+    parser.add_argument(
+        "--release-tag",
+        default=default_release_tag(),
+        help="Release tag in YYYYMMDD format. Default: current UTC date.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default="results",
+        help="Directory where the release file is written. Default: results.",
+    )
+    parser.add_argument(
+        "--list-files",
+        action="store_true",
+        help="Print the Turtle files included in the release.",
+    )
+    return parser
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    """Run the release-file generator."""
+
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    config = ReleaseConfig(
+        catalog_path=Path(args.catalog_path),
+        output_dir=Path(args.output_dir),
+        release_tag=args.release_tag,
+        list_files=args.list_files,
+    )
+
+    try:
+        generate_release_file(config)
+    except ReleaseGenerationError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_generate_release_file.py
+++ b/scripts/tests/test_generate_release_file.py
@@ -1,0 +1,360 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+from rdflib import Graph, Literal, URIRef
+
+
+PREDICATE = URIRef("https://example.org/p")
+
+
+def load_module():
+    script = None
+    for parent in Path(__file__).resolve().parents:
+        for candidate in (
+            parent / "generate_release_file.py",
+            parent / "scripts" / "generate_release_file.py",
+        ):
+            if candidate.exists():
+                script = candidate
+                break
+        if script is not None:
+            break
+
+    assert script is not None
+    spec = importlib.util.spec_from_file_location("generate_release_file", script)
+    assert spec is not None
+    assert spec.loader is not None
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def write_ttl(path: Path, subject: str, value: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        f"<https://example.org/{subject}> <https://example.org/p> {value!r} .\n",
+        encoding="utf-8",
+    )
+
+
+def parse_graph(path: Path) -> Graph:
+    graph = Graph()
+    graph.parse(path, format="turtle")
+    return graph
+
+
+def assert_triple(
+    graph: Graph, subject: str, value: str, *, present: bool = True
+) -> None:
+    triple = (URIRef(f"https://example.org/{subject}"), PREDICATE, Literal(value))
+    if present:
+        assert triple in graph
+    else:
+        assert triple not in graph
+
+
+def test_generate_release_file_aggregates_catalog_and_model_ttl_but_excludes_non_release_files(
+    tmp_path: Path,
+):
+    module = load_module()
+
+    write_ttl(tmp_path / "catalog.ttl", "catalog", "catalog")
+    write_ttl(tmp_path / "models" / "example" / "metadata.ttl", "metadata", "metadata")
+    write_ttl(tmp_path / "models" / "example" / "ontology.ttl", "ontology", "ontology")
+
+    write_ttl(tmp_path / "shapes" / "Resource-shape.ttl", "shape", "shape")
+    write_ttl(
+        tmp_path / "models" / "example" / "metadata-shape.ttl",
+        "model-shape",
+        "model-shape",
+    )
+    write_ttl(tmp_path / "vocabulary.ttl", "vocabulary", "vocabulary")
+    write_ttl(tmp_path / "results" / "ontouml-models-19990101.ttl", "old", "old")
+    write_ttl(tmp_path / "catalog-release.ttl", "ignored-release", "ignored-release")
+    write_ttl(tmp_path / ".cache" / "hidden.ttl", "hidden", "hidden")
+
+    output_file = module.generate_release_file(
+        module.ReleaseConfig(
+            catalog_path=tmp_path,
+            output_dir=tmp_path / "results",
+            release_tag="20260702",
+        )
+    )
+
+    assert output_file == tmp_path / "results" / "ontouml-models-20260702.ttl"
+    assert output_file.exists()
+
+    graph = parse_graph(output_file)
+
+    assert_triple(graph, "catalog", "catalog")
+    assert_triple(graph, "metadata", "metadata")
+    assert_triple(graph, "ontology", "ontology")
+
+    assert_triple(graph, "shape", "shape", present=False)
+    assert_triple(graph, "model-shape", "model-shape", present=False)
+    assert_triple(graph, "vocabulary", "vocabulary", present=False)
+    assert_triple(graph, "old", "old", present=False)
+    assert_triple(graph, "ignored-release", "ignored-release", present=False)
+    assert_triple(graph, "hidden", "hidden", present=False)
+
+
+def test_relative_output_dir_is_resolved_under_catalog_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    module = load_module()
+
+    catalog = tmp_path / "catalog"
+    other_cwd = tmp_path / "other"
+    other_cwd.mkdir()
+
+    write_ttl(catalog / "catalog.ttl", "catalog", "catalog")
+    (catalog / "models").mkdir(exist_ok=True)
+
+    monkeypatch.chdir(other_cwd)
+
+    output_file = module.generate_release_file(
+        module.ReleaseConfig(
+            catalog_path=catalog,
+            output_dir=Path("custom-results"),
+            release_tag="20260702",
+        )
+    )
+
+    assert output_file == catalog / "custom-results" / "ontouml-models-20260702.ttl"
+    assert output_file.exists()
+    assert not (other_cwd / "custom-results").exists()
+
+
+def test_release_tag_whitespace_is_normalized(tmp_path: Path):
+    module = load_module()
+
+    write_ttl(tmp_path / "catalog.ttl", "catalog", "catalog")
+    (tmp_path / "models").mkdir(exist_ok=True)
+
+    output_file = module.generate_release_file(
+        module.ReleaseConfig(
+            catalog_path=tmp_path,
+            output_dir=tmp_path / "results",
+            release_tag=" 20260702 ",
+        )
+    )
+
+    assert output_file.name == "ontouml-models-20260702.ttl"
+
+
+@pytest.mark.parametrize(
+    "release_tag",
+    ["", "2026072", "202607020", "release", "2026-07-02"],
+)
+def test_release_tag_must_use_yyyymmdd_format(tmp_path: Path, release_tag: str):
+    module = load_module()
+    (tmp_path / "models").mkdir()
+
+    with pytest.raises(module.ReleaseGenerationError, match="YYYYMMDD"):
+        module.generate_release_file(
+            module.ReleaseConfig(
+                catalog_path=tmp_path,
+                output_dir=tmp_path / "results",
+                release_tag=release_tag,
+            )
+        )
+
+
+@pytest.mark.parametrize("release_tag", ["20260230", "20261301", "20260001"])
+def test_release_tag_must_be_valid_calendar_date(tmp_path: Path, release_tag: str):
+    module = load_module()
+    (tmp_path / "models").mkdir()
+
+    with pytest.raises(module.ReleaseGenerationError, match="valid calendar date"):
+        module.generate_release_file(
+            module.ReleaseConfig(
+                catalog_path=tmp_path,
+                output_dir=tmp_path / "results",
+                release_tag=release_tag,
+            )
+        )
+
+
+def test_missing_catalog_path_fails_clearly(tmp_path: Path):
+    module = load_module()
+
+    missing_path = tmp_path / "missing"
+
+    with pytest.raises(module.ReleaseGenerationError, match="does not exist"):
+        module.generate_release_file(
+            module.ReleaseConfig(
+                catalog_path=missing_path,
+                output_dir=tmp_path / "results",
+                release_tag="20260702",
+            )
+        )
+
+
+def test_catalog_path_must_be_directory(tmp_path: Path):
+    module = load_module()
+
+    file_path = tmp_path / "not-a-directory"
+    file_path.write_text("content", encoding="utf-8")
+
+    with pytest.raises(module.ReleaseGenerationError, match="not a directory"):
+        module.generate_release_file(
+            module.ReleaseConfig(
+                catalog_path=file_path,
+                output_dir=tmp_path / "results",
+                release_tag="20260702",
+            )
+        )
+
+
+def test_catalog_path_must_contain_models_directory(tmp_path: Path):
+    module = load_module()
+
+    write_ttl(tmp_path / "catalog.ttl", "catalog", "catalog")
+
+    with pytest.raises(module.ReleaseGenerationError, match="models/ directory"):
+        module.generate_release_file(
+            module.ReleaseConfig(
+                catalog_path=tmp_path,
+                output_dir=tmp_path / "results",
+                release_tag="20260702",
+            )
+        )
+
+
+def test_no_includable_turtle_files_fails_clearly(tmp_path: Path):
+    module = load_module()
+
+    (tmp_path / "models").mkdir()
+    write_ttl(tmp_path / "shapes" / "Resource-shape.ttl", "shape", "shape")
+    write_ttl(tmp_path / "vocabulary.ttl", "vocabulary", "vocabulary")
+
+    with pytest.raises(module.ReleaseGenerationError, match="No Turtle files found"):
+        module.generate_release_file(
+            module.ReleaseConfig(
+                catalog_path=tmp_path,
+                output_dir=tmp_path / "results",
+                release_tag="20260702",
+            )
+        )
+
+
+def test_invalid_turtle_fails_with_clear_file_path(tmp_path: Path):
+    module = load_module()
+
+    (tmp_path / "models" / "broken").mkdir(parents=True)
+    (tmp_path / "models" / "broken" / "metadata.ttl").write_text(
+        "not valid turtle",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        module.ReleaseGenerationError, match="models/broken/metadata.ttl"
+    ):
+        module.generate_release_file(
+            module.ReleaseConfig(
+                catalog_path=tmp_path,
+                output_dir=tmp_path / "results",
+                release_tag="20260702",
+            )
+        )
+
+
+def test_list_release_ttl_files_is_deterministic_and_repository_relative(
+    tmp_path: Path,
+):
+    module = load_module()
+
+    write_ttl(tmp_path / "models" / "z-model" / "metadata.ttl", "z", "z")
+    write_ttl(tmp_path / "catalog.ttl", "catalog", "catalog")
+    write_ttl(tmp_path / "models" / "a-model" / "metadata.ttl", "a", "a")
+
+    listed = [
+        module.repository_relative_path(path, tmp_path)
+        for path in module.list_release_ttl_files(tmp_path)
+    ]
+
+    assert listed == [
+        "catalog.ttl",
+        "models/a-model/metadata.ttl",
+        "models/z-model/metadata.ttl",
+    ]
+
+
+def test_list_files_prints_included_files_but_not_excluded_files(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+):
+    module = load_module()
+
+    write_ttl(tmp_path / "catalog.ttl", "catalog", "catalog")
+    write_ttl(tmp_path / "models" / "example" / "metadata.ttl", "metadata", "metadata")
+    write_ttl(tmp_path / "shapes" / "Resource-shape.ttl", "shape", "shape")
+    write_ttl(tmp_path / "vocabulary.ttl", "vocabulary", "vocabulary")
+
+    module.generate_release_file(
+        module.ReleaseConfig(
+            catalog_path=tmp_path,
+            output_dir=tmp_path / "results",
+            release_tag="20260702",
+            list_files=True,
+        )
+    )
+
+    output = capsys.readouterr().out
+
+    assert "- catalog.ttl" in output
+    assert "- models/example/metadata.ttl" in output
+    assert "- shapes/Resource-shape.ttl" not in output
+    assert "- vocabulary.ttl" not in output
+
+
+def test_main_returns_zero_and_writes_release_file(tmp_path: Path):
+    module = load_module()
+
+    write_ttl(tmp_path / "catalog.ttl", "catalog", "catalog")
+    (tmp_path / "models").mkdir(exist_ok=True)
+
+    exit_code = module.main(
+        [
+            str(tmp_path),
+            "--release-tag",
+            "20260702",
+            "--output-dir",
+            str(tmp_path / "results"),
+        ]
+    )
+
+    assert exit_code == 0
+    assert (tmp_path / "results" / "ontouml-models-20260702.ttl").exists()
+
+
+def test_main_returns_nonzero_for_invalid_input(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+):
+    module = load_module()
+
+    (tmp_path / "models").mkdir()
+
+    exit_code = module.main(
+        [
+            str(tmp_path),
+            "--release-tag",
+            "2026-07-02",
+            "--output-dir",
+            str(tmp_path / "results"),
+        ]
+    )
+
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    assert "ERROR:" in captured.err
+    assert "YYYYMMDD" in captured.err


### PR DESCRIPTION
## Summary

This PR adds an in-repository release-file generator for the OntoUML/UFO Catalog, together with a dedicated test suite.

The new script reconstructs the historical release-generation behavior that was previously available in the separate `OntoUML/ontouml-models-tools` repository. It generates a single Turtle release file by aggregating the catalog’s relevant `.ttl` files into one output file named according to the documented release-tag convention:

```text
ontouml-models-YYYYMMDD.ttl
```

This PR does **not** add release automation yet. It only introduces the script and tests needed as a first step toward automating catalog releases later through GitHub Actions.

## Motivation

The catalog releases are currently outdated, and release generation has historically depended on a manual process using the old tooling repository.

Adding the release-generation script directly to this repository makes the process easier to maintain, test, and eventually automate. It also avoids depending on a separate repository for core catalog maintenance functionality.

## Added files

* `scripts/generate_release_file.py`
* `scripts/tests/test_generate_release_file.py`

## Release-generation behavior

The new script:

* generates a release file named `ontouml-models-YYYYMMDD.ttl`;
* accepts an explicit release tag through `--release-tag`;
* uses the current UTC date as the default release tag when none is provided;
* validates that the release tag follows the documented `YYYYMMDD` format;
* validates that the release tag is a real calendar date;
* aggregates includable Turtle files from the catalog;
* writes the output file to `results/` by default;
* supports a custom output directory through `--output-dir`;
* supports listing included files through `--list-files`;
* fails clearly when the catalog path is invalid, the `models/` directory is missing, no includable Turtle files are found, or an included Turtle file cannot be parsed.

## Files included in the release

The script includes catalog Turtle files such as:

* `catalog.ttl`;
* model-level metadata files under `models/**`;
* model ontology files under `models/**`;
* other includable `.ttl` files that are part of the catalog data.

## Files excluded from the release

The script excludes files that should not be part of the release aggregation, including:

* SHACL shape files under `shapes/`;
* files ending in `-shape.ttl`;
* `vocabulary.ttl`;
* previous/generated release outputs under `results/`;
* `catalog-release.ttl`;
* files matching `ontouml-models-*.ttl`;
* files under hidden folders such as `.cache/`.

These exclusions are intended to preserve the historical release semantics while avoiding accidental inclusion of generated or non-catalog files.

## Test coverage

The test suite covers:

* successful aggregation of catalog and model Turtle files;
* exclusion of shape files, vocabulary files, hidden files, and generated release outputs;
* deterministic ordering of included Turtle files;
* relative output directory handling;
* release-tag format validation;
* invalid calendar-date rejection;
* missing catalog path;
* catalog path pointing to a file instead of a directory;
* missing `models/` directory;
* absence of includable Turtle files;
* invalid Turtle parsing failure;
* CLI-level success and failure behavior.

## Validation

The test file can be run with:

```bash
python -m pytest -q scripts/tests/test_generate_release_file.py
```

Expected result:

```text
20 passed
```

A manual smoke test can also be run from the repository root:

```bash
python scripts/generate_release_file.py . --release-tag 19700101 --output-dir results --list-files
```

The generated `results/` directory is local output and should not be committed.

## Scope of this PR

This PR intentionally keeps the scope narrow.

It only adds:

1. the release-generation script;
2. the corresponding tests.

It does **not** yet add:

* a GitHub Actions workflow;
* automatic release publication;
* tag creation;
* GitHub Release asset upload;
* changes to release/versioning policy.

Those can be addressed in a follow-up PR after this script is reviewed and accepted.

## Known limitation

The documented release-tag convention is date-based: `YYYYMMDD`.

This means the release format itself does not naturally support multiple distinct releases on the same day. This PR preserves the existing convention rather than changing release semantics.
