### PR TITLE
Fix generated model namespace prefixes in catalog releases

### DIFF
--- a/scripts/generate_release_file.py
+++ b/scripts/generate_release_file.py
@@ -23,6 +23,8 @@ from rdflib import Graph
 
 
 RELEASE_TAG_PATTERN = re.compile(r"^\d{8}$")
+MODEL_NAMESPACE_BASE = "https://w3id.org/ontouml-models/model/"
+VALID_GENERATED_PREFIX_PATTERN = re.compile(r"^[a-z][a-z0-9_]*$")
 
 
 class ReleaseGenerationError(RuntimeError):
@@ -123,6 +125,94 @@ def bind_release_prefixes(graph: Graph) -> None:
     graph.bind("vann", "http://purl.org/vocab/vann/")
 
 
+def model_identifier_from_namespace(namespace: str) -> Optional[str]:
+    """Return the identifier represented by a catalog model namespace.
+
+    Catalog model namespaces are recognized when they are under
+    ``MODEL_NAMESPACE_BASE`` and end in either ``#`` or ``/``. The returned
+    identifier excludes that final namespace delimiter.
+    """
+
+    if not namespace.startswith(MODEL_NAMESPACE_BASE):
+        return None
+    if not namespace.endswith(("#", "/")):
+        return None
+
+    remainder = namespace[len(MODEL_NAMESPACE_BASE) :]
+    if remainder:
+        remainder = remainder[:-1]
+    return remainder
+
+
+def sanitize_model_prefix(identifier: str) -> str:
+    """Return a deterministic ASCII Turtle prefix derived from an identifier.
+
+    Generated prefixes use lowercase ASCII letters, digits, and underscores.
+    Runs of characters outside that set are normalized to one underscore. A
+    fallback is used for empty identifiers, and ``model_`` is prepended when
+    the normalized identifier would not begin with a letter. This deliberately
+    uses a conservative subset of Turtle's legal ``PN_PREFIX`` grammar.
+    """
+
+    normalized = re.sub(r"[^a-z0-9]+", "_", identifier.casefold()).strip("_")
+    if not normalized:
+        normalized = "model"
+    elif not normalized[0].isalpha():
+        normalized = f"model_{normalized}"
+
+    if not VALID_GENERATED_PREFIX_PATTERN.fullmatch(normalized):
+        raise ReleaseGenerationError(
+            f"Could not derive a valid Turtle prefix from model identifier: {identifier!r}"
+        )
+    return normalized
+
+
+def bind_model_prefixes(graph: Graph) -> dict[str, str]:
+    """Bind deterministic, meaningful prefixes for catalog model namespaces.
+
+    Namespace IRIs are sorted lexicographically before prefixes are assigned.
+    If normalization produces a collision, or a candidate is already used by a
+    shared/non-model namespace, the first available ``_<n>`` suffix is used,
+    beginning with ``_2``. Sorting and explicit suffix allocation make the
+    result independent of file traversal, parse order, and RDFLib's generated
+    ``defaultN`` labels.
+
+    Returns a mapping from namespace IRI to the assigned prefix.
+    """
+
+    model_namespaces = sorted(
+        {
+            str(namespace)
+            for _, namespace in graph.namespaces()
+            if model_identifier_from_namespace(str(namespace)) is not None
+        }
+    )
+
+    model_namespace_set = set(model_namespaces)
+    used_prefixes = {
+        str(prefix)
+        for prefix, namespace in graph.namespaces()
+        if str(namespace) not in model_namespace_set
+    }
+    assigned: dict[str, str] = {}
+
+    for namespace in model_namespaces:
+        identifier = model_identifier_from_namespace(namespace)
+        assert identifier is not None
+        base_prefix = sanitize_model_prefix(identifier)
+        prefix = base_prefix
+        suffix = 2
+        while prefix in used_prefixes:
+            prefix = f"{base_prefix}_{suffix}"
+            suffix += 1
+
+        graph.bind(prefix, namespace, override=True, replace=True)
+        used_prefixes.add(prefix)
+        assigned[namespace] = prefix
+
+    return assigned
+
+
 def generate_release_file(config: ReleaseConfig) -> Path:
     """Generate and return the release Turtle file path."""
 
