### PR TITLE
docs: clarify catalog status and highlight notices

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,11 @@ Also known as the FAIR Model Catalog for Ontology-Driven Conceptual Modeling Res
 | Understand the formats and validation limits | [Technical overview](documentation/technical-overview.md) |
 | Run repository maintenance tools | [Script index and setup](scripts/README.md) |
 
-This GitHub repository is the **storage, distribution, and contribution layer**. The [FAIR Data Point (FDP)](https://w3id.org/ontouml-models) is a separately operated **discovery layer**. This documentation covers the repository, not FDP operations. See the [documentation index](documentation/README.md) for the full reader paths.
+> [!IMPORTANT]
+> **Current source of catalog data:** This GitHub repository is the catalog's actively maintained and regularly updated **storage, distribution, and contribution layer**. The separately operated [FAIR Data Point (FDP)](https://w3id.org/ontouml-models) has not been updated since its initial release, is currently outdated, and has no planned update or synchronization work at this time. Use this repository and its releases for current catalog content. See the [documentation index](documentation/README.md) for the full reader paths.
 
-The existing [catalog dashboard](http://w3id.org/ontouml-models/dashboard) is another overview entry point; its operational behavior is outside this repository documentation's inspected scope.
+> [!NOTE]
+> **Community dashboard:** The existing [catalog dashboard](http://w3id.org/ontouml-models/dashboard) is a community-contributed companion project that provides another view of the catalog. It is independently operated, is not an official component of the OntoUML/UFO Catalog, and may lag behind the maintained GitHub repository. It remains linked here in recognition of that contribution.
 
 ## Table of Contents
 
@@ -86,7 +88,10 @@ RDF represents model content as a graph; Turtle is the text syntax used for the 
 
 ![Metadata overview showing a catalog, model datasets, their file distributions, and descriptive links. The technical overview explains the relationships and known constraint differences.](documentation/metadata-schema.png)
 
-This image is a conceptual overview, not the current normative validation specification. A [text explanation and constraint comparison](documentation/technical-overview.md#reading-the-metadata-overview-figure) documents differences from the stored shapes and the separate YAML authoring rules. Catalog metadata reuses classes and properties from the following RDF/OWL vocabularies:
+> [!NOTE]
+> This image is a conceptual overview, not the current normative validation specification. A [text explanation and constraint comparison](documentation/technical-overview.md#reading-the-metadata-overview-figure) documents differences from the stored shapes and the separate YAML authoring rules.
+
+Catalog metadata reuses classes and properties from the following RDF/OWL vocabularies:
 
 - [Data Catalog Vocabulary (DCAT)](http://www.w3.org/ns/dcat): The central vocabulary in our metadata schema, DCAT was “*designed to facilitate interoperability between data catalogs published on the Web*”.
 
@@ -112,7 +117,10 @@ The OntoUML/UFO Catalog Metadata Vocabulary's elements are identified below by t
 
 ### FAIR Data Point: The Data Discovery Service
 
-The [OntoUML FAIR Data Point](https://w3id.org/ontouml-models) is the catalog's separately operated discovery service, based on the [FAIR Data Point approach](https://doi.org/10.1162/dint_a_00160) to exposing rich metadata. GitHub remains the storage, distribution, and contribution layer described here. Repository-side catalog synchronization does not establish that the live FDP is synchronized. Its endpoints, search features, and operational behavior are outside this documentation's inspected scope; see the [responsibility boundary](documentation/technical-overview.md#github-storage-and-fdp-discovery).
+The [OntoUML FAIR Data Point](https://w3id.org/ontouml-models) is the catalog's separately operated discovery service, based on the [FAIR Data Point approach](https://doi.org/10.1162/dint_a_00160) to exposing rich metadata.
+
+> [!IMPORTANT]
+> The FDP has not been updated since its initial release and does not represent the current catalog state. No FDP update or synchronization work is currently planned. The GitHub repository remains actively maintained and is the authoritative source for current files, metadata, history, contributions, and releases. See the [responsibility boundary](documentation/technical-overview.md#github-storage-and-fdp-discovery).
 
 ## Catalog's Persistent URLs
 
@@ -120,7 +128,7 @@ Persistent entry points are listed below. A stable URL is not necessarily an imm
 
 | Resource | Persistent entry point |
 | --- | --- |
-| FDP catalog page | [Catalog discovery](https://w3id.org/ontouml-models) |
+| FDP catalog page (currently outdated) | [Catalog discovery](https://w3id.org/ontouml-models) |
 | GitHub repository | [Repository](https://w3id.org/ontouml-models/git) |
 | OntoUML vocabulary | [OntoUML](https://w3id.org/ontouml) |
 | Latest catalog release | [Latest release](https://w3id.org/ontouml-models/release) |
@@ -146,7 +154,8 @@ The easiest way to contribute to this catalog is to simply send us the following
 
 If you wish to contribute to this initiative by submitting your ontology, use the [catalog's contribution form](https://forms.gle/wNSMfaJfkS3hi69o7).
 
-Note that **anonymous ontologies are allowed in the catalog**. So, if you do not want your name to be displayed in your ontology’s metadata, you just have to inform us and we will keep the model’s authorship anonymous. It is important that, in such case, you must be the owner of the ontology’s legal rights.
+> [!NOTE]
+> **Anonymous ontologies are allowed in the catalog.** If you do not want your name to be displayed in your ontology's metadata, inform us and we will keep the model's authorship anonymous. In that case, you must be the owner of the ontology's legal rights.
 
 If you wish to contribute by submitting someone else's ontology, consult the "*Not Started*" or "*Started*" sheets in the [List of UFO and OntoUML Ontology Models](https://docs.google.com/spreadsheets/d/1JXEA3k58yAkV_jbmEc7HP9QK7RgZC5Jk1y8MR7ylFyQ/edit?usp=sharing). The *Started* sheet may identify an existing working branch; confirm the current entry and branch with an administrator before duplicating work.
 
@@ -162,7 +171,8 @@ For a repository submission, prepare one model folder directly under `models/` c
 
 Keep the JSON export consistent with the native project; VPP-to-JSON export is not automated by the catalog. Do not add a manually generated `ontology.ttl` or edit generated Turtle to change the model: update `ontology.json` instead.
 
-**Automatic submission processing requires a branch in the same repository as the PR's target. Fork-based PR writeback is not supported.** Contributors without branch access can use the contribution form above or contact a catalog administrator.
+> [!IMPORTANT]
+> **Automatic submission processing requires a branch in the same repository as the PR's target. Fork-based PR writeback is not supported.** Contributors without branch access can use the contribution form above or contact a catalog administrator.
 
 For a normal same-repository PR, automation validates the sources, generates `ontology.ttl`, synchronizes distribution and model metadata, updates root `catalog.ttl`, and commits changes back to the PR branch. This can include **normalized `metadata.yaml`**, with comments or formatting changed, as well as generated files. A synchronized rerun creates no additional commit. A curator reviews the resulting PR before merging it; automated checks do not establish semantic quality or rights clearance. See the [submission workflow guide](scripts/process-new-model-submission.md) for the exact processing order, warnings, failure behavior, and local validation commands.
 
@@ -207,7 +217,8 @@ We would like to thank all the [contributors](https://github.com/OntoUML/ontouml
 
 ## License disclaimer
 
-> **Caution:** Existing rights statements may have incomplete or inconsistent coverage, including differences between model YAML and retained RDF metadata. Consult the statements below, [LICENSE](LICENSE), and the relevant model metadata and original sources; seek clarification from the [catalog administrators](#catalog-administration) where necessary. This caution does not resolve those differences or determine which statement controls.
+> [!CAUTION]
+> Existing rights statements may have incomplete or inconsistent coverage, including differences between model YAML and retained RDF metadata. Consult the statements below, [LICENSE](LICENSE), and the relevant model metadata and original sources; seek clarification from the [catalog administrators](#catalog-administration) where necessary. This caution does not resolve those differences or determine which statement controls.
 
 The OntoUML/UFO Catalog is licensed under the [Creative Commons Attribution-ShareAlike 4.0 International Public License.](https://creativecommons.org/licenses/by-sa/4.0/)
 

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -11,9 +11,13 @@ The [OntoUML/UFO Catalog](../README.md) stores conceptual models and their repre
 | Check existing rights statements | [License disclaimer and caution](../README.md#license-disclaimer), [LICENSE](../LICENSE), and the selected model's metadata/sources |
 | Find the preferred catalog citation | [How to Cite this Catalog](../README.md#how-to-cite-this-catalog) and [CITATION.cff](../CITATION.cff) |
 
-GitHub is the file storage, distribution, and contribution layer. The [FAIR Data Point](https://w3id.org/ontouml-models) is a separate discovery layer; its operation is outside the repository guidance. See the [responsibility boundary](technical-overview.md#github-storage-and-fdp-discovery).
+> [!IMPORTANT]
+> **Use GitHub for current catalog content.** This repository is actively maintained and updated. The separate [FAIR Data Point](https://w3id.org/ontouml-models) has not been updated since its initial release, is currently outdated, and has no planned update or synchronization work at this time. See the [responsibility boundary](technical-overview.md#github-storage-and-fdp-discovery).
 
 ## Supporting assets and historical material
+
+> [!WARNING]
+> The historical guides and Wiki pages listed below are preserved for provenance and context. They are not current contribution, automation, or product-support instructions. Follow the tracked repository guidance first.
 
 - [Metadata overview figure](metadata-schema.png): retained conceptual overview, with a [text explanation and known constraint differences](technical-overview.md#reading-the-metadata-overview-figure). It is not an executable validation specification.
 - [Full Goal Diagram](Full%20Goal%20Diagram.png): a design-goal artifact, not a statement that every depicted goal is implemented or an architecture diagram of current automation.

--- a/documentation/contributing.md
+++ b/documentation/contributing.md
@@ -13,7 +13,8 @@ Contributions help researchers study and reuse OntoUML and UFO models. Current r
 | Report a model, script, or documentation problem, or suggest an application | [Open an issue](https://github.com/OntoUML/ontouml-models/issues), or use the existing form/administrator route. Include the information relevant to your report below. |
 | Ask about rights or removal | Use the routes in the [license disclaimer](../README.md#license-disclaimer) or contact an administrator. Do not post sensitive evidence publicly. |
 
-**Automatic submission writeback requires a PR branch inside the same repository as its target. Fork-based PR writeback is not supported.** This restriction belongs to the model-submission workflow; the separate [release validation workflow](../scripts/generate-release-file.md#pull-request-validation) does not require a same-repository PR.
+> [!IMPORTANT]
+> **Automatic submission writeback requires a PR branch inside the same repository as its target. Fork-based PR writeback is not supported.** This restriction belongs to the model-submission workflow; the separate [release validation workflow](../scripts/generate-release-file.md#pull-request-validation) does not require a same-repository PR.
 
 The README also documents [anonymous model contributions](../README.md#contribute-by-submitting-an-ontology). If helping catalog someone else's model, consult the existing [List of UFO and OntoUML Ontology Models](https://docs.google.com/spreadsheets/d/1JXEA3k58yAkV_jbmEc7HP9QK7RgZC5Jk1y8MR7ylFyQ/edit?usp=sharing) and confirm the entry's current status and any working branch with an administrator before duplicating work. A spreadsheet entry does not establish permission to redistribute a model.
 
@@ -66,4 +67,5 @@ Diagnostics are in check results and workflow logs, not automatically posted as 
 
 ## Historical modeling and import advice
 
-The tracked [historical model-reconstruction guidance](historical/model-reconstruction.md) and [historical Visual Paradigm import guide](historical/importing-models-to-visual-paradigm.md) preserve older Wiki material, including version-specific instructions. Treat them as historical references pending curator confirmation, not as the current automated conversion contract or an endorsement of present editor/edition support. Ask a curator when applying those modeling rules requires interpretation. Current submission mechanics are the tracked guidance linked above.
+> [!WARNING]
+> The tracked [historical model-reconstruction guidance](historical/model-reconstruction.md) and [historical Visual Paradigm import guide](historical/importing-models-to-visual-paradigm.md) preserve older Wiki material, including version-specific instructions. Treat them as historical references pending curator confirmation, not as the current automated conversion contract or an endorsement of present editor/edition support. Ask a curator when applying those modeling rules requires interpretation. Current submission mechanics are the tracked guidance linked above.

--- a/documentation/historical/importing-models-to-visual-paradigm.md
+++ b/documentation/historical/importing-models-to-visual-paradigm.md
@@ -1,5 +1,6 @@
 # Historical guide to importing models into Visual Paradigm
 
+> [!WARNING]
 > **Historical status:** This version-specific procedure was copied from a repository Wiki snapshot dated 8 November 2023. It describes Visual Paradigm 16.3 and editor behavior asserted by that snapshot; it has not been verified against current products, editions, licenses, or interfaces. It is not the current automated conversion contract. For current repository submissions, follow [Contributing and reporting problems](../contributing.md).
 
 **Provenance:** [Original Wiki page](https://github.com/OntoUML/ontouml-models/wiki/Importing-Models-from-Other-Editors-and-Formats-to-Visual-Paradigm) · [immutable page revision `72e6ca6db619a3e9aa3f4c982ff81dd5b4cfe85e`](https://github.com/OntoUML/ontouml-models/wiki/Importing-Models-from-Other-Editors-and-Formats-to-Visual-Paradigm/72e6ca6db619a3e9aa3f4c982ff81dd5b4cfe85e) · inspected in Wiki repository snapshot `8d172200661ba9abee6ca058ae26e558e0efa8a1` (8 November 2023)

--- a/documentation/historical/model-reconstruction.md
+++ b/documentation/historical/model-reconstruction.md
@@ -1,5 +1,6 @@
 # Historical model-reconstruction guidance
 
+> [!WARNING]
 > **Historical status:** This material was copied from a repository Wiki snapshot dated 8 November 2023. It preserves earlier guidance for manually reconstructing models and awaits curator confirmation. It is not the current automated conversion contract. For current repository submissions, follow [Contributing and reporting problems](../contributing.md); ask a curator before relying on these modeling rules where interpretation is required.
 
 **Provenance:** [Original Wiki page](https://github.com/OntoUML/ontouml-models/wiki/Frequently-Asked-Questions) · [immutable page revision `5d838b8dafb9ec4e48fd830460c79296b5ec4a96`](https://github.com/OntoUML/ontouml-models/wiki/Frequently-Asked-Questions/5d838b8dafb9ec4e48fd830460c79296b5ec4a96) · inspected in Wiki repository snapshot `8d172200661ba9abee6ca058ae26e558e0efa8a1` (8 November 2023)

--- a/documentation/technical-overview.md
+++ b/documentation/technical-overview.md
@@ -94,7 +94,10 @@ Changing ontology content alone need not change the Turtle distribution's metada
 
 ![Metadata overview: a catalog groups model datasets, each with file distributions; resources connect to contributors, contact information, themes, and descriptive metadata. Constraint differences are explained below.](metadata-schema.png)
 
-This existing image is a conceptual overview, **not the current normative validation specification**. In text: a catalog links to model datasets; a model links to its distributions; a distribution records its format and download location. Shared resource metadata supplies descriptions, dates, licenses, and people/organizations. Model metadata also records language, theme, purpose, context, representation style, and sources.
+> [!NOTE]
+> This existing image is a conceptual overview, **not the current normative validation specification**.
+
+In text: a catalog links to model datasets; a model links to its distributions; a distribution records its format and download location. Shared resource metadata supplies descriptions, dates, licenses, and people/organizations. Model metadata also records language, theme, purpose, context, representation style, and sources.
 
 Known differences between the image and the stored shapes are:
 
@@ -110,4 +113,7 @@ No editable source for this raster figure was identified in the inspected reposi
 
 ## GitHub storage and FDP discovery
 
-GitHub stores and distributes the files, records their history, accepts contributions, and runs the documented repository automation. The [FAIR Data Point](https://w3id.org/ontouml-models) is a separately operated discovery layer for catalog metadata. Repository-side `catalog.ttl` synchronization is not evidence that a live FDP has indexed or synchronized that content. FDP endpoints, search, deployment, and operational behavior are outside this guide's inspected scope; useful [FDP references](../README.md#fair-data-point-the-data-discovery-service) remain available.
+GitHub stores and distributes the files, records their history, accepts contributions, and runs the documented repository automation.
+
+> [!IMPORTANT]
+> GitHub is the actively maintained and regularly updated source for the current catalog. The separately operated [FAIR Data Point](https://w3id.org/ontouml-models) has not been updated since its initial release, is currently outdated, and has no planned update or synchronization work at this time. Repository-side `catalog.ttl` synchronization does not update the FDP. Its endpoints, search, deployment, and operational behavior remain outside this guide; useful [FDP references](../README.md#fair-data-point-the-data-discovery-service) are retained for context.

--- a/documentation/using-models.md
+++ b/documentation/using-models.md
@@ -30,7 +30,8 @@ The default branch and [latest-release entry point](https://w3id.org/ontouml-mod
 
 ## Walkthrough: the Reference Ontology of Trust
 
-This is a fixed historical example from [release `20260827`](https://github.com/OntoUML/ontouml-models/releases/tag/20260827), at commit `617dc16ee30a94d8c0587463f1b9ba3b3aef07d7`. It is not a claim that this remains the latest release or that later versions contain identical files.
+> [!NOTE]
+> This is a fixed historical example from [release `20260827`](https://github.com/OntoUML/ontouml-models/releases/tag/20260827), at commit `617dc16ee30a94d8c0587463f1b9ba3b3aef07d7`. It is not a claim that this remains the latest release or that later versions contain identical files.
 
 | Open this pinned file | What to learn |
 | --- | --- |

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -2,7 +2,10 @@
 
 [Repository overview](../README.md)
 
-These Python tools validate contributor files, generate committed model/catalog metadata, and assemble RDF releases. They operate on the GitHub repository's storage layer. They do not deploy, index, or verify the separately operated FAIR Data Point (FDP).
+These Python tools validate contributor files, generate committed model/catalog metadata, and assemble RDF releases.
+
+> [!NOTE]
+> These tools operate only on the GitHub repository's storage layer. They do not deploy, index, synchronize, or verify the separately operated FAIR Data Point (FDP).
 
 For a complete model submission, start with the [submission workflow guide](process-new-model-submission.md). For release artifacts and publication behavior, use the [release operator guide](generate-release-file.md). Running an individual generator does not run the whole pipeline or publish anything to GitHub.
 

--- a/scripts/metadata_yaml_to_ttl.md
+++ b/scripts/metadata_yaml_to_ttl.md
@@ -160,7 +160,7 @@ The remaining model-level descriptive metadata is regenerated from `metadata.yam
 
 When the regenerated `metadata.ttl` content differs from the current file, including formatting-only differences, the converter preserves existing `fdpo:metadataIssued` but updates `fdpo:metadataModified` to the explicit run timestamp provided through `--metadata-timestamp`. If `fdpo:metadataIssued` is missing, it is initialized with the same explicit run timestamp.
 
-This behavior allows safe regeneration of existing datasets without replacing stable catalog identifiers or distribution links, while keeping FDP modification metadata aligned with the actual regeneration outcome.
+This behavior allows safe regeneration of existing datasets without replacing stable catalog identifiers or distribution links, while keeping the stored FDP-vocabulary modification metadata aligned with the actual regeneration outcome. It does not synchronize or update the live FDP service.
 
 ## New datasets
 
@@ -177,7 +177,7 @@ New datasets must be generated with an explicit metadata timestamp unless one is
 python scripts/metadata_yaml_to_ttl.py models/new-dataset --metadata-timestamp 2026-01-31T12:00:00Z
 ```
 
-Use `--metadata-timestamp now` only when non-deterministic current timestamps are intentionally acceptable. Existing datasets preserve their current `fdpo:metadataIssued` value by default. Existing `fdpo:metadataModified` values are preserved only when the regenerated file is unchanged; if the file changes, `fdpo:metadataModified` is updated to the explicit run timestamp. Existing datasets that currently lack FDP metadata timestamps, or that need to be modified, require `--metadata-timestamp`; this avoids silently inventing catalog metadata timestamps.
+Use `--metadata-timestamp now` only when non-deterministic current timestamps are intentionally acceptable. Existing datasets preserve their current `fdpo:metadataIssued` value by default. Existing `fdpo:metadataModified` values are preserved only when the regenerated file is unchanged; if the file changes, `fdpo:metadataModified` is updated to the explicit run timestamp. Existing datasets that currently lack stored `fdpo:` metadata timestamps, or that need to be modified, require `--metadata-timestamp`; this avoids silently inventing catalog metadata timestamps.
 
 ## Exit codes
 


### PR DESCRIPTION
## Summary

* Use GitHub admonitions to make important operational, historical, and licensing notices more visible.
* Present the catalog dashboard as an independently operated community companion rather than an official catalog component, noting that it may lag behind the maintained repository.
* Clarify that GitHub is the actively maintained source for current catalog content.
* State that the FAIR Data Point has not been updated since its initial release, is currently outdated, and has no update or synchronization work planned.
* Clarify that repository-side FDP-vocabulary metadata generation does not update the live FDP service.

## Scope

This PR changes documentation only. It does not modify:

* model or catalog data;
* scripts or workflow behavior;
* FDP infrastructure or operations;
* release descriptions.

The corresponding historical notices in the repository Wiki were updated separately.

## Validation

* `python -m pip check`: no broken requirements
* `git diff --check`: passed
* `python -m pytest -q scripts/tests`: 429 passed with Python 3.13.7