@@ -159,6 +249,7 @@ def generate_release_file(config: ReleaseConfig) -> Path:
             ) from exc
 
     bind_release_prefixes(aggregated_graph)
+    bind_model_prefixes(aggregated_graph)
 
     output_dir = config.output_dir
     if not output_dir.is_absolute():

--- a/scripts/tests/test_generate_release_file.py
+++ b/scripts/tests/test_generate_release_file.py
@@ -1,14 +1,28 @@
 from __future__ import annotations
 
 import importlib.util
+import re
 import sys
 from pathlib import Path
 
 import pytest
-from rdflib import Graph, Literal, URIRef
+from rdflib import BNode, Graph, Literal, URIRef
+from rdflib.compare import isomorphic
+from rdflib.namespace import XSD
 
 
 PREDICATE = URIRef("https://example.org/p")
+MODEL_NAMESPACE_BASE = "https://w3id.org/ontouml-models/model/"
+PREFIX_DECLARATION_PATTERN = re.compile(
+    r"^@prefix\s+([A-Za-z][A-Za-z0-9_]*)\s*:\s*<([^>]+)>\s*\.\s*$",
+    re.MULTILINE,
+)
+DEFAULT_PREFIX_DECLARATION_PATTERN = re.compile(
+    r"^@prefix\s+default\d*\s*:", re.MULTILINE
+)
+MODEL_DEFAULT_PREFIX_DECLARATION_PATTERN = re.compile(
+    rf"^@prefix\s*:\s*<{re.escape(MODEL_NAMESPACE_BASE)}", re.MULTILINE
+)
 
 
 def load_module():
@@ -43,10 +57,49 @@ def write_ttl(path: Path, subject: str, value: str) -> None:
     )
 
 
+def write_model_ttl(
+    path: Path,
+    namespace: str,
+    local_name: str,
+    value: str,
+    *,
+    include_blank_node: bool = False,
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    blank_node_statement = ""
+    if include_blank_node:
+        blank_node_statement = (
+            f":{local_name} <https://example.org/detail> "
+            '[ <https://example.org/value> "nested" ] .\n'
+        )
+    path.write_text(
+        f"@prefix : <{namespace}> .\n"
+        f"@prefix ex: <https://example.org/> .\n\n"
+        f':{local_name} ex:p "{value}" .\n'
+        f"{blank_node_statement}",
+        encoding="utf-8",
+    )
+
+
 def parse_graph(path: Path) -> Graph:
     graph = Graph()
     graph.parse(path, format="turtle")
     return graph
+
+
+def parse_catalog_sources(module, catalog_path: Path) -> Graph:
+    graph = Graph()
+    for ttl_file in module.list_release_ttl_files(catalog_path):
+        graph.parse(ttl_file, format="turtle")
+    return graph
+
+
+def model_prefixes(turtle_text: str) -> dict[str, str]:
+    return {
+        namespace: prefix
+        for prefix, namespace in PREFIX_DECLARATION_PATTERN.findall(turtle_text)
+        if namespace.startswith(MODEL_NAMESPACE_BASE)
+    }
 
 
 def assert_triple(
@@ -358,3 +411,318 @@ def test_main_returns_nonzero_for_invalid_input(
     assert exit_code == 1
     assert "ERROR:" in captured.err
     assert "YYYYMMDD" in captured.err
+
+
+@pytest.mark.parametrize(
+    ("identifier", "expected"),
+    [
+        ("Abel2015Petroleum-System", "abel2015petroleum_system"),
+        ("123-model", "model_123_model"),
+        ("--A  B///C--", "a_b_c"),
+        ("___", "model"),
+        ("Straße", "strasse"),
+    ],
+)
+def test_sanitize_model_prefix_handles_edge_cases_deterministically(
+    identifier: str,
+    expected: str,
+):
+    module = load_module()
+
+    result = module.sanitize_model_prefix(identifier)
+
+    assert result == expected
+    assert module.VALID_GENERATED_PREFIX_PATTERN.fullmatch(result)
+
+
+@pytest.mark.parametrize(
+    ("namespace", "expected"),
+    [
+        (
+            f"{MODEL_NAMESPACE_BASE}abel2015petroleum-system#",
+            "abel2015petroleum-system",
+        ),
+        (
+            f"{MODEL_NAMESPACE_BASE}slash-style/",
+            "slash-style",
+        ),
+        (MODEL_NAMESPACE_BASE, ""),
+        (f"{MODEL_NAMESPACE_BASE}not-a-namespace", None),
+        ("https://example.org/model/example#", None),
+    ],
+)
+def test_model_identifier_from_namespace_supports_hash_and_slash_styles(
+    namespace: str,
+    expected: str | None,
+):
+    module = load_module()
+
+    assert module.model_identifier_from_namespace(namespace) == expected
+
+
+def test_generated_release_uses_meaningful_prefixes_for_hash_and_slash_namespaces(
+    tmp_path: Path,
+):
+    module = load_module()
+
+    hash_namespace = f"{MODEL_NAMESPACE_BASE}abel2015petroleum-system#"
+    slash_namespace = f"{MODEL_NAMESPACE_BASE}abrahao2018agriculture-operations/"
+    write_model_ttl(
+        tmp_path / "models" / "hash-model" / "ontology.ttl",
+        hash_namespace,
+        "HashSubject",
+        "hash",
+    )
+    write_model_ttl(
+        tmp_path / "models" / "slash-model" / "ontology.ttl",
+        slash_namespace,
+        "SlashSubject",
+        "slash",
+    )
+
+    output_file = module.generate_release_file(
+        module.ReleaseConfig(
+            catalog_path=tmp_path,
+            output_dir=tmp_path / "results",
+            release_tag="20260702",
+        )
+    )
+    turtle_text = output_file.read_text(encoding="utf-8")
+    prefixes = model_prefixes(turtle_text)
+
+    assert prefixes == {
+        hash_namespace: "abel2015petroleum_system",
+        slash_namespace: "abrahao2018agriculture_operations",
+    }
+    assert not DEFAULT_PREFIX_DECLARATION_PATTERN.search(turtle_text)
+    assert not MODEL_DEFAULT_PREFIX_DECLARATION_PATTERN.search(turtle_text)
+
+    graph = parse_graph(output_file)
+    assert (
+        URIRef(f"{hash_namespace}HashSubject"),
+        PREDICATE,
+        Literal("hash"),
+    ) in graph
+    assert (
+        URIRef(f"{slash_namespace}SlashSubject"),
+        PREDICATE,
+        Literal("slash"),
+    ) in graph
+
+
+def test_normalization_collisions_are_resolved_by_sorted_namespace_iri(
+    tmp_path: Path,
+):
+    module = load_module()
+
+    first_namespace = f"{MODEL_NAMESPACE_BASE}collision-model#"
+    second_namespace = f"{MODEL_NAMESPACE_BASE}collision_model#"
+    write_model_ttl(
+        tmp_path / "models" / "z-model" / "ontology.ttl",
+        second_namespace,
+        "Second",
+        "second",
+    )
+    write_model_ttl(
+        tmp_path / "models" / "a-model" / "ontology.ttl",
+        first_namespace,
+        "First",
+        "first",
+    )
+
+    output_file = module.generate_release_file(
+        module.ReleaseConfig(
+            catalog_path=tmp_path,
+            output_dir=tmp_path / "results",
+            release_tag="20260702",
+        )
+    )
+
+    assert model_prefixes(output_file.read_text(encoding="utf-8")) == {
+        first_namespace: "collision_model",
+        second_namespace: "collision_model_2",
+    }
+
+
+def test_prefix_assignment_is_independent_of_graph_parse_order():
+    module = load_module()
+
+    namespaces = [
+        f"{MODEL_NAMESPACE_BASE}collision_model#",
+        f"{MODEL_NAMESPACE_BASE}collision-model#",
+        f"{MODEL_NAMESPACE_BASE}123-model/",
+    ]
+    graphs = []
+    for parse_order in (namespaces, list(reversed(namespaces))):
+        graph = Graph()
+        for index, namespace in enumerate(parse_order):
+            graph.parse(
+                data=(
+                    f"@prefix : <{namespace}> .\n"
+                    f"@prefix ex: <https://example.org/> .\n"
+                    f':subject{index} ex:p "value{index}" .\n'
+                ),
+                format="turtle",
+            )
+        module.bind_release_prefixes(graph)
+        graphs.append(module.bind_model_prefixes(graph))
+
+    assert (
+        graphs[0]
+        == graphs[1]
+        == {
+            f"{MODEL_NAMESPACE_BASE}123-model/": "model_123_model",
+            f"{MODEL_NAMESPACE_BASE}collision-model#": "collision_model",
+            f"{MODEL_NAMESPACE_BASE}collision_model#": "collision_model_2",
+        }
+    )
+
+
+def test_generated_model_prefixes_do_not_replace_established_shared_prefixes(
+    tmp_path: Path,
+):
+    module = load_module()
+
+    namespace = f"{MODEL_NAMESPACE_BASE}dcat#"
+    ontology_file = tmp_path / "models" / "dcat" / "ontology.ttl"
+    write_model_ttl(
+        ontology_file,
+        namespace,
+        "Subject",
+        "value",
+    )
+    ontology_file.write_text(
+        ontology_file.read_text(encoding="utf-8")
+        + "@prefix dcat: <http://www.w3.org/ns/dcat#> .\n"
+        + ":Subject a dcat:Dataset .\n",
+        encoding="utf-8",
+    )
+
+    output_file = module.generate_release_file(
+        module.ReleaseConfig(
+            catalog_path=tmp_path,
+            output_dir=tmp_path / "results",
+            release_tag="20260702",
+        )
+    )
+    turtle_text = output_file.read_text(encoding="utf-8")
+
+    assert "@prefix dcat: <http://www.w3.org/ns/dcat#> ." in turtle_text
+    assert model_prefixes(turtle_text)[namespace] == "dcat_2"
+
+
+def test_generated_model_prefix_labels_use_a_valid_conservative_turtle_subset(
+    tmp_path: Path,
+):
+    module = load_module()
+
+    namespaces = [
+        f"{MODEL_NAMESPACE_BASE}123%20model#",
+        f"{MODEL_NAMESPACE_BASE}Repeated---Separators/",
+        f"{MODEL_NAMESPACE_BASE}___#",
+        f"{MODEL_NAMESPACE_BASE}mixed.CASE-model#",
+    ]
+    for index, namespace in enumerate(namespaces):
+        write_model_ttl(
+            tmp_path / "models" / f"model-{index}" / "ontology.ttl",
+            namespace,
+            f"Subject{index}",
+            f"value-{index}",
+        )
+
+    output_file = module.generate_release_file(
+        module.ReleaseConfig(
+            catalog_path=tmp_path,
+            output_dir=tmp_path / "results",
+            release_tag="20260702",
+        )
+    )
+    prefixes = model_prefixes(output_file.read_text(encoding="utf-8"))
+
+    assert set(prefixes) == set(namespaces)
+    assert all(
+        module.VALID_GENERATED_PREFIX_PATTERN.fullmatch(prefix)
+        for prefix in prefixes.values()
+    )
+    assert len(prefixes.values()) == len(set(prefixes.values()))
+
+
+def test_prefix_correction_preserves_rdf_graph_semantics_including_blank_nodes(
+    tmp_path: Path,
+):
+    module = load_module()
+
+    write_ttl(tmp_path / "catalog.ttl", "catalog", "catalog")
+    namespace = f"{MODEL_NAMESPACE_BASE}semantic-check#"
+    ontology_file = tmp_path / "models" / "hash-model" / "ontology.ttl"
+    write_model_ttl(
+        ontology_file,
+        namespace,
+        "Subject",
+        "value",
+        include_blank_node=True,
+    )
+    ontology_file.write_text(
+        ontology_file.read_text(encoding="utf-8")
+        + "@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n"
+        + ':Subject <https://example.org/label> "Label"@en ;\n'
+        + '    <https://example.org/count> "1"^^xsd:integer .\n',
+        encoding="utf-8",
+    )
+
+    expected_graph = parse_catalog_sources(module, tmp_path)
+    output_file = module.generate_release_file(
+        module.ReleaseConfig(
+            catalog_path=tmp_path,
+            output_dir=tmp_path / "results",
+            release_tag="20260702",
+        )
+    )
+    actual_graph = parse_graph(output_file)
+
+    assert len(actual_graph) == len(expected_graph)
+    assert isomorphic(actual_graph, expected_graph)
+    assert any(isinstance(term, BNode) for triple in actual_graph for term in triple)
+    assert (
+        URIRef(f"{namespace}Subject"),
+        URIRef("https://example.org/label"),
+        Literal("Label", lang="en"),
+    ) in actual_graph
+    assert (
+        URIRef(f"{namespace}Subject"),
+        URIRef("https://example.org/count"),
+        Literal(1, datatype=XSD.integer),
+    ) in actual_graph
+
+
+def test_model_prefix_results_are_stable_across_repeated_runs(tmp_path: Path):
+    module = load_module()
+
+    namespaces = [
+        f"{MODEL_NAMESPACE_BASE}stable-model#",
+        f"{MODEL_NAMESPACE_BASE}stable_model#",
+        f"{MODEL_NAMESPACE_BASE}another-model/",
+    ]
+    for index, namespace in enumerate(namespaces):
+        write_model_ttl(
+            tmp_path / "models" / f"model-{index}" / "ontology.ttl",
+            namespace,
+            f"Subject{index}",
+            f"value-{index}",
+        )
+
+    outputs = []
+    graphs = []
+    for output_dir in (tmp_path / "results-a", tmp_path / "results-b"):
+        output_file = module.generate_release_file(
+            module.ReleaseConfig(
+                catalog_path=tmp_path,
+                output_dir=output_dir,
+                release_tag="20260702",
+            )
+        )
+        outputs.append(model_prefixes(output_file.read_text(encoding="utf-8")))
+        graphs.append(parse_graph(output_file))
+
+    assert outputs[0] == outputs[1]
+    assert isomorphic(graphs[0], graphs[1])


### PR DESCRIPTION
## Summary

This PR improves the Turtle serialization quality of the consolidated OntoUML/UFO Catalog release by replacing RDFLib-generated model namespace aliases such as:

```turtle
@prefix : <https://w3id.org/ontouml-models/model/abel2015petroleum-system#> .
@prefix default1: <https://w3id.org/ontouml-models/model/abrahao2018agriculture-operations#> .
@prefix default2: <https://w3id.org/ontouml-models/model/aguiar2018rdbs-o#> .
@prefix default3: <https://w3id.org/ontouml-models/model/aguiar2019ooco#> .
```

with deterministic and meaningful prefixes derived from the corresponding model identifiers:

```turtle
@prefix abel2015petroleum_system:
    <https://w3id.org/ontouml-models/model/abel2015petroleum-system#> .

@prefix abrahao2018agriculture_operations:
    <https://w3id.org/ontouml-models/model/abrahao2018agriculture-operations#> .
```

The generated RDF was already valid: the automatically generated `defaultN` labels did not modify the underlying namespace IRIs or RDF triples.

This PR therefore addresses a serialization-quality issue affecting:

* readability;
* maintainability;
* namespace-prefix stability;
* human inspection of generated releases;
* traceability between a serialized prefix and its source model.

The correction is implemented centrally in the release generator and does not modify individual source model files.

## Motivation

Many model ontology files use the empty Turtle prefix `:` for their own model namespace.

For example:

```turtle
@prefix : <https://w3id.org/ontouml-models/model/abel2015petroleum-system#> .
```

This is valid when each model file is parsed independently.

However, the release generator aggregates all included Turtle files into a single RDFLib graph before serializing the complete catalog release.

Because different source files associate the same empty prefix with different namespace IRIs, RDFLib must resolve those namespace-label conflicts in the aggregated graph. During Turtle serialization, RDFLib assigns automatically generated aliases such as:

```text
default1
default2
default3
...
defaultN
```

These generated aliases preserve RDF semantics, but they are not meaningful to readers and are not directly traceable to the associated models.

For example:

```turtle
@prefix default37:
    <https://w3id.org/ontouml-models/model/example-model#> .
```

provides less useful information than:

```turtle
@prefix example_model:
    <https://w3id.org/ontouml-models/model/example-model#> .
```

The objective of this change is therefore to assign deterministic, readable, and valid Turtle prefixes to catalog model namespaces before RDFLib serializes the aggregated graph.

## Implementation

The implementation remains centralized in:

```text
scripts/generate_release_file.py
```

No source model Turtle files are modified.

The release generator now identifies catalog model namespaces under:

```text
https://w3id.org/ontouml-models/model/
```

and assigns each recognized namespace a deterministic prefix derived from its model identifier.

For example:

```text
https://w3id.org/ontouml-models/model/abel2015petroleum-system#
```

is assigned:

```text
abel2015petroleum_system
```

and:

```text
https://w3id.org/ontouml-models/model/abrahao2018agriculture-operations#
```

is assigned:

```text
abrahao2018agriculture_operations
```

The implementation operates through RDFLib's graph and namespace APIs.

It does **not** post-process the serialized Turtle using string replacement.

This avoids coupling the correction to:

* Turtle whitespace;
* declaration ordering;
* serializer line wrapping;
* serializer formatting conventions;
* arbitrary textual patterns.

The intended namespace bindings are established before RDFLib serializes the consolidated graph.

## Supported model namespace styles

The implementation supports both model namespace styles currently relevant to the catalog:

```text
https://w3id.org/ontouml-models/model/example-model#
```

and:

```text
https://w3id.org/ontouml-models/model/example-model/
```

The model identifier is derived independently of whether the namespace uses `#` or `/` as its final delimiter.

## Prefix normalization

Generated prefixes use a conservative valid Turtle-prefix subset:

```regex
^[a-z][a-z0-9_]*$
```

This deliberately favors simple and predictable generated labels.

Normalization includes the following behavior:

* case is normalized consistently;
* hyphens are replaced with underscores;
* spaces and unsupported characters are normalized to underscores;
* repeated unsupported separators collapse into a single underscore;
* leading and trailing underscores are removed;
* identifiers beginning with digits receive a `model_` prefix;
* empty or otherwise unusable identifiers receive the fallback prefix `model`.

Examples:

```text
Abel2015Petroleum-System
→
abel2015petroleum_system
```

```text
123-model
→
model_123_model
```

```text
A---B   C
→
a_b_c
```

```text
___
→
model
```

The implementation validates the generated result before binding it and does not silently emit an invalid Turtle prefix label.

## Deterministic collision handling

Different model namespace IRIs can normalize to the same candidate prefix.

For example:

```text
collision-model
```

and:

```text
collision_model
```

both normalize to:

```text
collision_model
```

To prevent different namespace IRIs from receiving the same prefix, model namespace IRIs are processed in lexicographic order.

The first namespace receives the normalized base prefix. Later collisions receive deterministic numeric suffixes beginning with `_2`.

For example:

```text
collision_model
collision_model_2
collision_model_3
```

The allocator also avoids reusing prefixes already occupied by shared or non-model namespaces.

This ensures that prefix assignment does not depend on:

* filesystem traversal order;
* source-file parse order;
* Python hash randomization;
* incidental RDFLib namespace ordering;
* previously generated `defaultN` labels.

## Preservation of established shared prefixes

The release generator continues to preserve the deliberately established shared catalog prefixes, including:

```text
ontouml
dcat
dct
ocmv
skos
mod
vcard
vann
```

Meaningful non-model namespace bindings are also preserved.

Generated model prefixes do not replace shared prefixes.

For example, if a model identifier normalizes to:

```text
dcat
```

the established `dcat` binding remains unchanged, and the model namespace receives the next available deterministic prefix, such as:

```text
dcat_2
```

## Removal of unintended `defaultN` model prefixes

The implementation replaces the previous model namespace associations through RDFLib's namespace manager before serialization.

As a result, model namespaces are serialized using their deterministic derived prefixes rather than automatically generated labels such as:

```text
default1
default2
default3
```

The implementation also removes the need for an empty model prefix in the consolidated release.

## RDF semantics

This change affects namespace labels only.

It does not rewrite or otherwise modify:

* subject IRIs;
* predicate IRIs;
* object IRIs;
* model namespace IRIs;
* literals;
* language tags;
* datatypes;
* blank-node structure;
* RDF graph content.

Prefix labels are serialization aliases and are not part of RDF graph semantics.

Regression tests verify graph equivalence using representative RDF content containing:

* URI resources;
* literal values;
* language-tagged literals;
* typed literals;
* blank nodes.

The generated Turtle is also parsed again with RDFLib to verify that the serialized output remains valid.

## Preserved release-generator behavior

The existing release-generator behavior remains unchanged outside model-prefix allocation.

This PR preserves:

* release-tag validation;
* validation of real calendar dates;
* the current UTC date as the default release tag;
* the `ontouml-models-YYYYMMDD.ttl` output naming convention;
* relative and absolute output-directory handling;
* deterministic Turtle-file discovery;
* current release inclusion rules;
* current release exclusion rules;
* existing Turtle parsing behavior;
* current error handling;
* `--list-files`;
* existing CLI behavior.

The change does not alter which RDF files or triples are included in the release.

## Test coverage

The existing release-generator tests are preserved and extended with focused regression coverage.

The test suite now verifies:

1. meaningful model prefixes derived from model identifiers;
2. normalization of hyphens to underscores;
3. support for namespaces ending in `#`;
4. support for namespaces ending in `/`;
5. absence of unintended `defaultN` prefix declarations;
6. absence of unintended empty model-prefix declarations;
7. distinct prefixes for multiple model namespaces;
8. deterministic normalization-collision handling;
9. prefix allocation independent of graph parse order;
10. preservation of established shared prefixes;
11. collision handling when a generated model prefix matches a shared prefix;
12. valid generated Turtle prefix labels;
13. identifiers beginning with digits;
14. repeated separators;
15. unsupported characters;
16. case normalization;
17. empty or unusable derived identifiers;
18. successful parsing of generated Turtle;
19. preservation of expected RDF triples;
20. preservation of URI resources;
21. preservation of ordinary literals;
22. preservation of language-tagged literals;
23. preservation of typed literals;
24. blank-node-aware RDF graph equivalence;
25. stable model-prefix declarations across repeated executions;
26. preservation of existing release-generator behavior.

The regression tests use focused synthetic fixtures where appropriate and do not depend on arbitrary RDF triple ordering.

## Validation

The focused release-generator test suite was executed with:

```bash
python -m pytest -q scripts/tests/test_generate_release_file.py
```

Result:

```text
37 passed
```

The release generator was also executed against the complete catalog using:

```bash
python scripts/generate_release_file.py . \
  --release-tag 19700101 \
  --output-dir results \
  --list-files
```

The generated release was validated successfully.

Validation confirmed that:

* the release generation completed successfully;
* the generated Turtle parsed successfully;
* the parsed triple count matched the generator output;
* representative model identifiers received the expected meaningful prefixes;
* model identifiers containing hyphens were normalized using underscores;
* no unintended `defaultN` model prefix declarations remained;
* repeated generation produced stable model-prefix declarations;
* the generated RDF remained semantically equivalent.

The generated `results/` directory was used only for local validation and is not included in this PR.

## Files changed

This PR modifies only:

```text
scripts/generate_release_file.py
scripts/tests/test_generate_release_file.py
```

No model files, generated release artifacts, workflow files, metadata files, or unrelated repository files are modified.

## Scope

This PR is intentionally limited to correcting model namespace prefixes in the consolidated Turtle serialization.

It does not:

* modify source model Turtle files;
* rewrite model namespace IRIs;
* change RDF content;
* change release inclusion rules;
* change release exclusion rules;
* change the public release naming convention;
* change release-tag semantics;
* modify the release workflow;
* modify release publication behavior;
* redesign the release architecture;
* introduce unrelated refactoring.

The change is limited to deterministic model-prefix generation in the existing release generator and the regression tests required to validate that behavior.
