### PR TITLE
fix(metadata): remove unauthorized licenses from generated artifacts

### DIFF
--- a/models/abel2015petroleum-system/metadata-json.ttl
+++ b/models/abel2015petroleum-system/metadata-json.ttl
@@ -12,10 +12,9 @@
     dct:isPartOf <https://w3id.org/ontouml-models/model/7ed5893a-ead6-4de1-b9c1-635e7af3de00>;
     dct:issued "2015"^^xsd:gYear;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of Petroleum System Model"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/abel2015petroleum-system/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T17:33:20.976070312Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .

--- a/models/abel2015petroleum-system/metadata-png-n-petroleum-system.ttl
+++ b/models/abel2015petroleum-system/metadata-png-n-petroleum-system.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/8decbca5-511b-48a0-97a4-727bd60b36a3> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/7ed5893a-ead6-4de1-b9c1-635e7af3de00> ;
     dct:issued "2015"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'petroleum system' from the Petroleum System Model (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/abel2015petroleum-system/new-diagrams/petroleum-system.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:33:22.898648451Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/abel2015petroleum-system/metadata-png-o-petroleum-system.ttl
+++ b/models/abel2015petroleum-system/metadata-png-o-petroleum-system.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/7e48f61c-5004-4c94-9c9c-d78c6e0b5443> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/7ed5893a-ead6-4de1-b9c1-635e7af3de00> ;
     dct:issued "2015"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'petroleum system' from the Petroleum System Model (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/abel2015petroleum-system/original-diagrams/petroleum-system.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:33:24.802284319Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/abel2015petroleum-system/metadata-turtle.ttl
+++ b/models/abel2015petroleum-system/metadata-turtle.ttl
@@ -7,11 +7,10 @@
 <https://w3id.org/ontouml-models/distribution/f5c87f00-66fa-47a9-a0a8-07b88588b095/> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/7ed5893a-ead6-4de1-b9c1-635e7af3de00> ;
     dct:issued "2015"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Turtle distribution of Petroleum System Model"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/abel2015petroleum-system/ontology.ttl> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
     fdpo:metadataIssued "2023-04-14T17:33:26.603879933Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/abel2015petroleum-system/metadata-vpp.ttl
+++ b/models/abel2015petroleum-system/metadata-vpp.ttl
@@ -8,11 +8,10 @@
     dct:format <https://www.file-extension.info/format/vpp> ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/7ed5893a-ead6-4de1-b9c1-635e7af3de00> ;
     dct:issued "2015"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Visual Paradigm distribution of Petroleum System Model"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/abel2015petroleum-system/ontology.vpp> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/octet-stream> ;
     fdpo:metadataIssued "2023-04-14T17:33:28.375970061Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T00:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/abel2015petroleum-system/metadata.ttl
+++ b/models/abel2015petroleum-system/metadata.ttl
@@ -17,7 +17,6 @@
     dcat:theme lcc:Q;
     skos:editorialNote "Despite being represented as simple attributes, some of the model's attributes represent enumerations - we decided to model them as enumerations for the correct representation. The attributes that do not represent enumerations were represented just like in its original version.";
     dct:language "en";
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:contributor <https://dblp.org/pid/a/MaraAbel>,
                     <https://dblp.org/pid/76/4608>,
                     <https://dblp.org/pid/121/5033>;
@@ -30,7 +29,7 @@
     ocmv:ontologyType ocmv:Domain;
     ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/abel2015petroleum-system"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:33:19.190667802Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .
 
 <https://w3id.org/ontouml-models/model/7ed5893a-ead6-4de1-b9c1-635e7af3de00> dcat:distribution <https://w3id.org/ontouml-models/distribution/f5c87f00-66fa-47a9-a0a8-07b88588b095/>,
                       <https://w3id.org/ontouml-models/distribution/ccddedaa-6508-41ee-a621-9d7f56c06419/>,

--- a/models/abrahao2018agriculture-operations/metadata-json.ttl
+++ b/models/abrahao2018agriculture-operations/metadata-json.ttl
@@ -12,10 +12,9 @@
     dct:isPartOf <https://w3id.org/ontouml-models/model/d07d44af-d127-4407-8d0f-72b9e17a6479>;
     dct:issued "2018"^^xsd:gYear;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of Agriculture Operations Task Ontology"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/abrahao2018agriculture-operations/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T17:33:32.949687929Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .

--- a/models/abrahao2018agriculture-operations/metadata-png-n-diagram1.ttl
+++ b/models/abrahao2018agriculture-operations/metadata-png-n-diagram1.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/e9f630e6-013c-45b7-8f2b-4e5161f27217> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/d07d44af-d127-4407-8d0f-72b9e17a6479> ;
     dct:issued "2018"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram1' from the Agriculture Operations Task Ontology (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/abrahao2018agriculture-operations/new-diagrams/diagram1.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:33:34.646249507Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/abrahao2018agriculture-operations/metadata-png-n-diagram2.ttl
+++ b/models/abrahao2018agriculture-operations/metadata-png-n-diagram2.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/607d5cd1-4329-43fc-be52-f7e8dc9b4a6b> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/d07d44af-d127-4407-8d0f-72b9e17a6479> ;
     dct:issued "2018"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram2' from the Agriculture Operations Task Ontology (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/abrahao2018agriculture-operations/new-diagrams/diagram2.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:33:36.421930965Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/abrahao2018agriculture-operations/metadata-png-o-diagram1.ttl
+++ b/models/abrahao2018agriculture-operations/metadata-png-o-diagram1.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/8b3255e7-b29e-4d72-8c43-f47b0b865944> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/d07d44af-d127-4407-8d0f-72b9e17a6479> ;
     dct:issued "2018"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram1' from the Agriculture Operations Task Ontology (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/abrahao2018agriculture-operations/original-diagrams/diagram1.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:33:38.065392984Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/abrahao2018agriculture-operations/metadata-png-o-diagram2.ttl
+++ b/models/abrahao2018agriculture-operations/metadata-png-o-diagram2.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/2649f247-8132-45ce-a6a9-e64f54443a38> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/d07d44af-d127-4407-8d0f-72b9e17a6479> ;
     dct:issued "2018"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram2' from the Agriculture Operations Task Ontology (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/abrahao2018agriculture-operations/original-diagrams/diagram2.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:33:39.777376236Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/abrahao2018agriculture-operations/metadata-turtle.ttl
+++ b/models/abrahao2018agriculture-operations/metadata-turtle.ttl
@@ -7,11 +7,10 @@
 <https://w3id.org/ontouml-models/distribution/f8b97967-0e4a-491c-8b3f-85e86d44cb5f/> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/d07d44af-d127-4407-8d0f-72b9e17a6479> ;
     dct:issued "2018"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Turtle distribution of Agriculture Operations Task Ontology"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/abrahao2018agriculture-operations/ontology.ttl> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
     fdpo:metadataIssued "2023-04-14T17:33:41.463786671Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/abrahao2018agriculture-operations/metadata-vpp.ttl
+++ b/models/abrahao2018agriculture-operations/metadata-vpp.ttl
@@ -8,11 +8,10 @@
     dct:format <https://www.file-extension.info/format/vpp> ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/d07d44af-d127-4407-8d0f-72b9e17a6479> ;
     dct:issued "2018"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Visual Paradigm distribution of Agriculture Operations Task Ontology"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/abrahao2018agriculture-operations/ontology.vpp> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/octet-stream> ;
     fdpo:metadataIssued "2023-04-14T17:33:43.144700162Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T00:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/abrahao2018agriculture-operations/metadata.ttl
+++ b/models/abrahao2018agriculture-operations/metadata.ttl
@@ -15,7 +15,6 @@
     dct:issued "2018"^^xsd:gYear;
     dcat:theme lcc:S;
     dct:language "en";
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:contributor <https://dblp.org/pid/58/7513>,
                     <https://dblp.org/pid/66/5960>;
     dcat:keyword "agriculture"@en;
@@ -27,7 +26,7 @@
     ocmv:ontologyType ocmv:Domain;
     ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/abrahao2018agriculture-operations"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:33:31.496875993Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .
 
 <https://w3id.org/ontouml-models/model/d07d44af-d127-4407-8d0f-72b9e17a6479> dcat:distribution <https://w3id.org/ontouml-models/distribution/f8b97967-0e4a-491c-8b3f-85e86d44cb5f/>,
                       <https://w3id.org/ontouml-models/distribution/51727a95-2d6b-448c-ac1e-e7506bd5174b/>,

--- a/models/ahmad2018aviation/metadata-json.ttl
+++ b/models/ahmad2018aviation/metadata-json.ttl
@@ -12,10 +12,9 @@
     dct:isPartOf <https://w3id.org/ontouml-models/model/660ad6c4-dbc1-43e7-b582-d7eb9ec43739>;
     dct:issued "2018"^^xsd:gYear;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of Aviation Safety Ontology"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/ahmad2018aviation/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T17:34:12.962539041Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .

--- a/models/ahmad2018aviation/metadata-png-n-aviation-safety-ontology-2.ttl
+++ b/models/ahmad2018aviation/metadata-png-n-aviation-safety-ontology-2.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/c093f9de-5481-41dd-9466-e74c2153b479> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/660ad6c4-dbc1-43e7-b582-d7eb9ec43739> ;
     dct:issued "2018"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'aviation safety ontology 2' from the Aviation Safety Ontology (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/ahmad2018aviation/new-diagrams/aviation-safety-ontology-2.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:34:14.648344927Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/ahmad2018aviation/metadata-png-n-aviation-safety-ontology.ttl
+++ b/models/ahmad2018aviation/metadata-png-n-aviation-safety-ontology.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/c2ba45c2-15ea-413b-a647-3a2fbc9a07e9> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/660ad6c4-dbc1-43e7-b582-d7eb9ec43739> ;
     dct:issued "2018"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'aviation safety ontology' from the Aviation Safety Ontology (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/ahmad2018aviation/new-diagrams/aviation-safety-ontology.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:34:16.244493608Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/ahmad2018aviation/metadata-png-o-aviation-safety-ontology-2.ttl
+++ b/models/ahmad2018aviation/metadata-png-o-aviation-safety-ontology-2.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/639ce4c9-d83b-4c4e-b207-e605284a3084> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/660ad6c4-dbc1-43e7-b582-d7eb9ec43739> ;
     dct:issued "2018"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'aviation safety ontology 2' from the Aviation Safety Ontology (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/ahmad2018aviation/original-diagrams/aviation-safety-ontology-2.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:34:17.775391863Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/ahmad2018aviation/metadata-png-o-aviation-safety-ontology.ttl
+++ b/models/ahmad2018aviation/metadata-png-o-aviation-safety-ontology.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/471c8f9e-f70f-45f9-a445-ca201e694ff1> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/660ad6c4-dbc1-43e7-b582-d7eb9ec43739> ;
     dct:issued "2018"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'aviation safety ontology' from the Aviation Safety Ontology (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/ahmad2018aviation/original-diagrams/aviation-safety-ontology.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:34:19.385757939Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/ahmad2018aviation/metadata-turtle.ttl
+++ b/models/ahmad2018aviation/metadata-turtle.ttl
@@ -7,11 +7,10 @@
 <https://w3id.org/ontouml-models/distribution/69cd521b-671c-49f2-a176-e31910dec404/> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/660ad6c4-dbc1-43e7-b582-d7eb9ec43739> ;
     dct:issued "2018"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Turtle distribution of Aviation Safety Ontology"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/ahmad2018aviation/ontology.ttl> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
     fdpo:metadataIssued "2023-04-14T17:34:20.99131566Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/ahmad2018aviation/metadata-vpp.ttl
+++ b/models/ahmad2018aviation/metadata-vpp.ttl
@@ -8,11 +8,10 @@
     dct:format <https://www.file-extension.info/format/vpp> ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/660ad6c4-dbc1-43e7-b582-d7eb9ec43739> ;
     dct:issued "2018"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Visual Paradigm distribution of Aviation Safety Ontology"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/ahmad2018aviation/ontology.vpp> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/octet-stream> ;
     fdpo:metadataIssued "2023-04-14T17:34:22.528566895Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T00:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/ahmad2018aviation/metadata.ttl
+++ b/models/ahmad2018aviation/metadata.ttl
@@ -15,7 +15,6 @@
     dct:issued "2018"^^xsd:gYear;
     dcat:theme lcc:T;
     dct:language "en";
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:contributor <https://dblp.org/pid/185/3559>,
                     <https://dblp.org/pid/77/5702>,
                     <https://dblp.org/pid/166/2116>;
@@ -28,7 +27,7 @@
     ocmv:ontologyType ocmv:Domain;
     ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/ahmad2018aviation"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:34:11.689440155Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .
 
 <https://w3id.org/ontouml-models/model/660ad6c4-dbc1-43e7-b582-d7eb9ec43739> dcat:distribution <https://w3id.org/ontouml-models/distribution/69cd521b-671c-49f2-a176-e31910dec404/>,
                       <https://w3id.org/ontouml-models/distribution/f74b710c-d8a5-4f95-b9d1-5a2e07327bbd/>,

--- a/models/aires2022valuenetworks-geo/metadata-json.ttl
+++ b/models/aires2022valuenetworks-geo/metadata-json.ttl
@@ -12,10 +12,9 @@
     dct:isPartOf <https://w3id.org/ontouml-models/model/3886f70e-5a91-411d-a50e-370eb4f93c5a>;
     dct:issued "2022"^^xsd:gYear;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of Ontology for Value Networks with Geographic Information"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/aires2022valuenetworks-geo/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T17:34:25.668396365Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .

--- a/models/aires2022valuenetworks-geo/metadata-png-n-business-need.ttl
+++ b/models/aires2022valuenetworks-geo/metadata-png-n-business-need.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/9d0309ef-011c-411f-a990-517d17404b42> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/3886f70e-5a91-411d-a50e-370eb4f93c5a> ;
     dct:issued "2022"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'business need' from the Ontology for Value Networks with Geographic Information (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/aires2022valuenetworks-geo/new-diagrams/business-need.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:34:27.195075343Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/aires2022valuenetworks-geo/metadata-png-n-organizational-model.ttl
+++ b/models/aires2022valuenetworks-geo/metadata-png-n-organizational-model.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/71b2894f-8e29-476a-b11f-6d401db22f76> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/3886f70e-5a91-411d-a50e-370eb4f93c5a> ;
     dct:issued "2022"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'organizational model' from the Ontology for Value Networks with Geographic Information (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/aires2022valuenetworks-geo/new-diagrams/organizational-model.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:34:28.71903205Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/aires2022valuenetworks-geo/metadata-png-o-business-need-model.ttl
+++ b/models/aires2022valuenetworks-geo/metadata-png-o-business-need-model.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/81c4321a-1e4e-483c-926b-c671bffdefcb> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/3886f70e-5a91-411d-a50e-370eb4f93c5a> ;
     dct:issued "2022"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'business need model' from the Ontology for Value Networks with Geographic Information (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/aires2022valuenetworks-geo/original-diagrams/business-need-model.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:34:30.262333542Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/aires2022valuenetworks-geo/metadata-png-o-organizational-model.ttl
+++ b/models/aires2022valuenetworks-geo/metadata-png-o-organizational-model.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/8a296356-6da0-4e20-819a-25634676e462> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/3886f70e-5a91-411d-a50e-370eb4f93c5a> ;
     dct:issued "2022"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'organizational model' from the Ontology for Value Networks with Geographic Information (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/aires2022valuenetworks-geo/original-diagrams/organizational-model.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:34:31.938760614Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/aires2022valuenetworks-geo/metadata-turtle.ttl
+++ b/models/aires2022valuenetworks-geo/metadata-turtle.ttl
@@ -7,11 +7,10 @@
 <https://w3id.org/ontouml-models/distribution/3109bec0-7e3c-4773-9cb2-7d982b38f11e/> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/3886f70e-5a91-411d-a50e-370eb4f93c5a> ;
     dct:issued "2022"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Turtle distribution of Ontology for Value Networks with Geographic Information"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/aires2022valuenetworks-geo/ontology.ttl> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
     fdpo:metadataIssued "2023-04-14T17:34:33.510918938Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/aires2022valuenetworks-geo/metadata-vpp.ttl
+++ b/models/aires2022valuenetworks-geo/metadata-vpp.ttl
@@ -8,11 +8,10 @@
     dct:format <https://www.file-extension.info/format/vpp> ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/3886f70e-5a91-411d-a50e-370eb4f93c5a> ;
     dct:issued "2022"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Visual Paradigm distribution of Ontology for Value Networks with Geographic Information"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/aires2022valuenetworks-geo/ontology.vpp> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/octet-stream> ;
     fdpo:metadataIssued "2023-04-14T17:34:35.162573585Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T00:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/aires2022valuenetworks-geo/metadata.ttl
+++ b/models/aires2022valuenetworks-geo/metadata.ttl
@@ -21,7 +21,6 @@ The cardinalities in derivation link were represented in UML notes.
 There is a collection of generalizations of relators into a single category near a {disjoint} constraint. Given the context, the generalizations were interpreted as part of the same set, and the category's "restrictedTo" was set to "relator".
 """;
     dct:language "en";
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:contributor <https://dblp.org/pid/284/5427>;
     dcat:keyword "value networks"@en;
     mod:designedForTask ocmv:LanguageEngineering;
@@ -30,7 +29,7 @@ There is a collection of generalizations of relators into a single category near
     ocmv:ontologyType ocmv:Domain;
     ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/aires2022valuenetworks-geo"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:34:24.406334322Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .
 
 <https://w3id.org/ontouml-models/model/3886f70e-5a91-411d-a50e-370eb4f93c5a> dcat:distribution <https://w3id.org/ontouml-models/distribution/3109bec0-7e3c-4773-9cb2-7d982b38f11e/>,
                       <https://w3id.org/ontouml-models/distribution/b49051c3-8f8a-468b-9802-2131a4d9ada9/>,

--- a/models/albuquerque2011ontobio/metadata-json.ttl
+++ b/models/albuquerque2011ontobio/metadata-json.ttl
@@ -12,10 +12,9 @@
     dct:isPartOf <https://w3id.org/ontouml-models/model/f3d40402-e30d-4bbc-8792-5566bc8c30e9>;
     dct:issued "2011"^^xsd:gYear;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of OntoBio"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/albuquerque2011ontobio/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T17:34:38.539952272Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .

--- a/models/albuquerque2011ontobio/metadata-png-n-classification.ttl
+++ b/models/albuquerque2011ontobio/metadata-png-n-classification.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/c2d3369d-7ca5-454f-902f-e2eab1accda3> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/f3d40402-e30d-4bbc-8792-5566bc8c30e9> ;
     dct:issued "2011"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'classification' from the OntoBio (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/albuquerque2011ontobio/new-diagrams/classification.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:34:40.401995271Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/albuquerque2011ontobio/metadata-png-n-ecosystem.ttl
+++ b/models/albuquerque2011ontobio/metadata-png-n-ecosystem.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/bd6e147c-95b4-45d0-bcca-8b58ee7c7095> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/f3d40402-e30d-4bbc-8792-5566bc8c30e9> ;
     dct:issued "2011"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'ecosystem' from the OntoBio (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/albuquerque2011ontobio/new-diagrams/ecosystem.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:34:42.058015298Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/albuquerque2011ontobio/metadata-png-n-environment.ttl
+++ b/models/albuquerque2011ontobio/metadata-png-n-environment.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/30353c59-7bc9-44b0-9c63-ffbd0bbe7fb5> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/f3d40402-e30d-4bbc-8792-5566bc8c30e9> ;
     dct:issued "2011"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'environment' from the OntoBio (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/albuquerque2011ontobio/new-diagrams/environment.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:34:45.128578503Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/albuquerque2011ontobio/metadata-png-n-materialentity.ttl
+++ b/models/albuquerque2011ontobio/metadata-png-n-materialentity.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/2f453c71-2cf4-4e9a-9743-9bf27b0df2d0> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/f3d40402-e30d-4bbc-8792-5566bc8c30e9> ;
     dct:issued "2011"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'materialentity' from the OntoBio (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/albuquerque2011ontobio/new-diagrams/materialentity.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:34:46.770844365Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/albuquerque2011ontobio/metadata-png-n-spatiallocation.ttl
+++ b/models/albuquerque2011ontobio/metadata-png-n-spatiallocation.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/57881ae9-a04a-422b-bf06-53981f75c103> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/f3d40402-e30d-4bbc-8792-5566bc8c30e9> ;
     dct:issued "2011"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'spatiallocation' from the OntoBio (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/albuquerque2011ontobio/new-diagrams/spatiallocation.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:34:48.322058413Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/albuquerque2011ontobio/metadata-png-o-diagram1.ttl
+++ b/models/albuquerque2011ontobio/metadata-png-o-diagram1.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/ddbda5c3-b3f4-4594-a8aa-c8475c3addcb> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/f3d40402-e30d-4bbc-8792-5566bc8c30e9> ;
     dct:issued "2011"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram1' from the OntoBio (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/albuquerque2011ontobio/original-diagrams/diagram1.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:34:49.90068323Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/albuquerque2011ontobio/metadata-png-o-diagram2.ttl
+++ b/models/albuquerque2011ontobio/metadata-png-o-diagram2.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/3b5772c6-7d3f-4218-8130-c8e965efa060> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/f3d40402-e30d-4bbc-8792-5566bc8c30e9> ;
     dct:issued "2011"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram2' from the OntoBio (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/albuquerque2011ontobio/original-diagrams/diagram2.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:34:51.440750821Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/albuquerque2011ontobio/metadata-png-o-diagram3.ttl
+++ b/models/albuquerque2011ontobio/metadata-png-o-diagram3.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/e9aff4cb-35dc-480a-805f-39e3a844b0bf> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/f3d40402-e30d-4bbc-8792-5566bc8c30e9> ;
     dct:issued "2011"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram3' from the OntoBio (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/albuquerque2011ontobio/original-diagrams/diagram3.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:34:53.069014218Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/albuquerque2011ontobio/metadata-png-o-diagram4.ttl
+++ b/models/albuquerque2011ontobio/metadata-png-o-diagram4.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/89c8999a-b6fe-4ddf-aa40-b3bf739953cc> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/f3d40402-e30d-4bbc-8792-5566bc8c30e9> ;
     dct:issued "2011"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram4' from the OntoBio (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/albuquerque2011ontobio/original-diagrams/diagram4.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:34:54.724163628Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/albuquerque2011ontobio/metadata-png-o-diagram5.ttl
+++ b/models/albuquerque2011ontobio/metadata-png-o-diagram5.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/7e36cc2e-57c8-4263-969b-e760ca339084> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/f3d40402-e30d-4bbc-8792-5566bc8c30e9> ;
     dct:issued "2011"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram5' from the OntoBio (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/albuquerque2011ontobio/original-diagrams/diagram5.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:34:56.308793614Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/albuquerque2011ontobio/metadata-png-o-diagram6.ttl
+++ b/models/albuquerque2011ontobio/metadata-png-o-diagram6.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/3542273f-972a-4c0c-8d04-9fe5e2297e70> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/f3d40402-e30d-4bbc-8792-5566bc8c30e9> ;
     dct:issued "2011"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram6' from the OntoBio (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/albuquerque2011ontobio/original-diagrams/diagram6.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:34:57.920177697Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/albuquerque2011ontobio/metadata-png-o-diagram7.ttl
+++ b/models/albuquerque2011ontobio/metadata-png-o-diagram7.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/174e42cd-5144-4772-a749-e83d01826595> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/f3d40402-e30d-4bbc-8792-5566bc8c30e9> ;
     dct:issued "2011"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram7' from the OntoBio (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/albuquerque2011ontobio/original-diagrams/diagram7.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:34:59.546107754Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/albuquerque2011ontobio/metadata-png-o-diagram8.ttl
+++ b/models/albuquerque2011ontobio/metadata-png-o-diagram8.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/d7fbd6dd-6ee9-4871-9141-69858e1773cd> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/f3d40402-e30d-4bbc-8792-5566bc8c30e9> ;
     dct:issued "2011"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram8' from the OntoBio (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/albuquerque2011ontobio/original-diagrams/diagram8.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:35:01.127919062Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/albuquerque2011ontobio/metadata-turtle.ttl
+++ b/models/albuquerque2011ontobio/metadata-turtle.ttl
@@ -7,11 +7,10 @@
 <https://w3id.org/ontouml-models/distribution/f374fbe4-fffb-4ce0-afe8-3145fadf7c68/> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/f3d40402-e30d-4bbc-8792-5566bc8c30e9> ;
     dct:issued "2011"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Turtle distribution of OntoBio"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/albuquerque2011ontobio/ontology.ttl> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
     fdpo:metadataIssued "2023-04-14T17:35:02.712923077Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/albuquerque2011ontobio/metadata-vpp.ttl
+++ b/models/albuquerque2011ontobio/metadata-vpp.ttl
@@ -8,11 +8,10 @@
     dct:format <https://www.file-extension.info/format/vpp> ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/f3d40402-e30d-4bbc-8792-5566bc8c30e9> ;
     dct:issued "2011"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Visual Paradigm distribution of OntoBio"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/albuquerque2011ontobio/ontology.vpp> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/octet-stream> ;
     fdpo:metadataIssued "2023-04-14T17:35:04.29165554Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T00:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/albuquerque2011ontobio/metadata.ttl
+++ b/models/albuquerque2011ontobio/metadata.ttl
@@ -18,7 +18,6 @@
     skos:editorialNote "in the reference papers we do not have reference diagrams. However, we have a GitHub page were to get some visual information. Still, the quality of the images is very low. Some images are unreadable which led to them not being included in this model";
     dct:language "en";
     dcat:landingPage <https://github.com/unibz-core/OntoBio_Ontology>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:contributor <https://dblp.org/pid/135/0761>,
                     <https://dblp.org/pid/88/711>,
                     <https://dblp.org/pid/61/2142>,
@@ -36,7 +35,7 @@
     ocmv:ontologyType ocmv:Domain;
     ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/albuquerque2011ontobio"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:34:37.144775488Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .
 
 <https://w3id.org/ontouml-models/model/f3d40402-e30d-4bbc-8792-5566bc8c30e9> dcat:distribution <https://w3id.org/ontouml-models/distribution/f374fbe4-fffb-4ce0-afe8-3145fadf7c68/>,
                       <https://w3id.org/ontouml-models/distribution/faf6213a-d88b-4399-a12b-e6ea29a4ad01/>,

--- a/models/andersson2018value-ascription/metadata-json.ttl
+++ b/models/andersson2018value-ascription/metadata-json.ttl
@@ -12,10 +12,9 @@
     dct:isPartOf <https://w3id.org/ontouml-models/model/3df10e52-a7e6-4e42-a5e5-c34495a5826b>;
     dct:issued "2018"^^xsd:gYear;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of Value Ascription Ontology"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/andersson2018value-ascription/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T17:36:33.551244162Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .

--- a/models/andersson2018value-ascription/metadata-png-n-value-ascription-ontology.ttl
+++ b/models/andersson2018value-ascription/metadata-png-n-value-ascription-ontology.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/34e886d7-1125-479a-9bec-d68a50ee3452> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/3df10e52-a7e6-4e42-a5e5-c34495a5826b> ;
     dct:issued "2018"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'value ascription ontology' from the Value Ascription Ontology (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/andersson2018value-ascription/new-diagrams/value-ascription-ontology.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:36:35.195966939Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/andersson2018value-ascription/metadata-png-o-value-ascription-ontology.ttl
+++ b/models/andersson2018value-ascription/metadata-png-o-value-ascription-ontology.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/4d50c81a-e5fe-47a8-927f-ef85ca3313a8> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/3df10e52-a7e6-4e42-a5e5-c34495a5826b> ;
     dct:issued "2018"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'value ascription ontology' from the Value Ascription Ontology (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/andersson2018value-ascription/original-diagrams/value-ascription-ontology.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:36:37.053459698Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/andersson2018value-ascription/metadata-turtle.ttl
+++ b/models/andersson2018value-ascription/metadata-turtle.ttl
@@ -7,11 +7,10 @@
 <https://w3id.org/ontouml-models/distribution/94303827-76ed-41cc-b2e1-4298b8a18a65/> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/3df10e52-a7e6-4e42-a5e5-c34495a5826b> ;
     dct:issued "2018"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Turtle distribution of Value Ascription Ontology"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/andersson2018value-ascription/ontology.ttl> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
     fdpo:metadataIssued "2023-04-14T17:36:38.583181445Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/andersson2018value-ascription/metadata-vpp.ttl
+++ b/models/andersson2018value-ascription/metadata-vpp.ttl
@@ -8,11 +8,10 @@
     dct:format <https://www.file-extension.info/format/vpp> ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/3df10e52-a7e6-4e42-a5e5-c34495a5826b> ;
     dct:issued "2018"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Visual Paradigm distribution of Value Ascription Ontology"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/andersson2018value-ascription/ontology.vpp> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/octet-stream> ;
     fdpo:metadataIssued "2023-04-14T17:36:40.266515753Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T00:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/andersson2018value-ascription/metadata.ttl
+++ b/models/andersson2018value-ascription/metadata.ttl
@@ -18,7 +18,6 @@
     skos:editorialNote """There is a previous publication on Value Ascription Ontology from the same authors, which even includes a more extensive use of OntoUML. However, it was decided to focus on this one as it seems to represent a step away from the original proposal.
 """;
     dct:language "en";
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:contributor <https://dblp.org/pid/g/JaapGordijn>,
                     <https://dblp.org/pid/p/ErikProper>;
     dcat:keyword "economics"@en,
@@ -31,7 +30,7 @@
     ocmv:ontologyType ocmv:Domain;
     ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/andersson2018value-ascription"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:36:32.310917693Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .
 
 <https://w3id.org/ontouml-models/model/3df10e52-a7e6-4e42-a5e5-c34495a5826b> dcat:distribution <https://w3id.org/ontouml-models/distribution/94303827-76ed-41cc-b2e1-4298b8a18a65/>,
                       <https://w3id.org/ontouml-models/distribution/9d8ead3b-b161-46e4-8a6a-83bf35d08c02/>,

--- a/models/buchtela2020connection/metadata-json.ttl
+++ b/models/buchtela2020connection/metadata-json.ttl
@@ -12,10 +12,9 @@
     dct:isPartOf <https://w3id.org/ontouml-models/model/1b479664-a287-4503-9d2b-7d8cf8bed271>;
     dct:issued "2020"^^xsd:gYear;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of Knowledge Representation Model of Students' Activities"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/buchtela2020connection/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T17:43:25.766842967Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .

--- a/models/buchtela2020connection/metadata-png-n-students'-activities.ttl
+++ b/models/buchtela2020connection/metadata-png-n-students'-activities.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/fa341f6e-f2e2-4fe5-9e52-9e44b2089b92> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/1b479664-a287-4503-9d2b-7d8cf8bed271> ;
     dct:issued "2020"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'students' activities' from the Knowledge Representation Model of Students' Activities (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/buchtela2020connection/new-diagrams/students'-activities.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:43:27.348027154Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/buchtela2020connection/metadata-png-o-diagram1.ttl
+++ b/models/buchtela2020connection/metadata-png-o-diagram1.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/75edf9e3-3878-4d92-816a-b96fc7eb6f73> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/1b479664-a287-4503-9d2b-7d8cf8bed271> ;
     dct:issued "2020"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram1' from the Knowledge Representation Model of Students' Activities (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/buchtela2020connection/original-diagrams/diagram1.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:43:28.851246932Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/buchtela2020connection/metadata-turtle.ttl
+++ b/models/buchtela2020connection/metadata-turtle.ttl
@@ -7,11 +7,10 @@
 <https://w3id.org/ontouml-models/distribution/038e6492-9309-40f8-8a64-fb34f92362f6/> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/1b479664-a287-4503-9d2b-7d8cf8bed271> ;
     dct:issued "2020"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Turtle distribution of Knowledge Representation Model of Students' Activities"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/buchtela2020connection/ontology.ttl> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
     fdpo:metadataIssued "2023-04-14T17:43:30.351180289Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/buchtela2020connection/metadata-vpp.ttl
+++ b/models/buchtela2020connection/metadata-vpp.ttl
@@ -8,11 +8,10 @@
     dct:format <https://www.file-extension.info/format/vpp> ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/1b479664-a287-4503-9d2b-7d8cf8bed271> ;
     dct:issued "2020"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Visual Paradigm distribution of Knowledge Representation Model of Students' Activities"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/buchtela2020connection/ontology.vpp> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/octet-stream> ;
     fdpo:metadataIssued "2023-04-14T17:43:31.780718558Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T00:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/buchtela2020connection/metadata.ttl
+++ b/models/buchtela2020connection/metadata.ttl
@@ -16,7 +16,6 @@
     dct:modified "2020"^^xsd:gYear;
     dcat:theme lcc:L;
     dct:language "en";
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:contributor <https://dblp.org/pid/03/3150>,
                     <https://orcid.org/0000-0001-8955-6002>;
     dcat:keyword "education"@en,
@@ -28,7 +27,7 @@
     ocmv:ontologyType ocmv:Domain;
     ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/buchtela2020connection"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:43:24.638462282Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .
 
 <https://w3id.org/ontouml-models/model/1b479664-a287-4503-9d2b-7d8cf8bed271> dcat:distribution <https://w3id.org/ontouml-models/distribution/038e6492-9309-40f8-8a64-fb34f92362f6/>,
                       <https://w3id.org/ontouml-models/distribution/f51e72a0-f624-48e3-abd2-af359eea0f23/>,

--- a/models/carolla2014campus-management/metadata-json.ttl
+++ b/models/carolla2014campus-management/metadata-json.ttl
@@ -12,10 +12,9 @@
     dct:isPartOf <https://w3id.org/ontouml-models/model/e58213c9-beec-47f7-ac55-b5530bad3930>;
     dct:issued "2014"^^xsd:gYear;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of Campus Management System Reference Data Model"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/carolla2014campus-management/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T17:43:49.975510717Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .

--- a/models/carolla2014campus-management/metadata-png-n-diagram.ttl
+++ b/models/carolla2014campus-management/metadata-png-n-diagram.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/1b78a165-6b20-42a9-b4d7-9ab1d291620d> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/e58213c9-beec-47f7-ac55-b5530bad3930> ;
     dct:issued "2014"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram' from the Campus Management System Reference Data Model (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/carolla2014campus-management/new-diagrams/diagram.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:43:51.398970341Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/carolla2014campus-management/metadata-png-o-diagram1.ttl
+++ b/models/carolla2014campus-management/metadata-png-o-diagram1.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/f9e9075c-adff-4a53-bc18-2266715ec689> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/e58213c9-beec-47f7-ac55-b5530bad3930> ;
     dct:issued "2014"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram1' from the Campus Management System Reference Data Model (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/carolla2014campus-management/original-diagrams/diagram1.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:43:52.898333527Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/carolla2014campus-management/metadata-turtle.ttl
+++ b/models/carolla2014campus-management/metadata-turtle.ttl
@@ -7,11 +7,10 @@
 <https://w3id.org/ontouml-models/distribution/ef15add8-be4c-413a-8927-beb28f0371ec/> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/e58213c9-beec-47f7-ac55-b5530bad3930> ;
     dct:issued "2014"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Turtle distribution of Campus Management System Reference Data Model"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/carolla2014campus-management/ontology.ttl> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
     fdpo:metadataIssued "2023-04-14T17:43:54.460629304Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/carolla2014campus-management/metadata-vpp.ttl
+++ b/models/carolla2014campus-management/metadata-vpp.ttl
@@ -8,11 +8,10 @@
     dct:format <https://www.file-extension.info/format/vpp> ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/e58213c9-beec-47f7-ac55-b5530bad3930> ;
     dct:issued "2014"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Visual Paradigm distribution of Campus Management System Reference Data Model"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/carolla2014campus-management/ontology.vpp> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/octet-stream> ;
     fdpo:metadataIssued "2023-04-14T17:43:55.934801402Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T00:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/carolla2014campus-management/metadata.ttl
+++ b/models/carolla2014campus-management/metadata.ttl
@@ -19,7 +19,6 @@
 The original diagram does not present all stereotypes explained in the text.
 """;
     dct:language "en";
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:contributor <https://dblp.org/pid/83/4571>;
     dcat:keyword "education"@en,
                  "university"@en;
@@ -30,7 +29,7 @@ The original diagram does not present all stereotypes explained in the text.
     ocmv:ontologyType ocmv:Domain;
     ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/carolla2014campus-management"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:43:48.856037859Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .
 
 <https://w3id.org/ontouml-models/model/e58213c9-beec-47f7-ac55-b5530bad3930> dcat:distribution <https://w3id.org/ontouml-models/distribution/ef15add8-be4c-413a-8927-beb28f0371ec/>,
                       <https://w3id.org/ontouml-models/distribution/82cd6931-d4d4-43a8-b06f-709890f7c8a1/>,

--- a/models/castro2012cloudvulnerability/metadata-json.ttl
+++ b/models/castro2012cloudvulnerability/metadata-json.ttl
@@ -12,10 +12,9 @@
     dct:isPartOf <https://w3id.org/ontouml-models/model/9d3dc47b-2ca8-430e-8e57-c2c0a5ed8015>;
     dct:issued "2012"^^xsd:gYear;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of Cloud Vulnerability Ontology"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/castro2012cloudvulnerability/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T17:43:58.841429286Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .

--- a/models/castro2012cloudvulnerability/metadata-png-n-it-resource.ttl
+++ b/models/castro2012cloudvulnerability/metadata-png-n-it-resource.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/6c226bca-3276-4b54-89da-bbcf6e54f9c9> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/9d3dc47b-2ca8-430e-8e57-c2c0a5ed8015> ;
     dct:issued "2012"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'it resource' from the Cloud Vulnerability Ontology (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/castro2012cloudvulnerability/new-diagrams/it-resource.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:44:00.314596543Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/castro2012cloudvulnerability/metadata-png-n-it-service-for-iaas.ttl
+++ b/models/castro2012cloudvulnerability/metadata-png-n-it-service-for-iaas.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/05e97f34-1a58-4b6e-b107-935a426d57de> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/9d3dc47b-2ca8-430e-8e57-c2c0a5ed8015> ;
     dct:issued "2012"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'it service for iaas' from the Cloud Vulnerability Ontology (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/castro2012cloudvulnerability/new-diagrams/it-service-for-iaas.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:44:01.814041583Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/castro2012cloudvulnerability/metadata-png-n-public-cloud.ttl
+++ b/models/castro2012cloudvulnerability/metadata-png-n-public-cloud.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/dfd0b1ba-a4b1-47bf-9717-0713cf65616f> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/9d3dc47b-2ca8-430e-8e57-c2c0a5ed8015> ;
     dct:issued "2012"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'public cloud' from the Cloud Vulnerability Ontology (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/castro2012cloudvulnerability/new-diagrams/public-cloud.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:44:03.231338766Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/castro2012cloudvulnerability/metadata-png-n-vulnerability-in-public-cloud.ttl
+++ b/models/castro2012cloudvulnerability/metadata-png-n-vulnerability-in-public-cloud.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/dbf36a8f-d6a7-4036-9eaa-d345629d47b5> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/9d3dc47b-2ca8-430e-8e57-c2c0a5ed8015> ;
     dct:issued "2012"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'vulnerability in public cloud' from the Cloud Vulnerability Ontology (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/castro2012cloudvulnerability/new-diagrams/vulnerability-in-public-cloud.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:44:04.751279686Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/castro2012cloudvulnerability/metadata-png-o-it-resource.ttl
+++ b/models/castro2012cloudvulnerability/metadata-png-o-it-resource.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/256a9f4f-1714-48cf-8bfd-fa1b3085289d> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/9d3dc47b-2ca8-430e-8e57-c2c0a5ed8015> ;
     dct:issued "2012"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'it resource' from the Cloud Vulnerability Ontology (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/castro2012cloudvulnerability/original-diagrams/it-resource.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:44:06.230180419Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/castro2012cloudvulnerability/metadata-png-o-it-service-for-iaas.ttl
+++ b/models/castro2012cloudvulnerability/metadata-png-o-it-service-for-iaas.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/a7304701-0734-460d-9b65-ebcbf9b6a0d6> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/9d3dc47b-2ca8-430e-8e57-c2c0a5ed8015> ;
     dct:issued "2012"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'it service for iaas' from the Cloud Vulnerability Ontology (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/castro2012cloudvulnerability/original-diagrams/it-service-for-iaas.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:44:07.723021269Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/castro2012cloudvulnerability/metadata-png-o-public-cloud.ttl
+++ b/models/castro2012cloudvulnerability/metadata-png-o-public-cloud.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/50f51c78-3419-4190-b67c-38ef7c99785f> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/9d3dc47b-2ca8-430e-8e57-c2c0a5ed8015> ;
     dct:issued "2012"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'public cloud' from the Cloud Vulnerability Ontology (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/castro2012cloudvulnerability/original-diagrams/public-cloud.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:44:09.431839682Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/castro2012cloudvulnerability/metadata-png-o-vulnerability-in-public-cloud.ttl
+++ b/models/castro2012cloudvulnerability/metadata-png-o-vulnerability-in-public-cloud.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/18f7c834-c8fc-4931-9dfc-5cb2b1150d62> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/9d3dc47b-2ca8-430e-8e57-c2c0a5ed8015> ;
     dct:issued "2012"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'vulnerability in public cloud' from the Cloud Vulnerability Ontology (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/castro2012cloudvulnerability/original-diagrams/vulnerability-in-public-cloud.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:44:10.976976976Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/castro2012cloudvulnerability/metadata-turtle.ttl
+++ b/models/castro2012cloudvulnerability/metadata-turtle.ttl
@@ -7,11 +7,10 @@
 <https://w3id.org/ontouml-models/distribution/333f75a6-bc22-4a06-942c-7e52fe469587/> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/9d3dc47b-2ca8-430e-8e57-c2c0a5ed8015> ;
     dct:issued "2012"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Turtle distribution of Cloud Vulnerability Ontology"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/castro2012cloudvulnerability/ontology.ttl> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
     fdpo:metadataIssued "2023-04-14T17:44:12.578385805Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/castro2012cloudvulnerability/metadata-vpp.ttl
+++ b/models/castro2012cloudvulnerability/metadata-vpp.ttl
@@ -8,11 +8,10 @@
     dct:format <https://www.file-extension.info/format/vpp> ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/9d3dc47b-2ca8-430e-8e57-c2c0a5ed8015> ;
     dct:issued "2012"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Visual Paradigm distribution of Cloud Vulnerability Ontology"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/castro2012cloudvulnerability/ontology.vpp> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/octet-stream> ;
     fdpo:metadataIssued "2023-04-14T17:44:14.001847674Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T00:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/castro2012cloudvulnerability/metadata.ttl
+++ b/models/castro2012cloudvulnerability/metadata.ttl
@@ -17,7 +17,6 @@
     dcat:theme lcc:T;
     skos:editorialNote "Thesis is not available anymore online, diagrams exerted from another repository effort.";
     dct:language "en";
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:contributor <https://dblp.org/pid/119/6017>,
                     <https://dblp.org/pid/119/6024>,
                     <https://dblp.org/pid/06/10125>,
@@ -33,7 +32,7 @@
     ocmv:ontologyType ocmv:Domain;
     ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/castro2012cloudvulnerability"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:43:57.670981508Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .
 
 <https://w3id.org/ontouml-models/model/9d3dc47b-2ca8-430e-8e57-c2c0a5ed8015> dcat:distribution <https://w3id.org/ontouml-models/distribution/333f75a6-bc22-4a06-942c-7e52fe469587/>,
                       <https://w3id.org/ontouml-models/distribution/e1cb841b-4437-490c-ac86-4454dd5d65a4/>,

--- a/models/duarte2018osdef/metadata-json.ttl
+++ b/models/duarte2018osdef/metadata-json.ttl
@@ -12,10 +12,9 @@
     dct:isPartOf <https://w3id.org/ontouml-models/model/bfc2ffb6-b4bb-4f6c-9f8f-cc522d13dc94>;
     dct:issued "2018"^^xsd:gYear;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of Ontology of Software Defects, Errors and Failures"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/duarte2018osdef/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T17:47:28.809205461Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .

--- a/models/duarte2018osdef/metadata-png-n-osdef.ttl
+++ b/models/duarte2018osdef/metadata-png-n-osdef.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/41cad05e-324c-4129-813f-b2cc22e7525b> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/bfc2ffb6-b4bb-4f6c-9f8f-cc522d13dc94> ;
     dct:issued "2018"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'osdef' from the Ontology of Software Defects, Errors and Failures (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/duarte2018osdef/new-diagrams/osdef.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:47:30.328173243Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/duarte2018osdef/metadata-png-o-diagram1.ttl
+++ b/models/duarte2018osdef/metadata-png-o-diagram1.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/5d998891-2390-4b9a-a8f6-63157006a3cb> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/bfc2ffb6-b4bb-4f6c-9f8f-cc522d13dc94> ;
     dct:issued "2018"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram1' from the Ontology of Software Defects, Errors and Failures (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/duarte2018osdef/original-diagrams/diagram1.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:47:31.886920872Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/duarte2018osdef/metadata-turtle.ttl
+++ b/models/duarte2018osdef/metadata-turtle.ttl
@@ -7,11 +7,10 @@
 <https://w3id.org/ontouml-models/distribution/3e52de2d-b288-4ffe-beef-83b21351d7fc/> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/bfc2ffb6-b4bb-4f6c-9f8f-cc522d13dc94> ;
     dct:issued "2018"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Turtle distribution of Ontology of Software Defects, Errors and Failures"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/duarte2018osdef/ontology.ttl> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
     fdpo:metadataIssued "2023-04-14T17:47:33.449644488Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/duarte2018osdef/metadata-vpp.ttl
+++ b/models/duarte2018osdef/metadata-vpp.ttl
@@ -8,11 +8,10 @@
     dct:format <https://www.file-extension.info/format/vpp> ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/bfc2ffb6-b4bb-4f6c-9f8f-cc522d13dc94> ;
     dct:issued "2018"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Visual Paradigm distribution of Ontology of Software Defects, Errors and Failures"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/duarte2018osdef/ontology.vpp> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/octet-stream> ;
     fdpo:metadataIssued "2023-04-14T17:47:34.985457769Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T00:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/duarte2018osdef/metadata.ttl
+++ b/models/duarte2018osdef/metadata.ttl
@@ -18,7 +18,6 @@
     dcat:theme lcc:T;
     skos:editorialNote "The ontology was documented based on the version on the journal publication.";
     dct:language "en";
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:contributor <https://dblp.org/pid/182/7298>,
                     <https://dblp.org/pid/11/78>,
                     <https://dblp.org/pid/72/3662>,
@@ -34,7 +33,7 @@
     ocmv:ontologyType ocmv:Domain;
     ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/duarte2018osdef"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:47:27.537555722Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .
 
 <https://w3id.org/ontouml-models/model/bfc2ffb6-b4bb-4f6c-9f8f-cc522d13dc94> dcat:distribution <https://w3id.org/ontouml-models/distribution/3e52de2d-b288-4ffe-beef-83b21351d7fc/>,
                       <https://w3id.org/ontouml-models/distribution/fae9307b-d1c1-40ac-a5fb-0768a84edf32/>,

--- a/models/duarte2018reqon/metadata-json.ttl
+++ b/models/duarte2018reqon/metadata-json.ttl
@@ -12,10 +12,9 @@
     dct:isPartOf <https://w3id.org/ontouml-models/model/10c716c3-7da2-4457-9e40-9f847d4cf37d>;
     dct:issued "2018"^^xsd:gYear;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of Requirements Engineering Ontology"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/duarte2018reqon/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T17:47:37.953979291Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .

--- a/models/duarte2018reqon/metadata-png-n-diagram1.ttl
+++ b/models/duarte2018reqon/metadata-png-n-diagram1.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/a9697c4f-26fa-430a-ae90-8d1e21f89523> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/10c716c3-7da2-4457-9e40-9f847d4cf37d> ;
     dct:issued "2018"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram1' from the Requirements Engineering Ontology (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/duarte2018reqon/new-diagrams/diagram1.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:47:39.551025974Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/duarte2018reqon/metadata-png-n-diagram2.ttl
+++ b/models/duarte2018reqon/metadata-png-n-diagram2.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/a9bd83f0-e95a-4b60-817b-a0ca875788a3> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/10c716c3-7da2-4457-9e40-9f847d4cf37d> ;
     dct:issued "2018"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram2' from the Requirements Engineering Ontology (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/duarte2018reqon/new-diagrams/diagram2.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:47:41.059899532Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/duarte2018reqon/metadata-png-n-diagram3.ttl
+++ b/models/duarte2018reqon/metadata-png-n-diagram3.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/3528a4d8-1c0a-4152-a673-6b4563d0ca80> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/10c716c3-7da2-4457-9e40-9f847d4cf37d> ;
     dct:issued "2018"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram3' from the Requirements Engineering Ontology (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/duarte2018reqon/new-diagrams/diagram3.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:47:42.666060865Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/duarte2018reqon/metadata-png-o-diagram1.ttl
+++ b/models/duarte2018reqon/metadata-png-o-diagram1.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/cd0aefd3-9927-49ce-9d61-1beb97f304ad> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/10c716c3-7da2-4457-9e40-9f847d4cf37d> ;
     dct:issued "2018"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram1' from the Requirements Engineering Ontology (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/duarte2018reqon/original-diagrams/diagram1.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:47:44.444269549Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/duarte2018reqon/metadata-png-o-diagram2.ttl
+++ b/models/duarte2018reqon/metadata-png-o-diagram2.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/82668a8b-f364-4a30-b8d1-28d58cfe102a> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/10c716c3-7da2-4457-9e40-9f847d4cf37d> ;
     dct:issued "2018"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram2' from the Requirements Engineering Ontology (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/duarte2018reqon/original-diagrams/diagram2.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:47:46.44818273Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/duarte2018reqon/metadata-png-o-diagram3.ttl
+++ b/models/duarte2018reqon/metadata-png-o-diagram3.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/8cc8c4f2-3952-478a-a01f-7c8a177c0026> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/10c716c3-7da2-4457-9e40-9f847d4cf37d> ;
     dct:issued "2018"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram3' from the Requirements Engineering Ontology (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/duarte2018reqon/original-diagrams/diagram3.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:47:48.206039545Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/duarte2018reqon/metadata-turtle.ttl
+++ b/models/duarte2018reqon/metadata-turtle.ttl
@@ -7,11 +7,10 @@
 <https://w3id.org/ontouml-models/distribution/4c864267-b753-49e6-b4e0-95d54a1ad48a/> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/10c716c3-7da2-4457-9e40-9f847d4cf37d> ;
     dct:issued "2018"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Turtle distribution of Requirements Engineering Ontology"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/duarte2018reqon/ontology.ttl> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
     fdpo:metadataIssued "2023-04-14T17:47:49.974396024Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/duarte2018reqon/metadata-vpp.ttl
+++ b/models/duarte2018reqon/metadata-vpp.ttl
@@ -8,11 +8,10 @@
     dct:format <https://www.file-extension.info/format/vpp> ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/10c716c3-7da2-4457-9e40-9f847d4cf37d> ;
     dct:issued "2018"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Visual Paradigm distribution of Requirements Engineering Ontology"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/duarte2018reqon/ontology.vpp> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/octet-stream> ;
     fdpo:metadataIssued "2023-04-14T17:47:51.507181019Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T00:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/duarte2018reqon/metadata.ttl
+++ b/models/duarte2018reqon/metadata.ttl
@@ -18,7 +18,6 @@
     dcat:theme lcc:T;
     skos:editorialNote "The \"Information Item\" class was duplicated. We merged both of its occurrences into a single one.";
     dct:language "en";
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:contributor <https://dblp.org/pid/182/7298>,
                     <https://dblp.org/pid/11/78>,
                     <https://dblp.org/pid/72/3662>,
@@ -34,7 +33,7 @@
                       ocmv:Application;
     ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/duarte2018reqon"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:47:36.725797738Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .
 
 <https://w3id.org/ontouml-models/model/10c716c3-7da2-4457-9e40-9f847d4cf37d> dcat:distribution <https://w3id.org/ontouml-models/distribution/4c864267-b753-49e6-b4e0-95d54a1ad48a/>,
                       <https://w3id.org/ontouml-models/distribution/d77de162-c9ef-4cdf-afc0-f0e98b23f06e/>,

--- a/models/duarte2021ross/metadata-json.ttl
+++ b/models/duarte2021ross/metadata-json.ttl
@@ -12,10 +12,9 @@
     dct:isPartOf <https://w3id.org/ontouml-models/model/3adf4afc-9f96-403d-914a-72e41547f673>;
     dct:issued "2021"^^xsd:gYear;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of Reference Ontology of Software Systems"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/duarte2021ross/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T17:48:07.012731319Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .

--- a/models/duarte2021ross/metadata-png-n-business-layer.ttl
+++ b/models/duarte2021ross/metadata-png-n-business-layer.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/cc2fd660-4e55-4e2a-a6d8-678498e5c614> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/3adf4afc-9f96-403d-914a-72e41547f673> ;
     dct:issued "2021"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'business layer' from the Reference Ontology of Software Systems (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/duarte2021ross/new-diagrams/business-layer.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:48:08.505733936Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/duarte2021ross/metadata-png-n-complex-system.ttl
+++ b/models/duarte2021ross/metadata-png-n-complex-system.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/3ee098a3-27bd-498d-ae3a-c69f112384b0> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/3adf4afc-9f96-403d-914a-72e41547f673> ;
     dct:issued "2021"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'complex system' from the Reference Ontology of Software Systems (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/duarte2021ross/new-diagrams/complex-system.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:48:10.101863706Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/duarte2021ross/metadata-png-n-machine-layer.ttl
+++ b/models/duarte2021ross/metadata-png-n-machine-layer.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/de1872c6-dc9c-4f75-8d9b-f910d42dba1f> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/3adf4afc-9f96-403d-914a-72e41547f673> ;
     dct:issued "2021"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'machine layer' from the Reference Ontology of Software Systems (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/duarte2021ross/new-diagrams/machine-layer.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:48:11.655395981Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/duarte2021ross/metadata-png-n-system-layer.ttl
+++ b/models/duarte2021ross/metadata-png-n-system-layer.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/89a71d40-70cc-4256-9343-56c1860808e3> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/3adf4afc-9f96-403d-914a-72e41547f673> ;
     dct:issued "2021"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'system layer' from the Reference Ontology of Software Systems (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/duarte2021ross/new-diagrams/system-layer.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:48:13.237932823Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/duarte2021ross/metadata-png-o-business-layer.ttl
+++ b/models/duarte2021ross/metadata-png-o-business-layer.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/67d4cd33-db9a-44aa-823e-a13ffd91cb88> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/3adf4afc-9f96-403d-914a-72e41547f673> ;
     dct:issued "2021"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'business layer' from the Reference Ontology of Software Systems (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/duarte2021ross/original-diagrams/business-layer.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:48:14.790370864Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/duarte2021ross/metadata-png-o-complex-system.ttl
+++ b/models/duarte2021ross/metadata-png-o-complex-system.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/eced4c7b-4bdd-44b6-bc03-4a2e4e6c152f> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/3adf4afc-9f96-403d-914a-72e41547f673> ;
     dct:issued "2021"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'complex system' from the Reference Ontology of Software Systems (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/duarte2021ross/original-diagrams/complex-system.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:48:16.321915963Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/duarte2021ross/metadata-png-o-machine-layer.ttl
+++ b/models/duarte2021ross/metadata-png-o-machine-layer.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/c2284a4f-6272-4ce9-8d08-22b6e4b5cd14> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/3adf4afc-9f96-403d-914a-72e41547f673> ;
     dct:issued "2021"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'machine layer' from the Reference Ontology of Software Systems (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/duarte2021ross/original-diagrams/machine-layer.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:48:17.79683782Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/duarte2021ross/metadata-png-o-system-layer.ttl
+++ b/models/duarte2021ross/metadata-png-o-system-layer.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/5614c367-5efd-4d21-9eb7-0fe1e0c375ab> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/3adf4afc-9f96-403d-914a-72e41547f673> ;
     dct:issued "2021"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'system layer' from the Reference Ontology of Software Systems (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/duarte2021ross/original-diagrams/system-layer.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:48:19.403517007Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/duarte2021ross/metadata-turtle.ttl
+++ b/models/duarte2021ross/metadata-turtle.ttl
@@ -7,11 +7,10 @@
 <https://w3id.org/ontouml-models/distribution/48151b6e-a47c-422a-932c-2cc0d141dae2/> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/3adf4afc-9f96-403d-914a-72e41547f673> ;
     dct:issued "2021"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Turtle distribution of Reference Ontology of Software Systems"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/duarte2021ross/ontology.ttl> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
     fdpo:metadataIssued "2023-04-14T17:48:20.936741361Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/duarte2021ross/metadata-vpp.ttl
+++ b/models/duarte2021ross/metadata-vpp.ttl
@@ -8,11 +8,10 @@
     dct:format <https://www.file-extension.info/format/vpp> ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/3adf4afc-9f96-403d-914a-72e41547f673> ;
     dct:issued "2021"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Visual Paradigm distribution of Reference Ontology of Software Systems"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/duarte2021ross/ontology.vpp> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/octet-stream> ;
     fdpo:metadataIssued "2023-04-14T17:48:22.557931002Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T00:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/duarte2021ross/metadata.ttl
+++ b/models/duarte2021ross/metadata.ttl
@@ -18,7 +18,6 @@
     dcat:theme lcc:T;
     skos:editorialNote "The paper identified as the main reference contains two ontologies: Ontology of Software Defects, Errors, and Faults (OSDEF) and the Reference Ontology of Software Systems (ROSS).";
     dct:language "en";
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:contributor <https://dblp.org/pid/182/7298>,
                     <https://dblp.org/pid/11/78>,
                     <https://dblp.org/pid/72/3662>,
@@ -33,7 +32,7 @@
     ocmv:ontologyType ocmv:Domain;
     ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/duarte2021ross"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:48:05.774060027Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .
 
 <https://w3id.org/ontouml-models/model/3adf4afc-9f96-403d-914a-72e41547f673> dcat:distribution <https://w3id.org/ontouml-models/distribution/48151b6e-a47c-422a-932c-2cc0d141dae2/>,
                       <https://w3id.org/ontouml-models/distribution/42793b9c-2cea-4252-bc24-2124d8405515/>,

--- a/models/eu-rent-refactored2022/metadata-json.ttl
+++ b/models/eu-rent-refactored2022/metadata-json.ttl
@@ -12,10 +12,9 @@
     dct:isPartOf <https://w3id.org/ontouml-models/model/e4940b3f-a31f-4341-a21d-494423c8d876>;
     dct:issued "2022"^^xsd:gYear;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of EU-Rent Car Rentals Refactored"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/eu-rent-refactored2022/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T17:48:44.124073376Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .

--- a/models/eu-rent-refactored2022/metadata-png-o-full-diagram.ttl
+++ b/models/eu-rent-refactored2022/metadata-png-o-full-diagram.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/63816bb0-dca2-4ab4-86d5-a0741b03c435> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/e4940b3f-a31f-4341-a21d-494423c8d876> ;
     dct:issued "2022"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'full diagram' from the EU-Rent Car Rentals Refactored (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/eu-rent-refactored2022/original-diagrams/full-diagram.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:48:45.863005068Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/eu-rent-refactored2022/metadata-turtle.ttl
+++ b/models/eu-rent-refactored2022/metadata-turtle.ttl
@@ -7,11 +7,10 @@
 <https://w3id.org/ontouml-models/distribution/5ce51d8b-2238-4d10-bfa1-20e36880ba6a/> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/e4940b3f-a31f-4341-a21d-494423c8d876> ;
     dct:issued "2022"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Turtle distribution of EU-Rent Car Rentals Refactored"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/eu-rent-refactored2022/ontology.ttl> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
     fdpo:metadataIssued "2023-04-14T17:48:47.372215969Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/eu-rent-refactored2022/metadata-vpp.ttl
+++ b/models/eu-rent-refactored2022/metadata-vpp.ttl
@@ -8,11 +8,10 @@
     dct:format <https://www.file-extension.info/format/vpp> ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/e4940b3f-a31f-4341-a21d-494423c8d876> ;
     dct:issued "2022"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Visual Paradigm distribution of EU-Rent Car Rentals Refactored"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/eu-rent-refactored2022/ontology.vpp> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/octet-stream> ;
     fdpo:metadataIssued "2023-04-14T17:48:49.452868628Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T00:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/eu-rent-refactored2022/metadata.ttl
+++ b/models/eu-rent-refactored2022/metadata.ttl
@@ -17,7 +17,6 @@
     dcat:theme lcc:H;
     skos:editorialNote "This model was created by partially refactoring and adapting the case study EU-Rent Car Rentals Specification (https://upcommons.upc.edu/bitstream/handle/2117/97816/R03-59.pdf), by Leonor Frias, Anna Queralt and Antoni Olivé.";
     dct:language "en";
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:contributor <https://dblp.org/pid/134/4947>,
                     <https://dblp.org/pid/222/8406>,
                     <https://dblp.org/pid/131/1200>,
@@ -30,7 +29,7 @@
     ocmv:ontologyType ocmv:Domain;
     ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/eu-rent-refactored2022"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:48:42.875935993Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .
 
 <https://w3id.org/ontouml-models/model/e4940b3f-a31f-4341-a21d-494423c8d876> dcat:distribution <https://w3id.org/ontouml-models/distribution/5ce51d8b-2238-4d10-bfa1-20e36880ba6a/>,
                       <https://w3id.org/ontouml-models/distribution/5d29593f-7d68-46ad-b8e1-52ae1e461ea9/>,

--- a/models/ferreira2015ontoemergeplan/metadata-json.ttl
+++ b/models/ferreira2015ontoemergeplan/metadata-json.ttl
@@ -12,10 +12,9 @@
     dct:isPartOf <https://w3id.org/ontouml-models/model/dddeec28-4c7c-4e5f-b22e-b536fa79ac72>;
     dct:issued "2013"^^xsd:gYear;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of Ontology for Emergency Plans"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/ferreira2015ontoemergeplan/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T17:49:24.418722586Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .

--- a/models/ferreira2015ontoemergeplan/metadata-png-n-emergency-event.ttl
+++ b/models/ferreira2015ontoemergeplan/metadata-png-n-emergency-event.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/e2fb53f8-824d-4b65-a527-8ebe2c812a9a> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/dddeec28-4c7c-4e5f-b22e-b536fa79ac72> ;
     dct:issued "2013"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'emergency event' from the Ontology for Emergency Plans (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/ferreira2015ontoemergeplan/new-diagrams/emergency-event.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:49:25.967662338Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/ferreira2015ontoemergeplan/metadata-png-n-environment.ttl
+++ b/models/ferreira2015ontoemergeplan/metadata-png-n-environment.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/394220b1-8fef-42ea-ba27-d3d63b698a07> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/dddeec28-4c7c-4e5f-b22e-b536fa79ac72> ;
     dct:issued "2013"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'environment' from the Ontology for Emergency Plans (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/ferreira2015ontoemergeplan/new-diagrams/environment.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:49:27.483662972Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/ferreira2015ontoemergeplan/metadata-png-n-geographical-region.ttl
+++ b/models/ferreira2015ontoemergeplan/metadata-png-n-geographical-region.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/07206b07-1e74-4542-b70c-8b9d0e68b949> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/dddeec28-4c7c-4e5f-b22e-b536fa79ac72> ;
     dct:issued "2013"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'geographical region' from the Ontology for Emergency Plans (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/ferreira2015ontoemergeplan/new-diagrams/geographical-region.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:49:29.138017608Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/ferreira2015ontoemergeplan/metadata-png-n-goals,-intentions-and-delegations.ttl
+++ b/models/ferreira2015ontoemergeplan/metadata-png-n-goals,-intentions-and-delegations.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/de84e5fa-f880-4ca9-ae78-46ba4a0d4ceb> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/dddeec28-4c7c-4e5f-b22e-b536fa79ac72> ;
     dct:issued "2013"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'goals, intentions and delegations' from the Ontology for Emergency Plans (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/ferreira2015ontoemergeplan/new-diagrams/goals,-intentions-and-delegations.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:49:30.759897024Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/ferreira2015ontoemergeplan/metadata-png-n-human-resources-and-materials.ttl
+++ b/models/ferreira2015ontoemergeplan/metadata-png-n-human-resources-and-materials.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/eb2f1e37-fb88-43bb-bfbc-0d7a3d3e1b03> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/dddeec28-4c7c-4e5f-b22e-b536fa79ac72> ;
     dct:issued "2013"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'human resources and materials' from the Ontology for Emergency Plans (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/ferreira2015ontoemergeplan/new-diagrams/human-resources-and-materials.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:49:32.347255849Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/ferreira2015ontoemergeplan/metadata-png-n-installation.ttl
+++ b/models/ferreira2015ontoemergeplan/metadata-png-n-installation.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/2a1d825b-6374-46ec-b8e0-fc96e69a21f1> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/dddeec28-4c7c-4e5f-b22e-b536fa79ac72> ;
     dct:issued "2013"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'installation' from the Ontology for Emergency Plans (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/ferreira2015ontoemergeplan/new-diagrams/installation.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:49:33.843477797Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/ferreira2015ontoemergeplan/metadata-png-n-plans,-processes-e-activities.ttl
+++ b/models/ferreira2015ontoemergeplan/metadata-png-n-plans,-processes-e-activities.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/5557c6ae-be4e-40e1-a6e3-65609f0c9db6> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/dddeec28-4c7c-4e5f-b22e-b536fa79ac72> ;
     dct:issued "2013"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'plans, processes e activities' from the Ontology for Emergency Plans (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/ferreira2015ontoemergeplan/new-diagrams/plans,-processes-e-activities.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:49:35.416986805Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/ferreira2015ontoemergeplan/metadata-png-n-resource,-types-of-resources-and-roles.ttl
+++ b/models/ferreira2015ontoemergeplan/metadata-png-n-resource,-types-of-resources-and-roles.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/ec6f6404-5cd6-4815-b67e-c8ceb9802eed> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/dddeec28-4c7c-4e5f-b22e-b536fa79ac72> ;
     dct:issued "2013"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'resource, types of resources and roles' from the Ontology for Emergency Plans (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/ferreira2015ontoemergeplan/new-diagrams/resource,-types-of-resources-and-roles.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:49:36.922042483Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/ferreira2015ontoemergeplan/metadata-png-n-risks-and-planned-activities.ttl
+++ b/models/ferreira2015ontoemergeplan/metadata-png-n-risks-and-planned-activities.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/cef48fdc-7b1f-43e1-9cae-6b0094d8802a> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/dddeec28-4c7c-4e5f-b22e-b536fa79ac72> ;
     dct:issued "2013"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'risks and planned activities' from the Ontology for Emergency Plans (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/ferreira2015ontoemergeplan/new-diagrams/risks-and-planned-activities.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:49:38.45879485Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/ferreira2015ontoemergeplan/metadata-png-o-emergency-event.ttl
+++ b/models/ferreira2015ontoemergeplan/metadata-png-o-emergency-event.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/20ed5c49-3fd3-421f-875c-a78425e1e072> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/dddeec28-4c7c-4e5f-b22e-b536fa79ac72> ;
     dct:issued "2013"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'emergency event' from the Ontology for Emergency Plans (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/ferreira2015ontoemergeplan/original-diagrams/emergency-event.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:49:40.031931941Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/ferreira2015ontoemergeplan/metadata-png-o-environment.ttl
+++ b/models/ferreira2015ontoemergeplan/metadata-png-o-environment.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/22734a4d-891b-462f-9b9a-cad71b6c173a> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/dddeec28-4c7c-4e5f-b22e-b536fa79ac72> ;
     dct:issued "2013"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'environment' from the Ontology for Emergency Plans (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/ferreira2015ontoemergeplan/original-diagrams/environment.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:49:41.514594825Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/ferreira2015ontoemergeplan/metadata-png-o-geographical-region.ttl
+++ b/models/ferreira2015ontoemergeplan/metadata-png-o-geographical-region.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/4235afb8-8200-43eb-b493-ed3809330dd9> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/dddeec28-4c7c-4e5f-b22e-b536fa79ac72> ;
     dct:issued "2013"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'geographical region' from the Ontology for Emergency Plans (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/ferreira2015ontoemergeplan/original-diagrams/geographical-region.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:49:43.273908874Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/ferreira2015ontoemergeplan/metadata-png-o-goals,-intentions-and-delegations.ttl
+++ b/models/ferreira2015ontoemergeplan/metadata-png-o-goals,-intentions-and-delegations.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/c03c79d4-1443-4c83-9c1f-0f86504afd11> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/dddeec28-4c7c-4e5f-b22e-b536fa79ac72> ;
     dct:issued "2013"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'goals, intentions and delegations' from the Ontology for Emergency Plans (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/ferreira2015ontoemergeplan/original-diagrams/goals,-intentions-and-delegations.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:49:44.868094869Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/ferreira2015ontoemergeplan/metadata-png-o-human-resources-and-materials.ttl
+++ b/models/ferreira2015ontoemergeplan/metadata-png-o-human-resources-and-materials.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/b789a904-2445-4ba3-ae5a-d3527bb06e02> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/dddeec28-4c7c-4e5f-b22e-b536fa79ac72> ;
     dct:issued "2013"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'human resources and materials' from the Ontology for Emergency Plans (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/ferreira2015ontoemergeplan/original-diagrams/human-resources-and-materials.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:49:46.438529336Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/ferreira2015ontoemergeplan/metadata-png-o-installation.ttl
+++ b/models/ferreira2015ontoemergeplan/metadata-png-o-installation.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/42dc25ed-7380-4816-a35e-23ace140ae51> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/dddeec28-4c7c-4e5f-b22e-b536fa79ac72> ;
     dct:issued "2013"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'installation' from the Ontology for Emergency Plans (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/ferreira2015ontoemergeplan/original-diagrams/installation.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:49:47.979474087Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/ferreira2015ontoemergeplan/metadata-png-o-plans,-processes-e-activities.ttl
+++ b/models/ferreira2015ontoemergeplan/metadata-png-o-plans,-processes-e-activities.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/2785bc7c-adee-410a-a4bd-ef4fb46eacd9> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/dddeec28-4c7c-4e5f-b22e-b536fa79ac72> ;
     dct:issued "2013"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'plans, processes e activities' from the Ontology for Emergency Plans (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/ferreira2015ontoemergeplan/original-diagrams/plans,-processes-e-activities.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:49:49.556566048Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/ferreira2015ontoemergeplan/metadata-png-o-resource,-types-of-resources-and-roles.ttl
+++ b/models/ferreira2015ontoemergeplan/metadata-png-o-resource,-types-of-resources-and-roles.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/53fa74d9-3a0c-4167-83db-a7eedb3a8ead> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/dddeec28-4c7c-4e5f-b22e-b536fa79ac72> ;
     dct:issued "2013"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'resource, types of resources and roles' from the Ontology for Emergency Plans (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/ferreira2015ontoemergeplan/original-diagrams/resource,-types-of-resources-and-roles.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:49:51.054787136Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/ferreira2015ontoemergeplan/metadata-png-o-risks-and-planned-activities.ttl
+++ b/models/ferreira2015ontoemergeplan/metadata-png-o-risks-and-planned-activities.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/54d47bd2-14b4-43c2-8772-a4629e80faac> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/dddeec28-4c7c-4e5f-b22e-b536fa79ac72> ;
     dct:issued "2013"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'risks and planned activities' from the Ontology for Emergency Plans (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/ferreira2015ontoemergeplan/original-diagrams/risks-and-planned-activities.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:49:52.69281475Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/ferreira2015ontoemergeplan/metadata-turtle.ttl
+++ b/models/ferreira2015ontoemergeplan/metadata-turtle.ttl
@@ -7,11 +7,10 @@
 <https://w3id.org/ontouml-models/distribution/b38da854-2538-4a87-a80b-5ad7aa609db4/> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/dddeec28-4c7c-4e5f-b22e-b536fa79ac72> ;
     dct:issued "2013"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Turtle distribution of Ontology for Emergency Plans"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/ferreira2015ontoemergeplan/ontology.ttl> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
     fdpo:metadataIssued "2023-04-14T17:49:54.233038499Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/ferreira2015ontoemergeplan/metadata-vpp.ttl
+++ b/models/ferreira2015ontoemergeplan/metadata-vpp.ttl
@@ -8,11 +8,10 @@
     dct:format <https://www.file-extension.info/format/vpp> ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/dddeec28-4c7c-4e5f-b22e-b536fa79ac72> ;
     dct:issued "2013"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Visual Paradigm distribution of Ontology for Emergency Plans"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/ferreira2015ontoemergeplan/ontology.vpp> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/octet-stream> ;
     fdpo:metadataIssued "2023-04-14T17:49:55.7458527Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T00:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/ferreira2015ontoemergeplan/metadata.ttl
+++ b/models/ferreira2015ontoemergeplan/metadata.ttl
@@ -18,7 +18,6 @@
     dcat:theme lcc:H;
     skos:editorialNote "The VP model was built over obtained XMI file. The complete model has more diagrams than the ones here modeled, however, just 9 of these were presented in the publications - these were the only ones that were re-modeled using VP. Some associations redefinitions and subsettings were not possible to be modeled because the related association end roles were not found. When imported from the XMI file, duplicated classes were identified and merged. The author comments in Portuguese were removed. Classes without any view were also removed. The class Geographical Region had two different stereotypes in two diagrams - Kind and Category. For the better representation we defined it only as a category. Some classes were defined in two different packages - the duplicates were removed. During the importation some classes were defined in the incorrect package - these were moved to their correct package.";
     dct:language "en";
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:contributor <https://dblp.org/pid/183/7439>,
                     <https://dblp.org/pid/74/7740>,
                     <https://dblp.org/pid/78/4279>,
@@ -38,7 +37,7 @@
     ocmv:ontologyType ocmv:Domain;
     ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/ferreira2015ontoemergeplan"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:49:23.176465527Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .
 
 <https://w3id.org/ontouml-models/model/dddeec28-4c7c-4e5f-b22e-b536fa79ac72> dcat:distribution <https://w3id.org/ontouml-models/distribution/b38da854-2538-4a87-a80b-5ad7aa609db4/>,
                       <https://w3id.org/ontouml-models/distribution/5e0b2be9-5c02-474d-871b-439641499a82/>,

--- a/models/fischer2018ontorea/metadata-json.ttl
+++ b/models/fischer2018ontorea/metadata-json.ttl
@@ -12,10 +12,9 @@
     dct:isPartOf <https://w3id.org/ontouml-models/model/dca91792-d4d7-4233-a62b-50040c242cf0>;
     dct:issued "2017"^^xsd:gYear;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of OntoREA© Accounting and Finance Model"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/fischer2018ontorea/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T17:49:59.065164632Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .

--- a/models/fischer2018ontorea/metadata-png-n-ontorea©-accounting-and-finance-model.ttl
+++ b/models/fischer2018ontorea/metadata-png-n-ontorea©-accounting-and-finance-model.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/ff0ece76-1edc-4547-a222-a91067c60252> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/dca91792-d4d7-4233-a62b-50040c242cf0> ;
     dct:issued "2017"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'ontorea© accounting and finance model' from the OntoREA© Accounting and Finance Model (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/fischer2018ontorea/new-diagrams/ontorea©-accounting-and-finance-model.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:50:00.572842069Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/fischer2018ontorea/metadata-png-o-ontorea-accounting-and-finance-model.ttl
+++ b/models/fischer2018ontorea/metadata-png-o-ontorea-accounting-and-finance-model.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/6589623e-dc23-48c6-9773-91fdb9682202> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/dca91792-d4d7-4233-a62b-50040c242cf0> ;
     dct:issued "2017"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'ontorea accounting and finance model' from the OntoREA© Accounting and Finance Model (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/fischer2018ontorea/original-diagrams/ontorea-accounting-and-finance-model.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:50:02.13799289Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/fischer2018ontorea/metadata-turtle.ttl
+++ b/models/fischer2018ontorea/metadata-turtle.ttl
@@ -7,11 +7,10 @@
 <https://w3id.org/ontouml-models/distribution/17762858-8496-463a-92d0-8ae74867f317/> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/dca91792-d4d7-4233-a62b-50040c242cf0> ;
     dct:issued "2017"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Turtle distribution of OntoREA© Accounting and Finance Model"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/fischer2018ontorea/ontology.ttl> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
     fdpo:metadataIssued "2023-04-14T17:50:03.707577525Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/fischer2018ontorea/metadata-vpp.ttl
+++ b/models/fischer2018ontorea/metadata-vpp.ttl
@@ -8,11 +8,10 @@
     dct:format <https://www.file-extension.info/format/vpp> ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/dca91792-d4d7-4233-a62b-50040c242cf0> ;
     dct:issued "2017"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Visual Paradigm distribution of OntoREA© Accounting and Finance Model"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/fischer2018ontorea/ontology.vpp> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/octet-stream> ;
     fdpo:metadataIssued "2023-04-14T17:50:05.237723867Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T00:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/fischer2018ontorea/metadata.ttl
+++ b/models/fischer2018ontorea/metadata.ttl
@@ -17,7 +17,6 @@
     dcat:theme lcc:H;
     skos:editorialNote "This model corresponds to the one proposed in the 2019 paper by Schwaiger et al.";
     dct:language "en";
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:contributor <https://dblp.org/pid/07/4333>,
                     <https://dblp.org/pid/253/7047>,
                     <https://dblp.org/pid/79/1814>,
@@ -39,7 +38,7 @@
     ocmv:ontologyType ocmv:Domain;
     ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/fischer2018ontorea"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:49:57.669102692Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .
 
 <https://w3id.org/ontouml-models/model/dca91792-d4d7-4233-a62b-50040c242cf0> dcat:distribution <https://w3id.org/ontouml-models/distribution/17762858-8496-463a-92d0-8ae74867f317/>,
                       <https://w3id.org/ontouml-models/distribution/b80a291e-2808-4e4a-95e0-d6d5a3582ca8/>,

--- a/models/fraller2019abc/metadata-json.ttl
+++ b/models/fraller2019abc/metadata-json.ttl
@@ -12,10 +12,9 @@
     dct:isPartOf <https://w3id.org/ontouml-models/model/dbd5fed6-8332-458f-90ec-b9270e7b6fdc>;
     dct:issued "2019"^^xsd:gYear;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of Capacity-Based Activity-Based Costing System Model"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/fraller2019abc/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T17:50:25.724805462Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .

--- a/models/fraller2019abc/metadata-png-n-diagram1.ttl
+++ b/models/fraller2019abc/metadata-png-n-diagram1.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/6d54045d-8849-4aa1-9768-54a001e5e889> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/dbd5fed6-8332-458f-90ec-b9270e7b6fdc> ;
     dct:issued "2019"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram1' from the Capacity-Based Activity-Based Costing System Model (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/fraller2019abc/new-diagrams/diagram1.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:50:27.260869849Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/fraller2019abc/metadata-png-n-diagram2.ttl
+++ b/models/fraller2019abc/metadata-png-n-diagram2.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/282be313-117e-448c-b5c1-b5f8fc3fc448> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/dbd5fed6-8332-458f-90ec-b9270e7b6fdc> ;
     dct:issued "2019"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram2' from the Capacity-Based Activity-Based Costing System Model (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/fraller2019abc/new-diagrams/diagram2.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:50:28.778960506Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/fraller2019abc/metadata-png-n-diagram3.ttl
+++ b/models/fraller2019abc/metadata-png-n-diagram3.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/bed45a0c-c530-4433-9be0-494b338d6e0c> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/dbd5fed6-8332-458f-90ec-b9270e7b6fdc> ;
     dct:issued "2019"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram3' from the Capacity-Based Activity-Based Costing System Model (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/fraller2019abc/new-diagrams/diagram3.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:50:30.431940357Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/fraller2019abc/metadata-png-n-diagram4.ttl
+++ b/models/fraller2019abc/metadata-png-n-diagram4.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/94ac4675-115c-4165-81db-2ce2b4178489> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/dbd5fed6-8332-458f-90ec-b9270e7b6fdc> ;
     dct:issued "2019"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram4' from the Capacity-Based Activity-Based Costing System Model (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/fraller2019abc/new-diagrams/diagram4.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:50:31.9582963Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/fraller2019abc/metadata-png-n-diagram5.ttl
+++ b/models/fraller2019abc/metadata-png-n-diagram5.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/edbde8c7-9dfd-4619-8a7c-0f1d6be95be8> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/dbd5fed6-8332-458f-90ec-b9270e7b6fdc> ;
     dct:issued "2019"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram5' from the Capacity-Based Activity-Based Costing System Model (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/fraller2019abc/new-diagrams/diagram5.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:50:33.692794616Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/fraller2019abc/metadata-png-n-diagram6.ttl
+++ b/models/fraller2019abc/metadata-png-n-diagram6.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/9e618de4-d201-4cab-a754-0d562750144d> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/dbd5fed6-8332-458f-90ec-b9270e7b6fdc> ;
     dct:issued "2019"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram6' from the Capacity-Based Activity-Based Costing System Model (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/fraller2019abc/new-diagrams/diagram6.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:50:35.515436506Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/fraller2019abc/metadata-png-n-diagram7.ttl
+++ b/models/fraller2019abc/metadata-png-n-diagram7.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/08c5b28e-c7a5-46da-ad93-99495e7ecf5e> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/dbd5fed6-8332-458f-90ec-b9270e7b6fdc> ;
     dct:issued "2019"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram7' from the Capacity-Based Activity-Based Costing System Model (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/fraller2019abc/new-diagrams/diagram7.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:50:37.048897722Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/fraller2019abc/metadata-png-o-diagram1.ttl
+++ b/models/fraller2019abc/metadata-png-o-diagram1.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/56c8fc41-d637-4b88-a912-9e35256a746a> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/dbd5fed6-8332-458f-90ec-b9270e7b6fdc> ;
     dct:issued "2019"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram1' from the Capacity-Based Activity-Based Costing System Model (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/fraller2019abc/original-diagrams/diagram1.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:50:38.667071092Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/fraller2019abc/metadata-png-o-diagram2.ttl
+++ b/models/fraller2019abc/metadata-png-o-diagram2.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/511c1b64-d7ca-4ae0-81f1-0b43bb487d09> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/dbd5fed6-8332-458f-90ec-b9270e7b6fdc> ;
     dct:issued "2019"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram2' from the Capacity-Based Activity-Based Costing System Model (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/fraller2019abc/original-diagrams/diagram2.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:50:40.448254199Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/fraller2019abc/metadata-png-o-diagram3.ttl
+++ b/models/fraller2019abc/metadata-png-o-diagram3.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/5e7992a5-de61-4ca8-8f05-e413c269b0f5> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/dbd5fed6-8332-458f-90ec-b9270e7b6fdc> ;
     dct:issued "2019"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram3' from the Capacity-Based Activity-Based Costing System Model (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/fraller2019abc/original-diagrams/diagram3.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:50:42.010024509Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/fraller2019abc/metadata-png-o-diagram4.ttl
+++ b/models/fraller2019abc/metadata-png-o-diagram4.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/62d2296c-a8b1-43e0-9553-5e496f1957d9> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/dbd5fed6-8332-458f-90ec-b9270e7b6fdc> ;
     dct:issued "2019"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram4' from the Capacity-Based Activity-Based Costing System Model (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/fraller2019abc/original-diagrams/diagram4.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:50:43.862234801Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/fraller2019abc/metadata-png-o-diagram5.ttl
+++ b/models/fraller2019abc/metadata-png-o-diagram5.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/c64b7622-5109-42b0-bec6-ccd03e51a149> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/dbd5fed6-8332-458f-90ec-b9270e7b6fdc> ;
     dct:issued "2019"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram5' from the Capacity-Based Activity-Based Costing System Model (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/fraller2019abc/original-diagrams/diagram5.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:50:45.419498559Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/fraller2019abc/metadata-png-o-diagram6.ttl
+++ b/models/fraller2019abc/metadata-png-o-diagram6.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/3097791e-2783-464d-8416-130012288959> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/dbd5fed6-8332-458f-90ec-b9270e7b6fdc> ;
     dct:issued "2019"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram6' from the Capacity-Based Activity-Based Costing System Model (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/fraller2019abc/original-diagrams/diagram6.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:50:46.977887108Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/fraller2019abc/metadata-png-o-diagram7.ttl
+++ b/models/fraller2019abc/metadata-png-o-diagram7.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/61652c4a-8079-4835-83cb-d85f4358c33c> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/dbd5fed6-8332-458f-90ec-b9270e7b6fdc> ;
     dct:issued "2019"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram7' from the Capacity-Based Activity-Based Costing System Model (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/fraller2019abc/original-diagrams/diagram7.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:50:48.526818891Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/fraller2019abc/metadata-turtle.ttl
+++ b/models/fraller2019abc/metadata-turtle.ttl
@@ -7,11 +7,10 @@
 <https://w3id.org/ontouml-models/distribution/5511de05-7efc-49bc-bd8a-b76e16667238/> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/dbd5fed6-8332-458f-90ec-b9270e7b6fdc> ;
     dct:issued "2019"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Turtle distribution of Capacity-Based Activity-Based Costing System Model"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/fraller2019abc/ontology.ttl> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
     fdpo:metadataIssued "2023-04-14T17:50:50.267540831Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/fraller2019abc/metadata-vpp.ttl
+++ b/models/fraller2019abc/metadata-vpp.ttl
@@ -8,11 +8,10 @@
     dct:format <https://www.file-extension.info/format/vpp> ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/dbd5fed6-8332-458f-90ec-b9270e7b6fdc> ;
     dct:issued "2019"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Visual Paradigm distribution of Capacity-Based Activity-Based Costing System Model"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/fraller2019abc/ontology.vpp> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/octet-stream> ;
     fdpo:metadataIssued "2023-04-14T17:50:51.764604781Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T00:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/fraller2019abc/metadata.ttl
+++ b/models/fraller2019abc/metadata.ttl
@@ -16,7 +16,6 @@
     dct:modified "2019"^^xsd:gYear;
     dcat:theme lcc:T;
     dct:language "en";
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:contributor <https://repositum.tuwien.at/cris/rp/rp05529>;
     dcat:keyword "activity-based costing"@en,
                  "accounting"@en,
@@ -29,7 +28,7 @@
     ocmv:ontologyType ocmv:Domain;
     ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/fraller2019abc"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:50:24.471735854Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .
 
 <https://w3id.org/ontouml-models/model/dbd5fed6-8332-458f-90ec-b9270e7b6fdc> dcat:distribution <https://w3id.org/ontouml-models/distribution/5511de05-7efc-49bc-bd8a-b76e16667238/>,
                       <https://w3id.org/ontouml-models/distribution/8741ccfc-4280-498c-8dc7-e5592d52c124/>,

--- a/models/gailly2016value/metadata-json.ttl
+++ b/models/gailly2016value/metadata-json.ttl
@@ -12,10 +12,9 @@
     dct:isPartOf <https://w3id.org/ontouml-models/model/27838506-29aa-4445-a1fe-73e710c9c186>;
     dct:issued "2016"^^xsd:gYear;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of Core Value Ontology"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/gailly2016value/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T17:51:38.931051931Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .

--- a/models/gailly2016value/metadata-png-n-core-value-ontology.ttl
+++ b/models/gailly2016value/metadata-png-n-core-value-ontology.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/e97baa9a-9831-404b-8b43-982b78aae293> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/27838506-29aa-4445-a1fe-73e710c9c186> ;
     dct:issued "2016"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'core value ontology' from the Core Value Ontology (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/gailly2016value/new-diagrams/core-value-ontology.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:51:40.590128873Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/gailly2016value/metadata-png-o-diagram1.ttl
+++ b/models/gailly2016value/metadata-png-o-diagram1.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/b4dcfd16-d911-47a5-9922-d2896c943176> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/27838506-29aa-4445-a1fe-73e710c9c186> ;
     dct:issued "2016"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram1' from the Core Value Ontology (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/gailly2016value/original-diagrams/diagram1.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:51:42.127556749Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/gailly2016value/metadata-turtle.ttl
+++ b/models/gailly2016value/metadata-turtle.ttl
@@ -7,11 +7,10 @@
 <https://w3id.org/ontouml-models/distribution/9535f276-2f73-4268-893e-5778df89b8ce/> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/27838506-29aa-4445-a1fe-73e710c9c186> ;
     dct:issued "2016"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Turtle distribution of Core Value Ontology"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/gailly2016value/ontology.ttl> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
     fdpo:metadataIssued "2023-04-14T17:51:43.757471202Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/gailly2016value/metadata-vpp.ttl
+++ b/models/gailly2016value/metadata-vpp.ttl
@@ -8,11 +8,10 @@
     dct:format <https://www.file-extension.info/format/vpp> ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/27838506-29aa-4445-a1fe-73e710c9c186> ;
     dct:issued "2016"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Visual Paradigm distribution of Core Value Ontology"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/gailly2016value/ontology.vpp> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/octet-stream> ;
     fdpo:metadataIssued "2023-04-14T17:51:45.342398156Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T00:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/gailly2016value/metadata.ttl
+++ b/models/gailly2016value/metadata.ttl
@@ -17,7 +17,6 @@
     dcat:theme lcc:H;
     skos:editorialNote "The paper first presents the Core Value Ontology (Fig. 9) and then presents an instantiation of this ontology for the healthcare domain (Fig. 10). Both diagrams were reproduced.";
     dct:language "en";
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:contributor <https://dblp.org/pid/95/6356>,
                     <https://dblp.org/pid/131/1200>,
                     <https://dblp.org/pid/11/78>;
@@ -29,7 +28,7 @@
     ocmv:ontologyType ocmv:Core;
     ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/gailly2016value"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:51:37.704953847Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .
 
 <https://w3id.org/ontouml-models/model/27838506-29aa-4445-a1fe-73e710c9c186> dcat:distribution <https://w3id.org/ontouml-models/distribution/9535f276-2f73-4268-893e-5778df89b8ce/>,
                       <https://w3id.org/ontouml-models/distribution/b63c3030-9de1-4272-bcb6-05ca764001db/>,

--- a/models/garcia2022human-genome-events/metadata-json.ttl
+++ b/models/garcia2022human-genome-events/metadata-json.ttl
@@ -12,10 +12,9 @@
     dct:isPartOf <https://w3id.org/ontouml-models/model/765516ef-53fe-4933-a0e5-0a38079d25c3>;
     dct:issued "2022"^^xsd:gYear;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of Ontologically enriched version of Conceptual Schema of the Human Genome"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/garcia2022human-genome-events/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T17:51:48.424007898Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .

--- a/models/garcia2022human-genome-events/metadata-png-n-ontouml-cshg.ttl
+++ b/models/garcia2022human-genome-events/metadata-png-n-ontouml-cshg.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/35bdbc97-7a8e-4b06-a0db-0e102b867966> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/765516ef-53fe-4933-a0e5-0a38079d25c3> ;
     dct:issued "2022"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'ontouml cshg' from the Ontologically enriched version of Conceptual Schema of the Human Genome (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/garcia2022human-genome-events/new-diagrams/ontouml-cshg.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:51:49.971479565Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/garcia2022human-genome-events/metadata-png-o-ontouml-cshg.ttl
+++ b/models/garcia2022human-genome-events/metadata-png-o-ontouml-cshg.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/08eafe8a-3279-43bc-93ca-affd8d2f4a75> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/765516ef-53fe-4933-a0e5-0a38079d25c3> ;
     dct:issued "2022"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'ontouml cshg' from the Ontologically enriched version of Conceptual Schema of the Human Genome (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/garcia2022human-genome-events/original-diagrams/ontouml-cshg.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:51:51.462997587Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/garcia2022human-genome-events/metadata-turtle.ttl
+++ b/models/garcia2022human-genome-events/metadata-turtle.ttl
@@ -7,11 +7,10 @@
 <https://w3id.org/ontouml-models/distribution/6d9762e4-6f5e-413d-aa9a-aaaeebc5f070/> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/765516ef-53fe-4933-a0e5-0a38079d25c3> ;
     dct:issued "2022"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Turtle distribution of Ontologically enriched version of Conceptual Schema of the Human Genome"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/garcia2022human-genome-events/ontology.ttl> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
     fdpo:metadataIssued "2023-04-14T17:51:53.026791321Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/garcia2022human-genome-events/metadata-vpp.ttl
+++ b/models/garcia2022human-genome-events/metadata-vpp.ttl
@@ -8,11 +8,10 @@
     dct:format <https://www.file-extension.info/format/vpp> ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/765516ef-53fe-4933-a0e5-0a38079d25c3> ;
     dct:issued "2022"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Visual Paradigm distribution of Ontologically enriched version of Conceptual Schema of the Human Genome"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/garcia2022human-genome-events/ontology.vpp> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/octet-stream> ;
     fdpo:metadataIssued "2023-04-14T17:51:54.467395873Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T00:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/garcia2022human-genome-events/metadata.ttl
+++ b/models/garcia2022human-genome-events/metadata.ttl
@@ -17,7 +17,6 @@
     dcat:theme lcc:Q;
     skos:editorialNote "The original diagram in vpp format was sent by the author. The only necessary action was the substitution of the generic categories by the same ones from the vp ontouml plugin. Metadata validated by the model author.";
     dct:language "en";
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:contributor <https://dblp.org/pid/201/2998.html>,
                     <https://dblp.org/pid/11/78>,
                     <https://dblp.org/pid/p/OscarPastor>,
@@ -34,7 +33,7 @@
     ocmv:ontologyType ocmv:Domain;
     ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/garcia2022human-genome-events"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:51:47.230441279Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .
 
 <https://w3id.org/ontouml-models/model/765516ef-53fe-4933-a0e5-0a38079d25c3> dcat:distribution <https://w3id.org/ontouml-models/distribution/6d9762e4-6f5e-413d-aa9a-aaaeebc5f070/>,
                       <https://w3id.org/ontouml-models/distribution/c398450e-3de4-4f5e-8504-86ad9977fd22/>,

--- a/models/grueau2013towards/metadata-json.ttl
+++ b/models/grueau2013towards/metadata-json.ttl
@@ -12,10 +12,9 @@
     dct:isPartOf <https://w3id.org/ontouml-models/model/12a721da-35ae-460f-9417-a2cf55e0f203>;
     dct:issued "2014"^^xsd:gYear;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of MAS/LUCC Domain Ontology (excerpt - the agents' layer)"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/grueau2013towards/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T17:53:10.637596064Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .

--- a/models/grueau2013towards/metadata-png-n-diagram1.ttl
+++ b/models/grueau2013towards/metadata-png-n-diagram1.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/6688027b-d89a-4749-8b71-6f848a7bae7d> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/12a721da-35ae-460f-9417-a2cf55e0f203> ;
     dct:issued "2014"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram1' from the MAS/LUCC Domain Ontology (excerpt - the agents' layer) (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/grueau2013towards/new-diagrams/diagram1.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:53:12.25210429Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/grueau2013towards/metadata-png-o-diagram1.ttl
+++ b/models/grueau2013towards/metadata-png-o-diagram1.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/1abf7d46-1c05-4fd2-bd05-758e2e70455b> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/12a721da-35ae-460f-9417-a2cf55e0f203> ;
     dct:issued "2014"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram1' from the MAS/LUCC Domain Ontology (excerpt - the agents' layer) (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/grueau2013towards/original-diagrams/diagram1.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:53:14.187960211Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/grueau2013towards/metadata-turtle.ttl
+++ b/models/grueau2013towards/metadata-turtle.ttl
@@ -7,11 +7,10 @@
 <https://w3id.org/ontouml-models/distribution/e309f16f-4618-4502-ab00-bf37008c6967/> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/12a721da-35ae-460f-9417-a2cf55e0f203> ;
     dct:issued "2014"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Turtle distribution of MAS/LUCC Domain Ontology (excerpt - the agents' layer)"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/grueau2013towards/ontology.ttl> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
     fdpo:metadataIssued "2023-04-14T17:53:16.18200434Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/grueau2013towards/metadata-vpp.ttl
+++ b/models/grueau2013towards/metadata-vpp.ttl
@@ -8,11 +8,10 @@
     dct:format <https://www.file-extension.info/format/vpp> ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/12a721da-35ae-460f-9417-a2cf55e0f203> ;
     dct:issued "2014"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Visual Paradigm distribution of MAS/LUCC Domain Ontology (excerpt - the agents' layer)"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/grueau2013towards/ontology.vpp> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/octet-stream> ;
     fdpo:metadataIssued "2023-04-14T17:53:18.040687847Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T00:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/grueau2013towards/metadata.ttl
+++ b/models/grueau2013towards/metadata.ttl
@@ -18,7 +18,6 @@
     skos:editorialNote """This ontology uses an unexpected set of stereotypes, but it is UFO-based. The publication the authors drive their stereotypes from is the following: https://doi.org/10.1109/WSC.2011.6147757
 """;
     dct:language "en";
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:contributor <https://dblp.org/pid/129/2240>;
     dcat:keyword "language engineering"@en;
     dct:source <https://doi.org/10.1007/978-3-319-14139-8_28>;
@@ -29,7 +28,7 @@
     ocmv:ontologyType ocmv:Domain;
     ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/grueau2013towards"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:53:09.390212546Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .
 
 <https://w3id.org/ontouml-models/model/12a721da-35ae-460f-9417-a2cf55e0f203> dcat:distribution <https://w3id.org/ontouml-models/distribution/e309f16f-4618-4502-ab00-bf37008c6967/>,
                       <https://w3id.org/ontouml-models/distribution/689fa9dc-a3d2-4626-8b7a-79d771b9abae/>,

--- a/models/haridy2021egyptian-e-government/metadata-json.ttl
+++ b/models/haridy2021egyptian-e-government/metadata-json.ttl
@@ -12,10 +12,9 @@
     dct:isPartOf <https://w3id.org/ontouml-models/model/5f85d9aa-67ac-4315-b60d-0212ea910320>;
     dct:issued "2021"^^xsd:gYear;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of Egyptian E-Government Conceptual Model"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/haridy2021egyptian-e-government/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T17:54:30.276780556Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .

--- a/models/haridy2021egyptian-e-government/metadata-png-n-diagram1.ttl
+++ b/models/haridy2021egyptian-e-government/metadata-png-n-diagram1.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/4a0f35ac-cc48-4596-9c27-a3c387d03b88> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/5f85d9aa-67ac-4315-b60d-0212ea910320> ;
     dct:issued "2021"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram1' from the Egyptian E-Government Conceptual Model (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/haridy2021egyptian-e-government/new-diagrams/diagram1.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:54:31.864812669Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/haridy2021egyptian-e-government/metadata-png-n-diagram2.ttl
+++ b/models/haridy2021egyptian-e-government/metadata-png-n-diagram2.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/e9c9f2e2-8e76-437f-874a-318ba5a3c73e> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/5f85d9aa-67ac-4315-b60d-0212ea910320> ;
     dct:issued "2021"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram2' from the Egyptian E-Government Conceptual Model (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/haridy2021egyptian-e-government/new-diagrams/diagram2.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:54:33.369386435Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/haridy2021egyptian-e-government/metadata-png-o-diagram1.ttl
+++ b/models/haridy2021egyptian-e-government/metadata-png-o-diagram1.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/9a5e36cd-a1fc-4e7f-b134-139a79aa5cd1> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/5f85d9aa-67ac-4315-b60d-0212ea910320> ;
     dct:issued "2021"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram1' from the Egyptian E-Government Conceptual Model (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/haridy2021egyptian-e-government/original-diagrams/diagram1.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:54:35.302639096Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/haridy2021egyptian-e-government/metadata-png-o-diagram2.ttl
+++ b/models/haridy2021egyptian-e-government/metadata-png-o-diagram2.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/edc423f7-30bc-400b-a8bf-741f53cfd7f1> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/5f85d9aa-67ac-4315-b60d-0212ea910320> ;
     dct:issued "2021"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram2' from the Egyptian E-Government Conceptual Model (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/haridy2021egyptian-e-government/original-diagrams/diagram2.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:54:36.938122191Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/haridy2021egyptian-e-government/metadata-turtle.ttl
+++ b/models/haridy2021egyptian-e-government/metadata-turtle.ttl
@@ -7,11 +7,10 @@
 <https://w3id.org/ontouml-models/distribution/280910f3-6369-4c2e-9785-ea4ad1588e1f/> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/5f85d9aa-67ac-4315-b60d-0212ea910320> ;
     dct:issued "2021"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Turtle distribution of Egyptian E-Government Conceptual Model"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/haridy2021egyptian-e-government/ontology.ttl> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
     fdpo:metadataIssued "2023-04-14T17:54:38.5149831Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/haridy2021egyptian-e-government/metadata-vpp.ttl
+++ b/models/haridy2021egyptian-e-government/metadata-vpp.ttl
@@ -8,11 +8,10 @@
     dct:format <https://www.file-extension.info/format/vpp> ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/5f85d9aa-67ac-4315-b60d-0212ea910320> ;
     dct:issued "2021"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Visual Paradigm distribution of Egyptian E-Government Conceptual Model"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/haridy2021egyptian-e-government/ontology.vpp> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/octet-stream> ;
     fdpo:metadataIssued "2023-04-14T17:54:40.239225652Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T00:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/haridy2021egyptian-e-government/metadata.ttl
+++ b/models/haridy2021egyptian-e-government/metadata.ttl
@@ -17,7 +17,6 @@
     dcat:theme lcc:J;
     skos:editorialNote "The diagrams represent the accessible subfragments of the full model, about the \"traveler\" and \"student\" case studies";
     dct:language "en";
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:contributor <https://dblp.org/pid/123/8870>,
                     <https://dblp.org/pid/123/9738>,
                     <https://dblp.org/pid/123/9749>,
@@ -30,7 +29,7 @@
     ocmv:ontologyType ocmv:Domain;
     ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/haridy2021egyptian-e-government"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:54:29.053597861Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .
 
 <https://w3id.org/ontouml-models/model/5f85d9aa-67ac-4315-b60d-0212ea910320> dcat:distribution <https://w3id.org/ontouml-models/distribution/280910f3-6369-4c2e-9785-ea4ad1588e1f/>,
                       <https://w3id.org/ontouml-models/distribution/74deef99-cf3e-43ad-905f-1fb158585e00/>,

--- a/models/khantong2020ontology/metadata-json.ttl
+++ b/models/khantong2020ontology/metadata-json.ttl
@@ -12,10 +12,9 @@
     dct:isPartOf <https://w3id.org/ontouml-models/model/5a426516-e211-4e7b-abc5-dca6b11d2d6a>;
     dct:issued "2019"^^xsd:gYear;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of Disaster Response Ontology - Flood Response Scenarios"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/khantong2020ontology/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T17:56:04.384430212Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .

--- a/models/khantong2020ontology/metadata-png-n-diagram1.ttl
+++ b/models/khantong2020ontology/metadata-png-n-diagram1.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/3a516b68-9ecb-442e-82e9-a830e54fb1fd> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/5a426516-e211-4e7b-abc5-dca6b11d2d6a> ;
     dct:issued "2019"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram1' from the Disaster Response Ontology - Flood Response Scenarios (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/khantong2020ontology/new-diagrams/diagram1.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:56:05.954984141Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/khantong2020ontology/metadata-png-o-diagram1.ttl
+++ b/models/khantong2020ontology/metadata-png-o-diagram1.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/d74f43fe-4a2c-4529-a21d-fe49399f5af5> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/5a426516-e211-4e7b-abc5-dca6b11d2d6a> ;
     dct:issued "2019"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram1' from the Disaster Response Ontology - Flood Response Scenarios (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/khantong2020ontology/original-diagrams/diagram1.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:56:07.549243856Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/khantong2020ontology/metadata-turtle.ttl
+++ b/models/khantong2020ontology/metadata-turtle.ttl
@@ -7,11 +7,10 @@
 <https://w3id.org/ontouml-models/distribution/48407f93-c4e4-4925-ba5c-3518169e223e/> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/5a426516-e211-4e7b-abc5-dca6b11d2d6a> ;
     dct:issued "2019"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Turtle distribution of Disaster Response Ontology - Flood Response Scenarios"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/khantong2020ontology/ontology.ttl> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
     fdpo:metadataIssued "2023-04-14T17:56:09.099167712Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/khantong2020ontology/metadata-vpp.ttl
+++ b/models/khantong2020ontology/metadata-vpp.ttl
@@ -8,11 +8,10 @@
     dct:format <https://www.file-extension.info/format/vpp> ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/5a426516-e211-4e7b-abc5-dca6b11d2d6a> ;
     dct:issued "2019"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Visual Paradigm distribution of Disaster Response Ontology - Flood Response Scenarios"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/khantong2020ontology/ontology.vpp> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/octet-stream> ;
     fdpo:metadataIssued "2023-04-14T17:56:10.732743053Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T00:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/khantong2020ontology/metadata.ttl
+++ b/models/khantong2020ontology/metadata.ttl
@@ -17,7 +17,6 @@
     dcat:theme lcc:H;
     skos:editorialNote "The ontology was documented based on the version on the journal publication. It employs UFO for endurants, but employs DEMO theory of speech acts for perdurants.";
     dct:language "en";
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:contributor <https://dblp.org/pid/262/2006>,
                     <https://dblp.org/pid/66/4875>,
                     <https://dblp.org/pid/35/3072>;
@@ -30,7 +29,7 @@
     ocmv:ontologyType ocmv:Domain;
     ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/khantong2020ontology"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:56:03.092028774Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .
 
 <https://w3id.org/ontouml-models/model/5a426516-e211-4e7b-abc5-dca6b11d2d6a> dcat:distribution <https://w3id.org/ontouml-models/distribution/48407f93-c4e4-4925-ba5c-3518169e223e/>,
                       <https://w3id.org/ontouml-models/distribution/094cc3c7-c53a-489a-bf84-207d0283c31a/>,

--- a/models/kostov2017towards/metadata-json.ttl
+++ b/models/kostov2017towards/metadata-json.ttl
@@ -12,10 +12,9 @@
     dct:isPartOf <https://w3id.org/ontouml-models/model/b8d64beb-327f-4e7c-96a7-a10ab1a9da3e>;
     dct:issued "2016"^^xsd:gYear;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of Aviation Safety Ontology"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/kostov2017towards/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T17:56:13.825909408Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .

--- a/models/kostov2017towards/metadata-png-n-diagram1.ttl
+++ b/models/kostov2017towards/metadata-png-n-diagram1.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/a8be78da-af8a-4308-a267-25e1b54cc14d> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/b8d64beb-327f-4e7c-96a7-a10ab1a9da3e> ;
     dct:issued "2016"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram1' from the Aviation Safety Ontology (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/kostov2017towards/new-diagrams/diagram1.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:56:15.550994147Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/kostov2017towards/metadata-png-n-diagram2.ttl
+++ b/models/kostov2017towards/metadata-png-n-diagram2.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/976ab279-112b-4e38-9d04-06ec400ba2fd> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/b8d64beb-327f-4e7c-96a7-a10ab1a9da3e> ;
     dct:issued "2016"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram2' from the Aviation Safety Ontology (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/kostov2017towards/new-diagrams/diagram2.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:56:17.207383764Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/kostov2017towards/metadata-png-n-diagram3.ttl
+++ b/models/kostov2017towards/metadata-png-n-diagram3.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/7cc30b6b-249e-47da-9780-cc62014a4e2b> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/b8d64beb-327f-4e7c-96a7-a10ab1a9da3e> ;
     dct:issued "2016"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram3' from the Aviation Safety Ontology (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/kostov2017towards/new-diagrams/diagram3.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:56:18.77962105Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/kostov2017towards/metadata-png-o-diagram1.ttl
+++ b/models/kostov2017towards/metadata-png-o-diagram1.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/29af279a-50ca-406f-85f5-a82fff0bfb5b> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/b8d64beb-327f-4e7c-96a7-a10ab1a9da3e> ;
     dct:issued "2016"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram1' from the Aviation Safety Ontology (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/kostov2017towards/original-diagrams/diagram1.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:56:20.451618158Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/kostov2017towards/metadata-png-o-diagram2.ttl
+++ b/models/kostov2017towards/metadata-png-o-diagram2.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/5da6873a-0c03-44dc-a6ee-da43a7ca3ee6> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/b8d64beb-327f-4e7c-96a7-a10ab1a9da3e> ;
     dct:issued "2016"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram2' from the Aviation Safety Ontology (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/kostov2017towards/original-diagrams/diagram2.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:56:22.159535294Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/kostov2017towards/metadata-png-o-diagram3.ttl
+++ b/models/kostov2017towards/metadata-png-o-diagram3.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/7f429482-a2db-4b2d-b9fe-a1eb5f797377> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/b8d64beb-327f-4e7c-96a7-a10ab1a9da3e> ;
     dct:issued "2016"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram3' from the Aviation Safety Ontology (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/kostov2017towards/original-diagrams/diagram3.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:56:23.821875116Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/kostov2017towards/metadata-turtle.ttl
+++ b/models/kostov2017towards/metadata-turtle.ttl
@@ -7,11 +7,10 @@
 <https://w3id.org/ontouml-models/distribution/8c8d9f3e-c061-4804-8cc2-f51099c85074/> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/b8d64beb-327f-4e7c-96a7-a10ab1a9da3e> ;
     dct:issued "2016"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Turtle distribution of Aviation Safety Ontology"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/kostov2017towards/ontology.ttl> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
     fdpo:metadataIssued "2023-04-14T17:56:25.572750358Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/kostov2017towards/metadata-vpp.ttl
+++ b/models/kostov2017towards/metadata-vpp.ttl
@@ -8,11 +8,10 @@
     dct:format <https://www.file-extension.info/format/vpp> ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/b8d64beb-327f-4e7c-96a7-a10ab1a9da3e> ;
     dct:issued "2016"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Visual Paradigm distribution of Aviation Safety Ontology"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/kostov2017towards/ontology.vpp> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/octet-stream> ;
     fdpo:metadataIssued "2023-04-14T17:56:27.073367782Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T00:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/kostov2017towards/metadata.ttl
+++ b/models/kostov2017towards/metadata.ttl
@@ -17,7 +17,6 @@
     dcat:theme lcc:T;
     skos:editorialNote "The main paper (kostov2017towards) presents just part of the Aviation Ontology (diagram 1). Other part of the same model can be found in ahmad2016ontological, which was reproduced in diagram 2. The Safety Ontology is represented in diagram3. When a class' stereotype is not present in one diagram but can be found in another we represent it in both diagrams. Associations originally represented as bound were represented separated.";
     dct:language "en";
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:contributor <https://dblp.org/pid/185/3559>,
                     <https://dblp.org/pid/77/5702>,
                     <https://dblp.org/pid/129/7052>,
@@ -38,7 +37,7 @@
     ocmv:ontologyType ocmv:Domain;
     ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/kostov2017towards"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:56:12.577469842Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .
 
 <https://w3id.org/ontouml-models/model/b8d64beb-327f-4e7c-96a7-a10ab1a9da3e> dcat:distribution <https://w3id.org/ontouml-models/distribution/8c8d9f3e-c061-4804-8cc2-f51099c85074/>,
                       <https://w3id.org/ontouml-models/distribution/f13f2b9e-ebc9-4694-9618-a67defc9ecca/>,

--- a/models/maddalena2021ontocovid/metadata-json.ttl
+++ b/models/maddalena2021ontocovid/metadata-json.ttl
@@ -12,10 +12,9 @@
     dct:isPartOf <https://w3id.org/ontouml-models/model/731a9856-9d6f-4a07-859c-48ec758fe5ce>;
     dct:issued "2021"^^xsd:gYear;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of OntoCovid"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/maddalena2021ontocovid/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T17:58:13.720975425Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .

--- a/models/maddalena2021ontocovid/metadata-png-o-caso.ttl
+++ b/models/maddalena2021ontocovid/metadata-png-o-caso.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/9a59e63f-4edb-4aab-ba35-52d79a772916> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/731a9856-9d6f-4a07-859c-48ec758fe5ce> ;
     dct:issued "2021"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'caso' from the OntoCovid (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/maddalena2021ontocovid/original-diagrams/caso.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:58:15.279558704Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/maddalena2021ontocovid/metadata-png-o-pessoa.ttl
+++ b/models/maddalena2021ontocovid/metadata-png-o-pessoa.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/c1e13f91-fc02-4d28-b0d3-6f0751248fb9> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/731a9856-9d6f-4a07-859c-48ec758fe5ce> ;
     dct:issued "2021"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'pessoa' from the OntoCovid (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/maddalena2021ontocovid/original-diagrams/pessoa.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:58:17.822439524Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/maddalena2021ontocovid/metadata-turtle.ttl
+++ b/models/maddalena2021ontocovid/metadata-turtle.ttl
@@ -7,11 +7,10 @@
 <https://w3id.org/ontouml-models/distribution/8ba63420-bbe8-4151-9918-14aab50751b7/> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/731a9856-9d6f-4a07-859c-48ec758fe5ce> ;
     dct:issued "2021"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Turtle distribution of OntoCovid"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/maddalena2021ontocovid/ontology.ttl> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
     fdpo:metadataIssued "2023-04-14T17:58:19.5761608Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/maddalena2021ontocovid/metadata-vpp.ttl
+++ b/models/maddalena2021ontocovid/metadata-vpp.ttl
@@ -8,11 +8,10 @@
     dct:format <https://www.file-extension.info/format/vpp> ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/731a9856-9d6f-4a07-859c-48ec758fe5ce> ;
     dct:issued "2021"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Visual Paradigm distribution of OntoCovid"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/maddalena2021ontocovid/ontology.vpp> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/octet-stream> ;
     fdpo:metadataIssued "2023-04-14T17:58:21.245869744Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T00:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/maddalena2021ontocovid/metadata.ttl
+++ b/models/maddalena2021ontocovid/metadata.ttl
@@ -16,7 +16,6 @@
     dct:modified "2021"^^xsd:gYear;
     dcat:theme lcc:R;
     dct:language "pt-br";
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:contributor <https://dblp.org/pid/309/4924>,
                     <https://dblp.org/pid/b/FAraujoBaiao>;
     dcat:keyword "health"@en,
@@ -28,7 +27,7 @@
     ocmv:ontologyType ocmv:Domain;
     ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/maddalena2021ontocovid"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:58:12.467273247Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .
 
 <https://w3id.org/ontouml-models/model/731a9856-9d6f-4a07-859c-48ec758fe5ce> dcat:distribution <https://w3id.org/ontouml-models/distribution/8ba63420-bbe8-4151-9918-14aab50751b7/>,
                       <https://w3id.org/ontouml-models/distribution/1a3c1d2b-679c-47d2-a2b4-59e81e1583e7/>,

--- a/models/martinez2013human-genome/metadata-json.ttl
+++ b/models/martinez2013human-genome/metadata-json.ttl
@@ -12,10 +12,9 @@
     dct:isPartOf <https://w3id.org/ontouml-models/model/7509f026-5e24-48e7-a995-ab2f419ce4d7>;
     dct:issued "2013"^^xsd:gYear;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of Conceptual Schema of Human Genome"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/martinez2013human-genome/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T17:58:24.432247449Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .

--- a/models/martinez2013human-genome/metadata-png-n-variation-core-concepts.ttl
+++ b/models/martinez2013human-genome/metadata-png-n-variation-core-concepts.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/5f288612-560c-4eb8-a166-538401b255bb> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/7509f026-5e24-48e7-a995-ab2f419ce4d7> ;
     dct:issued "2013"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'variation core concepts' from the Conceptual Schema of Human Genome (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/martinez2013human-genome/new-diagrams/variation-core-concepts.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:58:26.056683831Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/martinez2013human-genome/metadata-png-n-variation-insertion.ttl
+++ b/models/martinez2013human-genome/metadata-png-n-variation-insertion.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/1bc297ac-1a61-474d-833e-ad055fb2fc25> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/7509f026-5e24-48e7-a995-ab2f419ce4d7> ;
     dct:issued "2013"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'variation insertion' from the Conceptual Schema of Human Genome (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/martinez2013human-genome/new-diagrams/variation-insertion.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:58:27.599513076Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/martinez2013human-genome/metadata-png-o-variation-core-concepts.ttl
+++ b/models/martinez2013human-genome/metadata-png-o-variation-core-concepts.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/d53fdb12-3175-4151-b39e-31ed4e249f9a> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/7509f026-5e24-48e7-a995-ab2f419ce4d7> ;
     dct:issued "2013"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'variation core concepts' from the Conceptual Schema of Human Genome (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/martinez2013human-genome/original-diagrams/variation-core-concepts.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:58:29.099827175Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/martinez2013human-genome/metadata-png-o-variation-insertion.ttl
+++ b/models/martinez2013human-genome/metadata-png-o-variation-insertion.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/6a4cb048-3228-452d-aff0-0c4bb6a4489a> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/7509f026-5e24-48e7-a995-ab2f419ce4d7> ;
     dct:issued "2013"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'variation insertion' from the Conceptual Schema of Human Genome (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/martinez2013human-genome/original-diagrams/variation-insertion.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T17:58:30.799842238Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/martinez2013human-genome/metadata-turtle.ttl
+++ b/models/martinez2013human-genome/metadata-turtle.ttl
@@ -7,11 +7,10 @@
 <https://w3id.org/ontouml-models/distribution/5239badd-3f17-4eaf-9ef4-bab107211d70/> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/7509f026-5e24-48e7-a995-ab2f419ce4d7> ;
     dct:issued "2013"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Turtle distribution of Conceptual Schema of Human Genome"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/martinez2013human-genome/ontology.ttl> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
     fdpo:metadataIssued "2023-04-14T17:58:32.329139435Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/martinez2013human-genome/metadata-vpp.ttl
+++ b/models/martinez2013human-genome/metadata-vpp.ttl
@@ -8,11 +8,10 @@
     dct:format <https://www.file-extension.info/format/vpp> ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/7509f026-5e24-48e7-a995-ab2f419ce4d7> ;
     dct:issued "2013"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Visual Paradigm distribution of Conceptual Schema of Human Genome"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/martinez2013human-genome/ontology.vpp> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/octet-stream> ;
     fdpo:metadataIssued "2023-04-14T17:58:33.847415678Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T00:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/martinez2013human-genome/metadata.ttl
+++ b/models/martinez2013human-genome/metadata.ttl
@@ -17,7 +17,6 @@
     dct:modified "2013"^^xsd:gYear;
     dcat:theme lcc:R;
     dct:language "en";
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:contributor <https://dblp.org/pid/137/2813>,
                     <https://dblp.org/pid/p/OscarPastor>,
                     <https://dblp.org/pid/11/78>;
@@ -30,7 +29,7 @@
     ocmv:ontologyType ocmv:Domain;
     ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/martinez2013human-genome"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T17:58:23.166457014Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .
 
 <https://w3id.org/ontouml-models/model/7509f026-5e24-48e7-a995-ab2f419ce4d7> dcat:distribution <https://w3id.org/ontouml-models/distribution/5239badd-3f17-4eaf-9ef4-bab107211d70/>,
                       <https://w3id.org/ontouml-models/distribution/0a7b8bb6-a311-4806-9ff2-b8c87c5d8e61/>,

--- a/models/neves2021grain-production/metadata-json.ttl
+++ b/models/neves2021grain-production/metadata-json.ttl
@@ -12,10 +12,9 @@
     dct:isPartOf <https://w3id.org/ontouml-models/model/1d378243-6061-4e3a-b32e-05436601d9d9>;
     dct:issued "2021"^^xsd:gYear;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of Grain Production Ontology"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/neves2021grain-production/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T18:07:17.931582397Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .

--- a/models/neves2021grain-production/metadata-png-n-grain-production-ontology.ttl
+++ b/models/neves2021grain-production/metadata-png-n-grain-production-ontology.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/93ab29e4-4762-41c9-9687-0eaac5564e87> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/1d378243-6061-4e3a-b32e-05436601d9d9> ;
     dct:issued "2021"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'grain production ontology' from the Grain Production Ontology (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/neves2021grain-production/new-diagrams/grain-production-ontology.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:07:19.48574046Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/neves2021grain-production/metadata-png-o-diagram1.ttl
+++ b/models/neves2021grain-production/metadata-png-o-diagram1.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/c43ad639-7df9-4fb8-a923-894bd5166e45> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/1d378243-6061-4e3a-b32e-05436601d9d9> ;
     dct:issued "2021"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram1' from the Grain Production Ontology (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/neves2021grain-production/original-diagrams/diagram1.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:07:21.459808882Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/neves2021grain-production/metadata-turtle.ttl
+++ b/models/neves2021grain-production/metadata-turtle.ttl
@@ -7,11 +7,10 @@
 <https://w3id.org/ontouml-models/distribution/1e79d4ec-d6c5-4f71-8696-900f0458dfe7/> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/1d378243-6061-4e3a-b32e-05436601d9d9> ;
     dct:issued "2021"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Turtle distribution of Grain Production Ontology"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/neves2021grain-production/ontology.ttl> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
     fdpo:metadataIssued "2023-04-14T18:07:23.112471369Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/neves2021grain-production/metadata-vpp.ttl
+++ b/models/neves2021grain-production/metadata-vpp.ttl
@@ -8,11 +8,10 @@
     dct:format <https://www.file-extension.info/format/vpp> ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/1d378243-6061-4e3a-b32e-05436601d9d9> ;
     dct:issued "2021"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Visual Paradigm distribution of Grain Production Ontology"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/neves2021grain-production/ontology.vpp> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/octet-stream> ;
     fdpo:metadataIssued "2023-04-14T18:07:24.669637059Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T00:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/neves2021grain-production/metadata.ttl
+++ b/models/neves2021grain-production/metadata.ttl
@@ -17,7 +17,6 @@
     dcat:theme lcc:S;
     skos:editorialNote "I inferred the association direction from their names. For instance, I assumed that the association named 'Crop-Digital_Images' had 'Crop' as its source and 'Digital_Images' as its target.";
     dct:language "en";
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:contributor <https://dblp.org/pid/261/1068>,
                     <https://dblp.org/pid/92/1196>;
     dcat:keyword "agriculture"@en,
@@ -30,7 +29,7 @@
                       ocmv:Application;
     ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/neves2021grain-production"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T18:07:16.678198598Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .
 
 <https://w3id.org/ontouml-models/model/1d378243-6061-4e3a-b32e-05436601d9d9> dcat:distribution <https://w3id.org/ontouml-models/distribution/1e79d4ec-d6c5-4f71-8696-900f0458dfe7/>,
                       <https://w3id.org/ontouml-models/distribution/38a5d0e0-26f8-4daa-8df1-b9bdd147db31/>,

--- a/models/niederkofler2019dssapple/metadata-json.ttl
+++ b/models/niederkofler2019dssapple/metadata-json.ttl
@@ -12,10 +12,9 @@
     dct:isPartOf <https://w3id.org/ontouml-models/model/5f97c733-db8a-44cc-b94d-a28b7d3e85cc>;
     dct:issued "2019"^^xsd:gYear;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of DSSApple Ontology"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/niederkofler2019dssapple/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T18:07:27.592456072Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .

--- a/models/niederkofler2019dssapple/metadata-png-n-diagram1.ttl
+++ b/models/niederkofler2019dssapple/metadata-png-n-diagram1.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/684997b1-4606-4be4-a9c2-db36a5a996d5> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/5f97c733-db8a-44cc-b94d-a28b7d3e85cc> ;
     dct:issued "2019"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram1' from the DSSApple Ontology (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/niederkofler2019dssapple/new-diagrams/diagram1.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:07:29.197516715Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/niederkofler2019dssapple/metadata-png-n-diagram2.ttl
+++ b/models/niederkofler2019dssapple/metadata-png-n-diagram2.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/99aa0a36-37e0-45e4-8c24-54e5c262653c> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/5f97c733-db8a-44cc-b94d-a28b7d3e85cc> ;
     dct:issued "2019"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram2' from the DSSApple Ontology (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/niederkofler2019dssapple/new-diagrams/diagram2.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:07:30.844733261Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/niederkofler2019dssapple/metadata-png-n-diagram3.ttl
+++ b/models/niederkofler2019dssapple/metadata-png-n-diagram3.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/deedff70-f964-454f-8327-d63ad9e7fb8a> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/5f97c733-db8a-44cc-b94d-a28b7d3e85cc> ;
     dct:issued "2019"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram3' from the DSSApple Ontology (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/niederkofler2019dssapple/new-diagrams/diagram3.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:07:32.806438808Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/niederkofler2019dssapple/metadata-png-n-diagram4.ttl
+++ b/models/niederkofler2019dssapple/metadata-png-n-diagram4.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/6611ee0b-4cd1-4875-97e2-222326151354> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/5f97c733-db8a-44cc-b94d-a28b7d3e85cc> ;
     dct:issued "2019"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram4' from the DSSApple Ontology (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/niederkofler2019dssapple/new-diagrams/diagram4.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:07:34.406143902Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/niederkofler2019dssapple/metadata-png-n-diagram5.ttl
+++ b/models/niederkofler2019dssapple/metadata-png-n-diagram5.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/f58981c1-7752-4ffe-a8e2-5e2e342ad0fd> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/5f97c733-db8a-44cc-b94d-a28b7d3e85cc> ;
     dct:issued "2019"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram5' from the DSSApple Ontology (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/niederkofler2019dssapple/new-diagrams/diagram5.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:07:35.989222923Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/niederkofler2019dssapple/metadata-png-o-apple.ttl
+++ b/models/niederkofler2019dssapple/metadata-png-o-apple.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/29e15945-6397-47e0-a698-8294c6d0d5db> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/5f97c733-db8a-44cc-b94d-a28b7d3e85cc> ;
     dct:issued "2019"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'apple' from the DSSApple Ontology (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/niederkofler2019dssapple/original-diagrams/apple.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:07:37.608416878Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/niederkofler2019dssapple/metadata-png-o-dispositional-factors.ttl
+++ b/models/niederkofler2019dssapple/metadata-png-o-dispositional-factors.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/d99669c8-e78a-4359-bb23-6befe93bea0e> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/5f97c733-db8a-44cc-b94d-a28b7d3e85cc> ;
     dct:issued "2019"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'dispositional factors' from the DSSApple Ontology (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/niederkofler2019dssapple/original-diagrams/dispositional-factors.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:07:39.20621082Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/niederkofler2019dssapple/metadata-png-o-harvest.ttl
+++ b/models/niederkofler2019dssapple/metadata-png-o-harvest.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/afd3ef2e-09d3-4680-82ff-f4e849433f28> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/5f97c733-db8a-44cc-b94d-a28b7d3e85cc> ;
     dct:issued "2019"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'harvest' from the DSSApple Ontology (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/niederkofler2019dssapple/original-diagrams/harvest.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:07:40.661736099Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/niederkofler2019dssapple/metadata-png-o-image-data.ttl
+++ b/models/niederkofler2019dssapple/metadata-png-o-image-data.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/59ae34ad-f83a-4b9b-b0aa-37f92a45ae86> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/5f97c733-db8a-44cc-b94d-a28b7d3e85cc> ;
     dct:issued "2019"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'image data' from the DSSApple Ontology (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/niederkofler2019dssapple/original-diagrams/image-data.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:07:42.185273623Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/niederkofler2019dssapple/metadata-png-o-pathology.ttl
+++ b/models/niederkofler2019dssapple/metadata-png-o-pathology.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/9773c084-5df1-42d7-9844-fcd8e43e9b0b> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/5f97c733-db8a-44cc-b94d-a28b7d3e85cc> ;
     dct:issued "2019"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'pathology' from the DSSApple Ontology (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/niederkofler2019dssapple/original-diagrams/pathology.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:07:43.70349853Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/niederkofler2019dssapple/metadata-turtle.ttl
+++ b/models/niederkofler2019dssapple/metadata-turtle.ttl
@@ -7,11 +7,10 @@
 <https://w3id.org/ontouml-models/distribution/cb560e3e-8fad-4d7c-9168-35be47fc94fc/> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/5f97c733-db8a-44cc-b94d-a28b7d3e85cc> ;
     dct:issued "2019"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Turtle distribution of DSSApple Ontology"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/niederkofler2019dssapple/ontology.ttl> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
     fdpo:metadataIssued "2023-04-14T18:07:45.229898669Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/niederkofler2019dssapple/metadata-vpp.ttl
+++ b/models/niederkofler2019dssapple/metadata-vpp.ttl
@@ -8,11 +8,10 @@
     dct:format <https://www.file-extension.info/format/vpp> ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/5f97c733-db8a-44cc-b94d-a28b7d3e85cc> ;
     dct:issued "2019"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Visual Paradigm distribution of DSSApple Ontology"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/niederkofler2019dssapple/ontology.vpp> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/octet-stream> ;
     fdpo:metadataIssued "2023-04-14T18:07:46.781124438Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T00:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/niederkofler2019dssapple/metadata.ttl
+++ b/models/niederkofler2019dssapple/metadata.ttl
@@ -17,7 +17,6 @@
     dcat:theme lcc:S;
     skos:editorialNote "diagrams visualization not easy to replicate via vpp. By using \"Styles and Formatting\" > \"Curve\" the layout was partially replicated.";
     dct:language "en";
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:contributor <https://dblp.org/pid/255/6389>,
                     <https://dblp.org/pid/227/0572>,
                     <https://dblp.org/pid/11/78>,
@@ -35,7 +34,7 @@
     ocmv:ontologyType ocmv:Domain;
     ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/niederkofler2019dssapple"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T18:07:26.392881968Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .
 
 <https://w3id.org/ontouml-models/model/5f97c733-db8a-44cc-b94d-a28b7d3e85cc> dcat:distribution <https://w3id.org/ontouml-models/distribution/cb560e3e-8fad-4d7c-9168-35be47fc94fc/>,
                       <https://w3id.org/ontouml-models/distribution/36860b97-38e6-472a-9c2b-341eef7e90b0/>,

--- a/models/pereira2015doacao-orgaos/metadata-json.ttl
+++ b/models/pereira2015doacao-orgaos/metadata-json.ttl
@@ -12,10 +12,9 @@
     dct:isPartOf <https://w3id.org/ontouml-models/model/ff633ccf-80c1-4276-b9e2-7bf969b0d05b>;
     dct:issued "2015"^^xsd:gYear;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of Ontologia de Doação de Órgão e Tecidos"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/pereira2015doacao-orgaos/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T18:08:28.952183923Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .

--- a/models/pereira2015doacao-orgaos/metadata-png-n-diagram1.ttl
+++ b/models/pereira2015doacao-orgaos/metadata-png-n-diagram1.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/68835e65-28c7-4651-b8ff-7b22add04ee4> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/ff633ccf-80c1-4276-b9e2-7bf969b0d05b> ;
     dct:issued "2015"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram1' from the Ontologia de Doação de Órgão e Tecidos (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/pereira2015doacao-orgaos/new-diagrams/diagram1.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:08:30.578981034Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/pereira2015doacao-orgaos/metadata-png-n-diagram2.ttl
+++ b/models/pereira2015doacao-orgaos/metadata-png-n-diagram2.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/bd1913a7-6cd5-4d59-a505-a0268675d043> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/ff633ccf-80c1-4276-b9e2-7bf969b0d05b> ;
     dct:issued "2015"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram2' from the Ontologia de Doação de Órgão e Tecidos (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/pereira2015doacao-orgaos/new-diagrams/diagram2.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:08:32.121174502Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/pereira2015doacao-orgaos/metadata-png-o-diagram1.ttl
+++ b/models/pereira2015doacao-orgaos/metadata-png-o-diagram1.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/a032b424-2c43-4cd8-bbcf-469fea40ef0d> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/ff633ccf-80c1-4276-b9e2-7bf969b0d05b> ;
     dct:issued "2015"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram1' from the Ontologia de Doação de Órgão e Tecidos (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/pereira2015doacao-orgaos/original-diagrams/diagram1.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:08:33.667520978Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/pereira2015doacao-orgaos/metadata-png-o-diagram2.ttl
+++ b/models/pereira2015doacao-orgaos/metadata-png-o-diagram2.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/bb237183-27c2-472f-a8d3-d99fceff5bbc> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/ff633ccf-80c1-4276-b9e2-7bf969b0d05b> ;
     dct:issued "2015"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram2' from the Ontologia de Doação de Órgão e Tecidos (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/pereira2015doacao-orgaos/original-diagrams/diagram2.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:08:35.213282686Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/pereira2015doacao-orgaos/metadata-turtle.ttl
+++ b/models/pereira2015doacao-orgaos/metadata-turtle.ttl
@@ -7,11 +7,10 @@
 <https://w3id.org/ontouml-models/distribution/a26bccc2-0f0f-4e02-9044-7c84c52a0dc0/> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/ff633ccf-80c1-4276-b9e2-7bf969b0d05b> ;
     dct:issued "2015"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Turtle distribution of Ontologia de Doação de Órgão e Tecidos"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/pereira2015doacao-orgaos/ontology.ttl> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
     fdpo:metadataIssued "2023-04-14T18:08:36.717219926Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/pereira2015doacao-orgaos/metadata-vpp.ttl
+++ b/models/pereira2015doacao-orgaos/metadata-vpp.ttl
@@ -8,11 +8,10 @@
     dct:format <https://www.file-extension.info/format/vpp> ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/ff633ccf-80c1-4276-b9e2-7bf969b0d05b> ;
     dct:issued "2015"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Visual Paradigm distribution of Ontologia de Doação de Órgão e Tecidos"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/pereira2015doacao-orgaos/ontology.vpp> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/octet-stream> ;
     fdpo:metadataIssued "2023-04-14T18:08:38.685804091Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T00:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/pereira2015doacao-orgaos/metadata.ttl
+++ b/models/pereira2015doacao-orgaos/metadata.ttl
@@ -16,7 +16,6 @@
     dct:modified "2015"^^xsd:gYear;
     dcat:theme lcc:R;
     dct:language "pt-br";
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:contributor <https://dblp.org/pid/74/4999>,
                     <https://dblp.org/pid/63/9777>,
                     <https://dblp.org/pid/234/2383>,
@@ -29,7 +28,7 @@
     ocmv:ontologyType ocmv:Domain;
     ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/pereira2015doacao-orgaos"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T18:08:27.754080944Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .
 
 <https://w3id.org/ontouml-models/model/ff633ccf-80c1-4276-b9e2-7bf969b0d05b> dcat:distribution <https://w3id.org/ontouml-models/distribution/a26bccc2-0f0f-4e02-9044-7c84c52a0dc0/>,
                       <https://w3id.org/ontouml-models/distribution/5a69dd6a-ba39-4a5a-b64e-0647e21862b7/>,

--- a/models/pereira2020ontotrans/metadata-json.ttl
+++ b/models/pereira2020ontotrans/metadata-json.ttl
@@ -12,10 +12,9 @@
     dct:isPartOf <https://w3id.org/ontouml-models/model/0a01a029-1863-498e-aba5-6e9580f94dc5>;
     dct:issued "2020"^^xsd:gYear;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of OntoTrans"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/pereira2020ontotrans/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T18:08:41.692176531Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .

--- a/models/pereira2020ontotrans/metadata-png-n-diagram1.ttl
+++ b/models/pereira2020ontotrans/metadata-png-n-diagram1.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/b0681911-8fbc-469e-8285-752cca933862> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/0a01a029-1863-498e-aba5-6e9580f94dc5> ;
     dct:issued "2020"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram1' from the OntoTrans (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/pereira2020ontotrans/new-diagrams/diagram1.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:08:43.368565745Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/pereira2020ontotrans/metadata-png-o-diagram1.ttl
+++ b/models/pereira2020ontotrans/metadata-png-o-diagram1.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/27d53ec1-fd5b-45b1-afc8-5689d662d2a9> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/0a01a029-1863-498e-aba5-6e9580f94dc5> ;
     dct:issued "2020"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram1' from the OntoTrans (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/pereira2020ontotrans/original-diagrams/diagram1.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:08:44.917857234Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/pereira2020ontotrans/metadata-turtle.ttl
+++ b/models/pereira2020ontotrans/metadata-turtle.ttl
@@ -7,11 +7,10 @@
 <https://w3id.org/ontouml-models/distribution/d5a06614-857b-474b-b32b-5336aa4338bf/> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/0a01a029-1863-498e-aba5-6e9580f94dc5> ;
     dct:issued "2020"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Turtle distribution of OntoTrans"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/pereira2020ontotrans/ontology.ttl> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
     fdpo:metadataIssued "2023-04-14T18:08:46.46680544Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/pereira2020ontotrans/metadata-vpp.ttl
+++ b/models/pereira2020ontotrans/metadata-vpp.ttl
@@ -8,11 +8,10 @@
     dct:format <https://www.file-extension.info/format/vpp> ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/0a01a029-1863-498e-aba5-6e9580f94dc5> ;
     dct:issued "2020"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Visual Paradigm distribution of OntoTrans"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/pereira2020ontotrans/ontology.vpp> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/octet-stream> ;
     fdpo:metadataIssued "2023-04-14T18:08:48.006820906Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T00:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/pereira2020ontotrans/metadata.ttl
+++ b/models/pereira2020ontotrans/metadata.ttl
@@ -16,7 +16,6 @@
     dct:modified "2020"^^xsd:gYear;
     dcat:theme lcc:J;
     dct:language "en";
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:contributor <https://dblp.org/pid/247/3238>,
                     <https://dblp.org/pid/20/5813>,
                     <https://dblp.org/pid/b/FAraujoBaiao>,
@@ -30,7 +29,7 @@
     ocmv:ontologyType ocmv:Domain;
     ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/pereira2020ontotrans"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T18:08:40.480778512Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .
 
 <https://w3id.org/ontouml-models/model/0a01a029-1863-498e-aba5-6e9580f94dc5> dcat:distribution <https://w3id.org/ontouml-models/distribution/d5a06614-857b-474b-b32b-5336aa4338bf/>,
                       <https://w3id.org/ontouml-models/distribution/e4eb323d-5ebe-4ef5-a32a-06f6324d447e/>,

--- a/models/ppo-o2021/metadata-json.ttl
+++ b/models/ppo-o2021/metadata-json.ttl
@@ -12,10 +12,9 @@
     dct:isPartOf <https://w3id.org/ontouml-models/model/6c200266-ceb5-4cc6-8c8a-b01038687b72>;
     dct:issued "2021"^^xsd:gYear;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of PreProcessing Operators Ontology"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/ppo-o2021/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T18:09:32.895531806Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .

--- a/models/ppo-o2021/metadata-png-n-data-pre-processing-event.ttl
+++ b/models/ppo-o2021/metadata-png-n-data-pre-processing-event.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/8077ce1a-4700-4785-b1a2-7603915b15e5> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/6c200266-ceb5-4cc6-8c8a-b01038687b72> ;
     dct:issued "2021"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'data pre processing event' from the PreProcessing Operators Ontology (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/ppo-o2021/new-diagrams/data-pre-processing-event.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:09:34.391051772Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/ppo-o2021/metadata-png-n-data-pre-processing-operators.ttl
+++ b/models/ppo-o2021/metadata-png-n-data-pre-processing-operators.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/c03f14b4-7836-43bf-923c-d19cc61f4e28> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/6c200266-ceb5-4cc6-8c8a-b01038687b72> ;
     dct:issued "2021"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'data pre processing operators' from the PreProcessing Operators Ontology (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/ppo-o2021/new-diagrams/data-pre-processing-operators.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:09:35.91583096Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/ppo-o2021/metadata-png-n-dataset.ttl
+++ b/models/ppo-o2021/metadata-png-n-dataset.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/44ae6831-6fca-404e-adfb-059df1cc4d44> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/6c200266-ceb5-4cc6-8c8a-b01038687b72> ;
     dct:issued "2021"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'dataset' from the PreProcessing Operators Ontology (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/ppo-o2021/new-diagrams/dataset.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:09:37.403407357Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/ppo-o2021/metadata-png-n-provenance-information.ttl
+++ b/models/ppo-o2021/metadata-png-n-provenance-information.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/c213468d-f58e-4b82-8e6f-3dc33722c12d> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/6c200266-ceb5-4cc6-8c8a-b01038687b72> ;
     dct:issued "2021"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'provenance information' from the PreProcessing Operators Ontology (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/ppo-o2021/new-diagrams/provenance-information.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:09:39.081707795Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/ppo-o2021/metadata-png-o-data-pre-processing-event.ttl
+++ b/models/ppo-o2021/metadata-png-o-data-pre-processing-event.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/de410ae2-2ef9-4cdf-b5cb-a5771e1e71b3> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/6c200266-ceb5-4cc6-8c8a-b01038687b72> ;
     dct:issued "2021"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'data pre processing event' from the PreProcessing Operators Ontology (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/ppo-o2021/original-diagrams/data-pre-processing-event.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:09:40.59533932Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/ppo-o2021/metadata-png-o-data-pre-processing-operators.ttl
+++ b/models/ppo-o2021/metadata-png-o-data-pre-processing-operators.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/07882504-43e2-47e4-bf93-1f6db8f614a9> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/6c200266-ceb5-4cc6-8c8a-b01038687b72> ;
     dct:issued "2021"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'data pre processing operators' from the PreProcessing Operators Ontology (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/ppo-o2021/original-diagrams/data-pre-processing-operators.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:09:42.196650993Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/ppo-o2021/metadata-png-o-dataset.ttl
+++ b/models/ppo-o2021/metadata-png-o-dataset.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/50be4548-0060-4cab-a72f-518fd6fdb0e3> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/6c200266-ceb5-4cc6-8c8a-b01038687b72> ;
     dct:issued "2021"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'dataset' from the PreProcessing Operators Ontology (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/ppo-o2021/original-diagrams/dataset.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:09:44.233293591Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/ppo-o2021/metadata-png-o-provenance-information.ttl
+++ b/models/ppo-o2021/metadata-png-o-provenance-information.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/9b3d638c-a2ba-4103-8359-394b07b55018> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/6c200266-ceb5-4cc6-8c8a-b01038687b72> ;
     dct:issued "2021"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'provenance information' from the PreProcessing Operators Ontology (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/ppo-o2021/original-diagrams/provenance-information.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:09:46.344980546Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/ppo-o2021/metadata-turtle.ttl
+++ b/models/ppo-o2021/metadata-turtle.ttl
@@ -7,11 +7,10 @@
 <https://w3id.org/ontouml-models/distribution/df59c12e-bc63-4ed4-8e65-c71c923382da/> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/6c200266-ceb5-4cc6-8c8a-b01038687b72> ;
     dct:issued "2021"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Turtle distribution of PreProcessing Operators Ontology"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/ppo-o2021/ontology.ttl> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
     fdpo:metadataIssued "2023-04-14T18:09:47.926037495Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/ppo-o2021/metadata-vpp.ttl
+++ b/models/ppo-o2021/metadata-vpp.ttl
@@ -8,11 +8,10 @@
     dct:format <https://www.file-extension.info/format/vpp> ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/6c200266-ceb5-4cc6-8c8a-b01038687b72> ;
     dct:issued "2021"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Visual Paradigm distribution of PreProcessing Operators Ontology"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/ppo-o2021/ontology.vpp> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/octet-stream> ;
     fdpo:metadataIssued "2023-04-14T18:09:49.5376857Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T00:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/ppo-o2021/metadata.ttl
+++ b/models/ppo-o2021/metadata.ttl
@@ -18,7 +18,6 @@
     dcat:theme lcc:T;
     skos:editorialNote "According to the authors, \"the purpose of [PPO-O] is to identify and represent the concepts related to the preparation of \"cured\" raw data, that is, data significantly selected, more organized, easier to analyze and understand. The idea is to facilitate the generation of training and test data to be consumed by ML algorithms.\"";
     dct:language "en";
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:contributor <https://dblp.org/pid/293/7222>,
                     <https://dblp.org/pid/151/7984>,
                     <https://dblp.org/pid/43/7740>,
@@ -32,7 +31,7 @@
     ocmv:ontologyType ocmv:Domain;
     ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/ppo-o2021"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T18:09:31.704568786Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .
 
 <https://w3id.org/ontouml-models/model/6c200266-ceb5-4cc6-8c8a-b01038687b72> dcat:distribution <https://w3id.org/ontouml-models/distribution/df59c12e-bc63-4ed4-8e65-c71c923382da/>,
                       <https://w3id.org/ontouml-models/distribution/207a8ad9-0897-471d-b95a-9924fb8e9664/>,

--- a/models/public-expense-ontology2020/metadata-json.ttl
+++ b/models/public-expense-ontology2020/metadata-json.ttl
@@ -12,10 +12,9 @@
     dct:isPartOf <https://w3id.org/ontouml-models/model/0a044a49-bd7c-4429-8b83-68769b9037ee>;
     dct:issued "2020"^^xsd:gYear;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of Public Expense Ontology"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/public-expense-ontology2020/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T18:10:02.09922098Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .

--- a/models/public-expense-ontology2020/metadata-png-n-entidadegovernamental.ttl
+++ b/models/public-expense-ontology2020/metadata-png-n-entidadegovernamental.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/ad898467-eef6-4e79-8855-13d7a62d3dd2> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/0a044a49-bd7c-4429-8b83-68769b9037ee> ;
     dct:issued "2020"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'entidadegovernamental' from the Public Expense Ontology (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/public-expense-ontology2020/new-diagrams/entidadegovernamental.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:10:03.771017321Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/public-expense-ontology2020/metadata-png-n-execucãodedespesa.ttl
+++ b/models/public-expense-ontology2020/metadata-png-n-execucãodedespesa.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/fd6e9ce5-767a-495f-8c60-fa25d1a86020> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/0a044a49-bd7c-4429-8b83-68769b9037ee> ;
     dct:issued "2020"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'execucãodedespesa' from the Public Expense Ontology (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/public-expense-ontology2020/new-diagrams/execucãodedespesa.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:10:05.304034288Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/public-expense-ontology2020/metadata-png-n-licitacaoecontrato.ttl
+++ b/models/public-expense-ontology2020/metadata-png-n-licitacaoecontrato.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/1962b854-8e69-485d-ab8d-098a65a4a939> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/0a044a49-bd7c-4429-8b83-68769b9037ee> ;
     dct:issued "2020"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'licitacaoecontrato' from the Public Expense Ontology (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/public-expense-ontology2020/new-diagrams/licitacaoecontrato.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:10:06.83818335Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/public-expense-ontology2020/metadata-png-o-diagram1.ttl
+++ b/models/public-expense-ontology2020/metadata-png-o-diagram1.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/fbab8498-3e03-4695-9e9a-078a73e22284> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/0a044a49-bd7c-4429-8b83-68769b9037ee> ;
     dct:issued "2020"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram1' from the Public Expense Ontology (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/public-expense-ontology2020/original-diagrams/diagram1.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:10:08.379787004Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/public-expense-ontology2020/metadata-png-o-diagram2.ttl
+++ b/models/public-expense-ontology2020/metadata-png-o-diagram2.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/64026512-94e6-47d6-a8e0-e10d18ab3da0> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/0a044a49-bd7c-4429-8b83-68769b9037ee> ;
     dct:issued "2020"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram2' from the Public Expense Ontology (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/public-expense-ontology2020/original-diagrams/diagram2.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:10:09.91517238Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/public-expense-ontology2020/metadata-png-o-diagram3.ttl
+++ b/models/public-expense-ontology2020/metadata-png-o-diagram3.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/e1d666ab-076d-48cf-96d0-e492d747e783> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/0a044a49-bd7c-4429-8b83-68769b9037ee> ;
     dct:issued "2020"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram3' from the Public Expense Ontology (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/public-expense-ontology2020/original-diagrams/diagram3.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:10:11.43825079Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/public-expense-ontology2020/metadata-turtle.ttl
+++ b/models/public-expense-ontology2020/metadata-turtle.ttl
@@ -7,11 +7,10 @@
 <https://w3id.org/ontouml-models/distribution/5eeec4ed-31ef-4b42-b206-9d13675eddb5/> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/0a044a49-bd7c-4429-8b83-68769b9037ee> ;
     dct:issued "2020"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Turtle distribution of Public Expense Ontology"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/public-expense-ontology2020/ontology.ttl> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
     fdpo:metadataIssued "2023-04-14T18:10:12.967672109Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/public-expense-ontology2020/metadata-vpp.ttl
+++ b/models/public-expense-ontology2020/metadata-vpp.ttl
@@ -8,11 +8,10 @@
     dct:format <https://www.file-extension.info/format/vpp> ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/0a044a49-bd7c-4429-8b83-68769b9037ee> ;
     dct:issued "2020"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Visual Paradigm distribution of Public Expense Ontology"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/public-expense-ontology2020/ontology.vpp> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/octet-stream> ;
     fdpo:metadataIssued "2023-04-14T18:10:14.588617357Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T00:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/public-expense-ontology2020/metadata.ttl
+++ b/models/public-expense-ontology2020/metadata.ttl
@@ -16,7 +16,6 @@
     dcat:theme lcc:H;
     skos:editorialNote "The ontology was documented based on the author's publication.";
     dct:language "pt-br";
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:contributor <https://dblp.org/pid/150/9241>,
                     <https://dblp.org/pid/37/528>,
                     <https://dblp.org/pid/54/10278>;
@@ -29,7 +28,7 @@
     ocmv:ontologyType ocmv:Domain;
     ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/public-expense-ontology2020"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T18:10:00.840108165Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .
 
 <https://w3id.org/ontouml-models/model/0a044a49-bd7c-4429-8b83-68769b9037ee> dcat:distribution <https://w3id.org/ontouml-models/distribution/5eeec4ed-31ef-4b42-b206-9d13675eddb5/>,
                       <https://w3id.org/ontouml-models/distribution/c57044ac-f96f-41d7-b01f-5cfc1409d18d/>,

--- a/models/ramos2021bias/metadata-json.ttl
+++ b/models/ramos2021bias/metadata-json.ttl
@@ -12,10 +12,9 @@
     dct:isPartOf <https://w3id.org/ontouml-models/model/e3e0f697-53e8-45dc-8d32-bf282b5434cb>;
     dct:issued "2021"^^xsd:gYear;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of Decision Making Ontology Extended with Intuitive Decision Making"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/ramos2021bias/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T18:11:21.209818584Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .

--- a/models/ramos2021bias/metadata-png-o-cognitive-bias.ttl
+++ b/models/ramos2021bias/metadata-png-o-cognitive-bias.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/f7f8aee3-3360-42d3-8498-24b1916bf761> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/e3e0f697-53e8-45dc-8d32-bf282b5434cb> ;
     dct:issued "2021"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'cognitive bias' from the Decision Making Ontology Extended with Intuitive Decision Making (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/ramos2021bias/original-diagrams/cognitive-bias.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:11:22.791337239Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/ramos2021bias/metadata-png-o-decision-making.ttl
+++ b/models/ramos2021bias/metadata-png-o-decision-making.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/93d3202d-2430-4d7d-935f-636eee74d614> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/e3e0f697-53e8-45dc-8d32-bf282b5434cb> ;
     dct:issued "2021"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'decision making' from the Decision Making Ontology Extended with Intuitive Decision Making (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/ramos2021bias/original-diagrams/decision-making.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:11:24.327205376Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/ramos2021bias/metadata-turtle.ttl
+++ b/models/ramos2021bias/metadata-turtle.ttl
@@ -7,11 +7,10 @@
 <https://w3id.org/ontouml-models/distribution/d17cb65c-4e65-4f05-9f99-87e6bc2339c6/> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/e3e0f697-53e8-45dc-8d32-bf282b5434cb> ;
     dct:issued "2021"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Turtle distribution of Decision Making Ontology Extended with Intuitive Decision Making"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/ramos2021bias/ontology.ttl> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
     fdpo:metadataIssued "2023-04-14T18:11:25.872733476Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/ramos2021bias/metadata-vpp.ttl
+++ b/models/ramos2021bias/metadata-vpp.ttl
@@ -8,11 +8,10 @@
     dct:format <https://www.file-extension.info/format/vpp> ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/e3e0f697-53e8-45dc-8d32-bf282b5434cb> ;
     dct:issued "2021"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Visual Paradigm distribution of Decision Making Ontology Extended with Intuitive Decision Making"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/ramos2021bias/ontology.vpp> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/octet-stream> ;
     fdpo:metadataIssued "2023-04-14T18:11:27.512458561Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T00:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/ramos2021bias/metadata.ttl
+++ b/models/ramos2021bias/metadata.ttl
@@ -19,7 +19,6 @@
 The ontology contains ternary relations that are ignored by the current serialization.
 """;
     dct:language "en";
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:contributor <https://dblp.org/pid/30/11293>,
                     <https://dblp.org/pid/78/4279>,
                     <https://dblp.org/pid/b/FAraujoBaiao>,
@@ -35,7 +34,7 @@ The ontology contains ternary relations that are ignored by the current serializ
     ocmv:ontologyType ocmv:Core;
     ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/ramos2021bias"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T18:11:19.922357852Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .
 
 <https://w3id.org/ontouml-models/model/e3e0f697-53e8-45dc-8d32-bf282b5434cb> dcat:distribution <https://w3id.org/ontouml-models/distribution/d17cb65c-4e65-4f05-9f99-87e6bc2339c6/>,
                       <https://w3id.org/ontouml-models/distribution/7e275e7a-0431-473f-8b67-ba5f2d2f3cc1/>,

--- a/models/repa2021public-administration/metadata-json.ttl
+++ b/models/repa2021public-administration/metadata-json.ttl
@@ -12,10 +12,9 @@
     dct:isPartOf <https://w3id.org/ontouml-models/model/54af0ca8-e341-4457-b0dc-2594425a6489>;
     dct:issued "2015"^^xsd:gYear;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of Public Administration Ontology Model"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/repa2021public-administration/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T18:11:49.285076289Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .

--- a/models/repa2021public-administration/metadata-png-n-diagram1.ttl
+++ b/models/repa2021public-administration/metadata-png-n-diagram1.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/c3388ee5-20ac-450a-9487-e7f505bb991f> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/54af0ca8-e341-4457-b0dc-2594425a6489> ;
     dct:issued "2015"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram1' from the Public Administration Ontology Model (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/repa2021public-administration/new-diagrams/diagram1.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:11:50.786212815Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/repa2021public-administration/metadata-png-o-diagram1.ttl
+++ b/models/repa2021public-administration/metadata-png-o-diagram1.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/a964add5-9dec-4d83-b160-c6433f730292> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/54af0ca8-e341-4457-b0dc-2594425a6489> ;
     dct:issued "2015"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram1' from the Public Administration Ontology Model (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/repa2021public-administration/original-diagrams/diagram1.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:11:52.428215293Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/repa2021public-administration/metadata-turtle.ttl
+++ b/models/repa2021public-administration/metadata-turtle.ttl
@@ -7,11 +7,10 @@
 <https://w3id.org/ontouml-models/distribution/44c92bf9-fa31-4f0d-ab28-a476b9c45e2a/> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/54af0ca8-e341-4457-b0dc-2594425a6489> ;
     dct:issued "2015"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Turtle distribution of Public Administration Ontology Model"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/repa2021public-administration/ontology.ttl> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
     fdpo:metadataIssued "2023-04-14T18:11:53.959505498Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/repa2021public-administration/metadata-vpp.ttl
+++ b/models/repa2021public-administration/metadata-vpp.ttl
@@ -8,11 +8,10 @@
     dct:format <https://www.file-extension.info/format/vpp> ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/54af0ca8-e341-4457-b0dc-2594425a6489> ;
     dct:issued "2015"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Visual Paradigm distribution of Public Administration Ontology Model"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/repa2021public-administration/ontology.vpp> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/octet-stream> ;
     fdpo:metadataIssued "2023-04-14T18:11:55.540097019Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T00:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/repa2021public-administration/metadata.ttl
+++ b/models/repa2021public-administration/metadata.ttl
@@ -19,7 +19,6 @@
 The author makes use of a «viewpoint» stereotype, which an extension of OntoUML proposed in the following work: https://doi.org/10.1007/978-1-4614-7540-8_34
 """;
     dct:language "en";
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:contributor <https://dblp.org/pid/08/5518>;
     dcat:keyword "e-government"@en,
                  "public administration"@en;
@@ -31,7 +30,7 @@ The author makes use of a «viewpoint» stereotype, which an extension of OntoUM
     ocmv:ontologyType ocmv:Domain;
     ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/repa2021public-administration"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T18:11:48.05622345Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .
 
 <https://w3id.org/ontouml-models/model/54af0ca8-e341-4457-b0dc-2594425a6489> dcat:distribution <https://w3id.org/ontouml-models/distribution/44c92bf9-fa31-4f0d-ab28-a476b9c45e2a/>,
                       <https://w3id.org/ontouml-models/distribution/e6ccc1da-6edf-43a9-9dc1-5353b40016cc/>,

--- a/models/richetti2019tdecision/metadata-json.ttl
+++ b/models/richetti2019tdecision/metadata-json.ttl
@@ -12,10 +12,9 @@
     dct:isPartOf <https://w3id.org/ontouml-models/model/a0ce75d5-54d0-4949-b9d0-444bad20573c>;
     dct:issued "2019"^^xsd:gYear;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of Decision Making in knowledge intensive process in Value Ascription and Goal processing"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/richetti2019tdecision/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T18:11:58.832970123Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .

--- a/models/richetti2019tdecision/metadata-png-n-goaltypes.ttl
+++ b/models/richetti2019tdecision/metadata-png-n-goaltypes.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/43ff3ed7-640e-48ca-b01a-00148f0695ce> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/a0ce75d5-54d0-4949-b9d0-444bad20573c> ;
     dct:issued "2019"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'goaltypes' from the Decision Making in knowledge intensive process in Value Ascription and Goal processing (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/richetti2019tdecision/new-diagrams/goaltypes.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:12:00.351175383Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/richetti2019tdecision/metadata-png-n-value-ascription-to-knowledge-intensive-activities.ttl
+++ b/models/richetti2019tdecision/metadata-png-n-value-ascription-to-knowledge-intensive-activities.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/e8958218-3286-4302-94aa-330025094e69> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/a0ce75d5-54d0-4949-b9d0-444bad20573c> ;
     dct:issued "2019"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'value ascription to knowledge intensive activities' from the Decision Making in knowledge intensive process in Value Ascription and Goal processing (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/richetti2019tdecision/new-diagrams/value-ascription-to-knowledge-intensive-activities.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:12:01.93022894Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/richetti2019tdecision/metadata-png-o-diagram1.ttl
+++ b/models/richetti2019tdecision/metadata-png-o-diagram1.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/ec125ce0-30d7-4434-a61a-b04504e6198b> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/a0ce75d5-54d0-4949-b9d0-444bad20573c> ;
     dct:issued "2019"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram1' from the Decision Making in knowledge intensive process in Value Ascription and Goal processing (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/richetti2019tdecision/original-diagrams/diagram1.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:12:03.770592109Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/richetti2019tdecision/metadata-png-o-diagram2.ttl
+++ b/models/richetti2019tdecision/metadata-png-o-diagram2.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/b087b1b9-536f-4fb6-99ce-78f5b04d6912> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/a0ce75d5-54d0-4949-b9d0-444bad20573c> ;
     dct:issued "2019"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram2' from the Decision Making in knowledge intensive process in Value Ascription and Goal processing (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/richetti2019tdecision/original-diagrams/diagram2.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:12:05.328110025Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/richetti2019tdecision/metadata-turtle.ttl
+++ b/models/richetti2019tdecision/metadata-turtle.ttl
@@ -7,11 +7,10 @@
 <https://w3id.org/ontouml-models/distribution/c1a8a442-85b5-4375-80c9-77e6cbf8ff18/> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/a0ce75d5-54d0-4949-b9d0-444bad20573c> ;
     dct:issued "2019"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Turtle distribution of Decision Making in knowledge intensive process in Value Ascription and Goal processing"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/richetti2019tdecision/ontology.ttl> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
     fdpo:metadataIssued "2023-04-14T18:12:06.865654861Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/richetti2019tdecision/metadata-vpp.ttl
+++ b/models/richetti2019tdecision/metadata-vpp.ttl
@@ -8,11 +8,10 @@
     dct:format <https://www.file-extension.info/format/vpp> ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/a0ce75d5-54d0-4949-b9d0-444bad20573c> ;
     dct:issued "2019"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Visual Paradigm distribution of Decision Making in knowledge intensive process in Value Ascription and Goal processing"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/richetti2019tdecision/ontology.vpp> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/octet-stream> ;
     fdpo:metadataIssued "2023-04-14T18:12:08.391454795Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T00:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/richetti2019tdecision/metadata.ttl
+++ b/models/richetti2019tdecision/metadata.ttl
@@ -16,7 +16,6 @@
     dcat:theme lcc:H;
     skos:editorialNote "The ontology was documented based on the author's paper. Also, some special changes were needed to adapt to VP structure on Packages";
     dct:language "en";
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:contributor <https://dblp.org/pid/150/5453>,
                     <https://dblp.org/pid/b/FAraujoBaiao>,
                     <https://dblp.org/pid/78/4279>;
@@ -28,7 +27,7 @@
     ocmv:ontologyType ocmv:Domain;
     ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/richetti2019tdecision"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T18:11:57.611992711Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .
 
 <https://w3id.org/ontouml-models/model/a0ce75d5-54d0-4949-b9d0-444bad20573c> dcat:distribution <https://w3id.org/ontouml-models/distribution/c1a8a442-85b5-4375-80c9-77e6cbf8ff18/>,
                       <https://w3id.org/ontouml-models/distribution/60647cbd-4094-4d38-b893-a4a9719ff13a/>,

--- a/models/rodrigues2017urinary-profiles/metadata-json.ttl
+++ b/models/rodrigues2017urinary-profiles/metadata-json.ttl
@@ -12,10 +12,9 @@
     dct:isPartOf <https://w3id.org/ontouml-models/model/ab12ac77-6476-4b22-9c2b-bb70a9c6f26d>;
     dct:issued "2015"^^xsd:gYear;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of Ontological Model for Urinary Profiles and Events"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/rodrigues2017urinary-profiles/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T18:12:11.534182914Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .

--- a/models/rodrigues2017urinary-profiles/metadata-png-n-extended-urinary-profile.ttl
+++ b/models/rodrigues2017urinary-profiles/metadata-png-n-extended-urinary-profile.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/baab9559-f4bd-4079-b1f9-562a900ead30> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/ab12ac77-6476-4b22-9c2b-bb70a9c6f26d> ;
     dct:issued "2015"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'extended urinary profile' from the Ontological Model for Urinary Profiles and Events (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/rodrigues2017urinary-profiles/new-diagrams/extended-urinary-profile.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:12:13.044635553Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/rodrigues2017urinary-profiles/metadata-png-n-immune-response-event.ttl
+++ b/models/rodrigues2017urinary-profiles/metadata-png-n-immune-response-event.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/f590d05f-2d4b-462a-a0c1-bacb137ab6b5> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/ab12ac77-6476-4b22-9c2b-bb70a9c6f26d> ;
     dct:issued "2015"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'immune response event' from the Ontological Model for Urinary Profiles and Events (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/rodrigues2017urinary-profiles/new-diagrams/immune-response-event.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:12:14.607477937Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/rodrigues2017urinary-profiles/metadata-png-n-nephritic-profile.ttl
+++ b/models/rodrigues2017urinary-profiles/metadata-png-n-nephritic-profile.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/61b28ee5-cd61-46cf-916c-5e3ad48b7860> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/ab12ac77-6476-4b22-9c2b-bb70a9c6f26d> ;
     dct:issued "2015"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'nephritic profile' from the Ontological Model for Urinary Profiles and Events (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/rodrigues2017urinary-profiles/new-diagrams/nephritic-profile.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:12:16.159225688Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/rodrigues2017urinary-profiles/metadata-png-n-spermatozoa-contamination-profile.ttl
+++ b/models/rodrigues2017urinary-profiles/metadata-png-n-spermatozoa-contamination-profile.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/cf93ad2d-64e6-43d0-87ee-8c38b58dca6b> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/ab12ac77-6476-4b22-9c2b-bb70a9c6f26d> ;
     dct:issued "2015"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'spermatozoa contamination profile' from the Ontological Model for Urinary Profiles and Events (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/rodrigues2017urinary-profiles/new-diagrams/spermatozoa-contamination-profile.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:12:17.769494729Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/rodrigues2017urinary-profiles/metadata-png-n-taxonomy-of-urinary-events.ttl
+++ b/models/rodrigues2017urinary-profiles/metadata-png-n-taxonomy-of-urinary-events.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/b196c56f-90da-4bd1-ab5d-014913b620b9> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/ab12ac77-6476-4b22-9c2b-bb70a9c6f26d> ;
     dct:issued "2015"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'taxonomy of urinary events' from the Ontological Model for Urinary Profiles and Events (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/rodrigues2017urinary-profiles/new-diagrams/taxonomy-of-urinary-events.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:12:19.291720975Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/rodrigues2017urinary-profiles/metadata-png-n-urinary-event-model.ttl
+++ b/models/rodrigues2017urinary-profiles/metadata-png-n-urinary-event-model.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/c860803f-b094-41a1-b0c4-5d70a5baa964> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/ab12ac77-6476-4b22-9c2b-bb70a9c6f26d> ;
     dct:issued "2015"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'urinary event model' from the Ontological Model for Urinary Profiles and Events (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/rodrigues2017urinary-profiles/new-diagrams/urinary-event-model.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:12:20.82474901Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/rodrigues2017urinary-profiles/metadata-png-n-urinary-profile.ttl
+++ b/models/rodrigues2017urinary-profiles/metadata-png-n-urinary-profile.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/0b40f3e3-e4fa-46c8-a18d-acc711e607f2> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/ab12ac77-6476-4b22-9c2b-bb70a9c6f26d> ;
     dct:issued "2015"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'urinary profile' from the Ontological Model for Urinary Profiles and Events (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/rodrigues2017urinary-profiles/new-diagrams/urinary-profile.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:12:22.359544132Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/rodrigues2017urinary-profiles/metadata-png-o-extended-urinary-profile.ttl
+++ b/models/rodrigues2017urinary-profiles/metadata-png-o-extended-urinary-profile.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/d87d83c7-ed5f-439c-b14d-c5d752dbe627> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/ab12ac77-6476-4b22-9c2b-bb70a9c6f26d> ;
     dct:issued "2015"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'extended urinary profile' from the Ontological Model for Urinary Profiles and Events (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/rodrigues2017urinary-profiles/original-diagrams/extended-urinary-profile.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:12:23.900435191Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/rodrigues2017urinary-profiles/metadata-png-o-immune-response-event.ttl
+++ b/models/rodrigues2017urinary-profiles/metadata-png-o-immune-response-event.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/3e82a0e8-bdf2-4bc7-a701-a8509680fd49> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/ab12ac77-6476-4b22-9c2b-bb70a9c6f26d> ;
     dct:issued "2015"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'immune response event' from the Ontological Model for Urinary Profiles and Events (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/rodrigues2017urinary-profiles/original-diagrams/immune-response-event.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:12:25.403937357Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/rodrigues2017urinary-profiles/metadata-png-o-nephritic-profile.ttl
+++ b/models/rodrigues2017urinary-profiles/metadata-png-o-nephritic-profile.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/1b05a71a-d7fe-483e-a8b1-24d7148fc55a> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/ab12ac77-6476-4b22-9c2b-bb70a9c6f26d> ;
     dct:issued "2015"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'nephritic profile' from the Ontological Model for Urinary Profiles and Events (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/rodrigues2017urinary-profiles/original-diagrams/nephritic-profile.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:12:26.936333079Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/rodrigues2017urinary-profiles/metadata-png-o-spermatozoa-contamination-profile.ttl
+++ b/models/rodrigues2017urinary-profiles/metadata-png-o-spermatozoa-contamination-profile.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/d3fe2608-3dac-40cb-8e92-aef349b38a59> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/ab12ac77-6476-4b22-9c2b-bb70a9c6f26d> ;
     dct:issued "2015"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'spermatozoa contamination profile' from the Ontological Model for Urinary Profiles and Events (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/rodrigues2017urinary-profiles/original-diagrams/spermatozoa-contamination-profile.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:12:28.617054711Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/rodrigues2017urinary-profiles/metadata-png-o-taxonomy-of-urinary-events.ttl
+++ b/models/rodrigues2017urinary-profiles/metadata-png-o-taxonomy-of-urinary-events.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/94a2ac5f-00de-4178-bf60-fa86d1bf75e3> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/ab12ac77-6476-4b22-9c2b-bb70a9c6f26d> ;
     dct:issued "2015"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'taxonomy of urinary events' from the Ontological Model for Urinary Profiles and Events (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/rodrigues2017urinary-profiles/original-diagrams/taxonomy-of-urinary-events.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:12:30.184148268Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/rodrigues2017urinary-profiles/metadata-png-o-urinary-event-model.ttl
+++ b/models/rodrigues2017urinary-profiles/metadata-png-o-urinary-event-model.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/c3c704f8-2a32-4ccb-a642-10789926e4e6> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/ab12ac77-6476-4b22-9c2b-bb70a9c6f26d> ;
     dct:issued "2015"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'urinary event model' from the Ontological Model for Urinary Profiles and Events (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/rodrigues2017urinary-profiles/original-diagrams/urinary-event-model.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:12:31.811700601Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/rodrigues2017urinary-profiles/metadata-png-o-urinary-profile.ttl
+++ b/models/rodrigues2017urinary-profiles/metadata-png-o-urinary-profile.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/4c14360c-0319-4852-9ace-fc625f408268> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/ab12ac77-6476-4b22-9c2b-bb70a9c6f26d> ;
     dct:issued "2015"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'urinary profile' from the Ontological Model for Urinary Profiles and Events (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/rodrigues2017urinary-profiles/original-diagrams/urinary-profile.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:12:33.535006422Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/rodrigues2017urinary-profiles/metadata-turtle.ttl
+++ b/models/rodrigues2017urinary-profiles/metadata-turtle.ttl
@@ -7,11 +7,10 @@
 <https://w3id.org/ontouml-models/distribution/62fd42c9-77be-4991-809f-e91e6864bf22/> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/ab12ac77-6476-4b22-9c2b-bb70a9c6f26d> ;
     dct:issued "2015"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Turtle distribution of Ontological Model for Urinary Profiles and Events"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/rodrigues2017urinary-profiles/ontology.ttl> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
     fdpo:metadataIssued "2023-04-14T18:12:35.109135636Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/rodrigues2017urinary-profiles/metadata-vpp.ttl
+++ b/models/rodrigues2017urinary-profiles/metadata-vpp.ttl
@@ -8,11 +8,10 @@
     dct:format <https://www.file-extension.info/format/vpp> ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/ab12ac77-6476-4b22-9c2b-bb70a9c6f26d> ;
     dct:issued "2015"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Visual Paradigm distribution of Ontological Model for Urinary Profiles and Events"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/rodrigues2017urinary-profiles/ontology.vpp> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/octet-stream> ;
     fdpo:metadataIssued "2023-04-14T18:12:36.657120939Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T00:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/rodrigues2017urinary-profiles/metadata.ttl
+++ b/models/rodrigues2017urinary-profiles/metadata.ttl
@@ -17,7 +17,6 @@
     dcat:theme lcc:R;
     skos:editorialNote "Comparing the diagrams from the original 2015 paper and from the \"extended\" 2017 version, precisely \"Nephritic profile\", there is one missing \"is-a\" between \"Nephritic-Defining Albumin\" and \"Albumin\". I considered that it was just a lost, so I kept it as in the original paper (since they were supposed to change the layout only). It was not possible to identify what the \"Added\" keyword in \"Immune Response Event\" is.";
     dct:language "en";
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:contributor <https://dblp.org/pid/151/1055>,
                     <https://dblp.org/pid/151/1107>,
                     <https://dblp.org/pid/a/MaraAbel>,
@@ -34,7 +33,7 @@
     ocmv:ontologyType ocmv:Domain;
     ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/rodrigues2017urinary-profiles"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T18:12:10.290196298Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .
 
 <https://w3id.org/ontouml-models/model/ab12ac77-6476-4b22-9c2b-bb70a9c6f26d> dcat:distribution <https://w3id.org/ontouml-models/distribution/62fd42c9-77be-4991-809f-e91e6864bf22/>,
                       <https://w3id.org/ontouml-models/distribution/fea6bb77-64c0-4d1c-9c6e-ded255d01916/>,

--- a/models/santos2020valuenetworks/metadata-json.ttl
+++ b/models/santos2020valuenetworks/metadata-json.ttl
@@ -12,10 +12,9 @@
     dct:isPartOf <https://w3id.org/ontouml-models/model/87dea242-75d9-4b89-99f3-6f52c0855f3a>;
     dct:issued "2020"^^xsd:gYear;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of Ontology for Value Networks with Corporate Responsibility"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/santos2020valuenetworks/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T18:14:43.235008058Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .

--- a/models/santos2020valuenetworks/metadata-png-n-model.ttl
+++ b/models/santos2020valuenetworks/metadata-png-n-model.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/417b647f-be23-4c7a-a8c0-25b2fd18e440> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/87dea242-75d9-4b89-99f3-6f52c0855f3a> ;
     dct:issued "2020"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'model' from the Ontology for Value Networks with Corporate Responsibility (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/santos2020valuenetworks/new-diagrams/model.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:14:44.809242988Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/santos2020valuenetworks/metadata-png-o-orsc.ttl
+++ b/models/santos2020valuenetworks/metadata-png-o-orsc.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/02ddc4f5-b2ce-45a0-baa1-1234aa078711> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/87dea242-75d9-4b89-99f3-6f52c0855f3a> ;
     dct:issued "2020"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'orsc' from the Ontology for Value Networks with Corporate Responsibility (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/santos2020valuenetworks/original-diagrams/orsc.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:14:46.324823588Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/santos2020valuenetworks/metadata-turtle.ttl
+++ b/models/santos2020valuenetworks/metadata-turtle.ttl
@@ -7,11 +7,10 @@
 <https://w3id.org/ontouml-models/distribution/6eb5fef7-837f-49ef-8c8f-8d7a7ccc174f/> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/87dea242-75d9-4b89-99f3-6f52c0855f3a> ;
     dct:issued "2020"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Turtle distribution of Ontology for Value Networks with Corporate Responsibility"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/santos2020valuenetworks/ontology.ttl> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
     fdpo:metadataIssued "2023-04-14T18:14:47.948717151Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/santos2020valuenetworks/metadata-vpp.ttl
+++ b/models/santos2020valuenetworks/metadata-vpp.ttl
@@ -8,11 +8,10 @@
     dct:format <https://www.file-extension.info/format/vpp> ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/87dea242-75d9-4b89-99f3-6f52c0855f3a> ;
     dct:issued "2020"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Visual Paradigm distribution of Ontology for Value Networks with Corporate Responsibility"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/santos2020valuenetworks/ontology.vpp> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/octet-stream> ;
     fdpo:metadataIssued "2023-04-14T18:14:49.53590074Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T00:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/santos2020valuenetworks/metadata.ttl
+++ b/models/santos2020valuenetworks/metadata.ttl
@@ -16,7 +16,6 @@
     dcat:theme lcc:H;
     skos:editorialNote "The author does not explicitly give a name to the ontology. In the original work, she refers to it by \"Ontologia para Modelagem de Redes de Valor com Responsabilidade Corporativa\", which I translated here to \"Ontology for Value Networks with Corporate Responsibility\". The diagram name was given by the author.";
     dct:language "en";
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:contributor <https://dblp.org/pid/253/7660>;
     dcat:keyword "value networks"@en,
                  "corporate responsibility"@en;
@@ -27,7 +26,7 @@
     ocmv:ontologyType ocmv:Domain;
     ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/santos2020valuenetworks"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T18:14:41.999159589Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .
 
 <https://w3id.org/ontouml-models/model/87dea242-75d9-4b89-99f3-6f52c0855f3a> dcat:distribution <https://w3id.org/ontouml-models/distribution/6eb5fef7-837f-49ef-8c8f-8d7a7ccc174f/>,
                       <https://w3id.org/ontouml-models/distribution/e76e2bc1-8044-42e9-a8c7-9734069bff0e/>,

--- a/models/sikora2021online-education/metadata-json.ttl
+++ b/models/sikora2021online-education/metadata-json.ttl
@@ -12,10 +12,9 @@
     dct:isPartOf <https://w3id.org/ontouml-models/model/c3b6f81b-7d10-4e11-bdf2-4e291d0f8f70>;
     dct:issued "2021"^^xsd:gYear;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of Online Education Ontology"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/sikora2021online-education/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T18:14:52.697875961Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .

--- a/models/sikora2021online-education/metadata-png-n-diagram1.ttl
+++ b/models/sikora2021online-education/metadata-png-n-diagram1.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/857e2eed-6ea4-44f7-80cd-51c83681afb8> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/c3b6f81b-7d10-4e11-bdf2-4e291d0f8f70> ;
     dct:issued "2021"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram1' from the Online Education Ontology (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/sikora2021online-education/new-diagrams/diagram1.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:14:54.404240618Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/sikora2021online-education/metadata-png-n-diagram10.ttl
+++ b/models/sikora2021online-education/metadata-png-n-diagram10.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/0be12cea-f13d-4b2b-93d4-e6b99a19b38e> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/c3b6f81b-7d10-4e11-bdf2-4e291d0f8f70> ;
     dct:issued "2021"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram10' from the Online Education Ontology (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/sikora2021online-education/new-diagrams/diagram10.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:14:55.944268398Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/sikora2021online-education/metadata-png-n-diagram11.ttl
+++ b/models/sikora2021online-education/metadata-png-n-diagram11.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/48cb0903-3b0c-49d4-a142-f8d8f16a9b4f> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/c3b6f81b-7d10-4e11-bdf2-4e291d0f8f70> ;
     dct:issued "2021"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram11' from the Online Education Ontology (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/sikora2021online-education/new-diagrams/diagram11.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:14:57.472283458Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/sikora2021online-education/metadata-png-n-diagram12.ttl
+++ b/models/sikora2021online-education/metadata-png-n-diagram12.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/49d69d4f-dd17-4ba6-9272-b219a3dd2479> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/c3b6f81b-7d10-4e11-bdf2-4e291d0f8f70> ;
     dct:issued "2021"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram12' from the Online Education Ontology (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/sikora2021online-education/new-diagrams/diagram12.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:14:59.036680679Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/sikora2021online-education/metadata-png-n-diagram2.ttl
+++ b/models/sikora2021online-education/metadata-png-n-diagram2.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/6402fde4-a02e-4df7-aac5-6a2b733dcd9c> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/c3b6f81b-7d10-4e11-bdf2-4e291d0f8f70> ;
     dct:issued "2021"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram2' from the Online Education Ontology (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/sikora2021online-education/new-diagrams/diagram2.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:15:00.623003769Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/sikora2021online-education/metadata-png-n-diagram3.ttl
+++ b/models/sikora2021online-education/metadata-png-n-diagram3.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/64dc5702-8c25-43ad-972a-b4588b120c7c> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/c3b6f81b-7d10-4e11-bdf2-4e291d0f8f70> ;
     dct:issued "2021"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram3' from the Online Education Ontology (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/sikora2021online-education/new-diagrams/diagram3.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:15:02.18369861Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/sikora2021online-education/metadata-png-n-diagram4.ttl
+++ b/models/sikora2021online-education/metadata-png-n-diagram4.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/756b0027-3dd0-4f3f-ab46-1d30f74bfb73> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/c3b6f81b-7d10-4e11-bdf2-4e291d0f8f70> ;
     dct:issued "2021"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram4' from the Online Education Ontology (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/sikora2021online-education/new-diagrams/diagram4.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:15:03.734407097Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/sikora2021online-education/metadata-png-n-diagram5.ttl
+++ b/models/sikora2021online-education/metadata-png-n-diagram5.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/74ce77fe-4c69-474d-bc5f-2fb4493c51fe> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/c3b6f81b-7d10-4e11-bdf2-4e291d0f8f70> ;
     dct:issued "2021"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram5' from the Online Education Ontology (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/sikora2021online-education/new-diagrams/diagram5.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:15:05.265493745Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/sikora2021online-education/metadata-png-n-diagram6.ttl
+++ b/models/sikora2021online-education/metadata-png-n-diagram6.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/6ab29812-fa94-457b-b6e9-61bd79dd62a0> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/c3b6f81b-7d10-4e11-bdf2-4e291d0f8f70> ;
     dct:issued "2021"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram6' from the Online Education Ontology (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/sikora2021online-education/new-diagrams/diagram6.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:15:06.865766061Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/sikora2021online-education/metadata-png-n-diagram7.ttl
+++ b/models/sikora2021online-education/metadata-png-n-diagram7.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/8ebcfcb4-eaf2-474e-bc8f-9b954a31e7af> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/c3b6f81b-7d10-4e11-bdf2-4e291d0f8f70> ;
     dct:issued "2021"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram7' from the Online Education Ontology (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/sikora2021online-education/new-diagrams/diagram7.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:15:08.466122709Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/sikora2021online-education/metadata-png-n-diagram8.ttl
+++ b/models/sikora2021online-education/metadata-png-n-diagram8.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/dec761fb-ff58-46cf-aa61-74464a11e2cc> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/c3b6f81b-7d10-4e11-bdf2-4e291d0f8f70> ;
     dct:issued "2021"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram8' from the Online Education Ontology (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/sikora2021online-education/new-diagrams/diagram8.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:15:10.005782091Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/sikora2021online-education/metadata-png-n-diagram9.ttl
+++ b/models/sikora2021online-education/metadata-png-n-diagram9.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/793d36a5-7ea0-4468-8bc2-f5c9a7671d4b> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/c3b6f81b-7d10-4e11-bdf2-4e291d0f8f70> ;
     dct:issued "2021"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram9' from the Online Education Ontology (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/sikora2021online-education/new-diagrams/diagram9.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:15:11.552033289Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/sikora2021online-education/metadata-png-o-diagram1.ttl
+++ b/models/sikora2021online-education/metadata-png-o-diagram1.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/4d80b145-6266-40a8-ba85-1d65a49cf4c0> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/c3b6f81b-7d10-4e11-bdf2-4e291d0f8f70> ;
     dct:issued "2021"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram1' from the Online Education Ontology (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/sikora2021online-education/original-diagrams/diagram1.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:15:13.19807432Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/sikora2021online-education/metadata-png-o-diagram10.ttl
+++ b/models/sikora2021online-education/metadata-png-o-diagram10.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/23984be2-a829-405b-b003-d65c3214565c> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/c3b6f81b-7d10-4e11-bdf2-4e291d0f8f70> ;
     dct:issued "2021"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram10' from the Online Education Ontology (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/sikora2021online-education/original-diagrams/diagram10.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:15:15.210796898Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/sikora2021online-education/metadata-png-o-diagram11.ttl
+++ b/models/sikora2021online-education/metadata-png-o-diagram11.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/86de3456-8fb7-42e1-a7fd-ddbd2cebdfd1> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/c3b6f81b-7d10-4e11-bdf2-4e291d0f8f70> ;
     dct:issued "2021"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram11' from the Online Education Ontology (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/sikora2021online-education/original-diagrams/diagram11.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:15:16.924214939Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/sikora2021online-education/metadata-png-o-diagram12.ttl
+++ b/models/sikora2021online-education/metadata-png-o-diagram12.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/920ee75d-5e48-4340-9a84-5beae5fdd408> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/c3b6f81b-7d10-4e11-bdf2-4e291d0f8f70> ;
     dct:issued "2021"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram12' from the Online Education Ontology (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/sikora2021online-education/original-diagrams/diagram12.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:15:18.571447459Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/sikora2021online-education/metadata-png-o-diagram2.ttl
+++ b/models/sikora2021online-education/metadata-png-o-diagram2.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/8bdeb698-4585-4b01-be31-4097f7f75541> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/c3b6f81b-7d10-4e11-bdf2-4e291d0f8f70> ;
     dct:issued "2021"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram2' from the Online Education Ontology (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/sikora2021online-education/original-diagrams/diagram2.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:15:20.097393964Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/sikora2021online-education/metadata-png-o-diagram3.ttl
+++ b/models/sikora2021online-education/metadata-png-o-diagram3.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/b66c24e5-5a5a-4cbf-b915-24171417966f> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/c3b6f81b-7d10-4e11-bdf2-4e291d0f8f70> ;
     dct:issued "2021"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram3' from the Online Education Ontology (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/sikora2021online-education/original-diagrams/diagram3.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:15:21.632197149Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/sikora2021online-education/metadata-png-o-diagram4.ttl
+++ b/models/sikora2021online-education/metadata-png-o-diagram4.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/91640df3-4901-4717-9b3e-32112de7195c> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/c3b6f81b-7d10-4e11-bdf2-4e291d0f8f70> ;
     dct:issued "2021"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram4' from the Online Education Ontology (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/sikora2021online-education/original-diagrams/diagram4.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:15:23.204939507Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/sikora2021online-education/metadata-png-o-diagram5.ttl
+++ b/models/sikora2021online-education/metadata-png-o-diagram5.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/3f95fc2e-662d-41c0-a214-e782e8d0e3b0> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/c3b6f81b-7d10-4e11-bdf2-4e291d0f8f70> ;
     dct:issued "2021"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram5' from the Online Education Ontology (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/sikora2021online-education/original-diagrams/diagram5.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:15:24.687686333Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/sikora2021online-education/metadata-png-o-diagram6.ttl
+++ b/models/sikora2021online-education/metadata-png-o-diagram6.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/5cd0c10d-40bd-4ffb-a779-877cf0f1fb0f> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/c3b6f81b-7d10-4e11-bdf2-4e291d0f8f70> ;
     dct:issued "2021"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram6' from the Online Education Ontology (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/sikora2021online-education/original-diagrams/diagram6.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:15:26.170889235Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/sikora2021online-education/metadata-png-o-diagram7.ttl
+++ b/models/sikora2021online-education/metadata-png-o-diagram7.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/13d7a7bb-0382-4ff5-8f31-821bd07ca04d> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/c3b6f81b-7d10-4e11-bdf2-4e291d0f8f70> ;
     dct:issued "2021"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram7' from the Online Education Ontology (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/sikora2021online-education/original-diagrams/diagram7.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:15:27.75850628Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/sikora2021online-education/metadata-png-o-diagram8.ttl
+++ b/models/sikora2021online-education/metadata-png-o-diagram8.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/623766f3-4edb-4cd9-9f82-d483ff66734e> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/c3b6f81b-7d10-4e11-bdf2-4e291d0f8f70> ;
     dct:issued "2021"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram8' from the Online Education Ontology (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/sikora2021online-education/original-diagrams/diagram8.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:15:29.235549139Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/sikora2021online-education/metadata-png-o-diagram9.ttl
+++ b/models/sikora2021online-education/metadata-png-o-diagram9.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/679c9c8d-2d54-4121-849a-619574c64002> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/c3b6f81b-7d10-4e11-bdf2-4e291d0f8f70> ;
     dct:issued "2021"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram9' from the Online Education Ontology (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/sikora2021online-education/original-diagrams/diagram9.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:15:30.850585049Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/sikora2021online-education/metadata-turtle.ttl
+++ b/models/sikora2021online-education/metadata-turtle.ttl
@@ -7,11 +7,10 @@
 <https://w3id.org/ontouml-models/distribution/b03c171f-b771-4ea0-9fa0-91024d89168e/> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/c3b6f81b-7d10-4e11-bdf2-4e291d0f8f70> ;
     dct:issued "2021"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Turtle distribution of Online Education Ontology"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/sikora2021online-education/ontology.ttl> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
     fdpo:metadataIssued "2023-04-14T18:15:32.375722128Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/sikora2021online-education/metadata-vpp.ttl
+++ b/models/sikora2021online-education/metadata-vpp.ttl
@@ -8,11 +8,10 @@
     dct:format <https://www.file-extension.info/format/vpp> ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/c3b6f81b-7d10-4e11-bdf2-4e291d0f8f70> ;
     dct:issued "2021"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Visual Paradigm distribution of Online Education Ontology"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/sikora2021online-education/ontology.vpp> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/octet-stream> ;
     fdpo:metadataIssued "2023-04-14T18:15:34.015913825Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T00:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/sikora2021online-education/metadata.ttl
+++ b/models/sikora2021online-education/metadata.ttl
@@ -17,7 +17,6 @@
     dcat:theme lcc:L;
     skos:editorialNote "there is a class \"comment\" that is both a \"kind\" and a \"relator\"";
     dct:language "en";
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:contributor <https://orcid.org/0000-0003-0155-6345>;
     dcat:keyword "education"@en;
     dct:source <https://dspace.cvut.cz/handle/10467/95442>;
@@ -27,7 +26,7 @@
     ocmv:ontologyType ocmv:Domain;
     ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/sikora2021online-education"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T18:14:51.359962306Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .
 
 <https://w3id.org/ontouml-models/model/c3b6f81b-7d10-4e11-bdf2-4e291d0f8f70> dcat:distribution <https://w3id.org/ontouml-models/distribution/b03c171f-b771-4ea0-9fa0-91024d89168e/>,
                       <https://w3id.org/ontouml-models/distribution/26661f89-956e-4840-bbae-02503e01e524/>,

--- a/models/silva2012itarchitecture/metadata-json.ttl
+++ b/models/silva2012itarchitecture/metadata-json.ttl
@@ -12,10 +12,9 @@
     dct:isPartOf <https://w3id.org/ontouml-models/model/65c6c4c6-a903-48dd-bd28-dcb4f0b8fe6d>;
     dct:issued "2012"^^xsd:gYear;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of IT Architecture Ontology (PAS 77:2006 Ontology)"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/silva2012itarchitecture/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T18:15:36.934851761Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .

--- a/models/silva2012itarchitecture/metadata-png-o-data-resilience.ttl
+++ b/models/silva2012itarchitecture/metadata-png-o-data-resilience.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/774d363b-5d23-4d12-892a-f474eae3bc88> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/65c6c4c6-a903-48dd-bd28-dcb4f0b8fe6d> ;
     dct:issued "2012"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'data resilience' from the IT Architecture Ontology (PAS 77:2006 Ontology) (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/silva2012itarchitecture/original-diagrams/data-resilience.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:15:38.479746364Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/silva2012itarchitecture/metadata-png-o-it-architecture.ttl
+++ b/models/silva2012itarchitecture/metadata-png-o-it-architecture.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/c28cb6bb-d731-4a0a-8c79-a2fcd84e4435> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/65c6c4c6-a903-48dd-bd28-dcb4f0b8fe6d> ;
     dct:issued "2012"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'it architecture' from the IT Architecture Ontology (PAS 77:2006 Ontology) (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/silva2012itarchitecture/original-diagrams/it-architecture.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:15:40.15177724Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/silva2012itarchitecture/metadata-png-o-it-components.ttl
+++ b/models/silva2012itarchitecture/metadata-png-o-it-components.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/a4245a71-8136-4054-b5bd-6c6b18ec65a5> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/65c6c4c6-a903-48dd-bd28-dcb4f0b8fe6d> ;
     dct:issued "2012"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'it components' from the IT Architecture Ontology (PAS 77:2006 Ontology) (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/silva2012itarchitecture/original-diagrams/it-components.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:15:41.726973757Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/silva2012itarchitecture/metadata-png-o-it-service-continuity-components.ttl
+++ b/models/silva2012itarchitecture/metadata-png-o-it-service-continuity-components.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/6fd7672f-1c91-4e81-b273-80671dac9f21> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/65c6c4c6-a903-48dd-bd28-dcb4f0b8fe6d> ;
     dct:issued "2012"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'it service continuity components' from the IT Architecture Ontology (PAS 77:2006 Ontology) (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/silva2012itarchitecture/original-diagrams/it-service-continuity-components.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:15:43.184095773Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/silva2012itarchitecture/metadata-png-o-platform.ttl
+++ b/models/silva2012itarchitecture/metadata-png-o-platform.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/034fad7d-3ae3-40d9-b009-e294d8dbf969> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/65c6c4c6-a903-48dd-bd28-dcb4f0b8fe6d> ;
     dct:issued "2012"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'platform' from the IT Architecture Ontology (PAS 77:2006 Ontology) (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/silva2012itarchitecture/original-diagrams/platform.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:15:44.704720779Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/silva2012itarchitecture/metadata-png-o-site.ttl
+++ b/models/silva2012itarchitecture/metadata-png-o-site.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/f39eb53d-5e96-4c8c-9400-4fb1ecb543b4> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/65c6c4c6-a903-48dd-bd28-dcb4f0b8fe6d> ;
     dct:issued "2012"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'site' from the IT Architecture Ontology (PAS 77:2006 Ontology) (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/silva2012itarchitecture/original-diagrams/site.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:15:46.333826041Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/silva2012itarchitecture/metadata-png-o-specialization.ttl
+++ b/models/silva2012itarchitecture/metadata-png-o-specialization.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/b42aa003-977e-4dd1-ba40-136ec28a58fe> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/65c6c4c6-a903-48dd-bd28-dcb4f0b8fe6d> ;
     dct:issued "2012"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'specialization' from the IT Architecture Ontology (PAS 77:2006 Ontology) (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/silva2012itarchitecture/original-diagrams/specialization.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:15:47.862545651Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/silva2012itarchitecture/metadata-turtle.ttl
+++ b/models/silva2012itarchitecture/metadata-turtle.ttl
@@ -7,11 +7,10 @@
 <https://w3id.org/ontouml-models/distribution/e8d04b21-786c-425e-9efc-48ef7846493d/> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/65c6c4c6-a903-48dd-bd28-dcb4f0b8fe6d> ;
     dct:issued "2012"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Turtle distribution of IT Architecture Ontology (PAS 77:2006 Ontology)"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/silva2012itarchitecture/ontology.ttl> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
     fdpo:metadataIssued "2023-04-14T18:15:50.492598337Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/silva2012itarchitecture/metadata-vpp.ttl
+++ b/models/silva2012itarchitecture/metadata-vpp.ttl
@@ -8,11 +8,10 @@
     dct:format <https://www.file-extension.info/format/vpp> ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/65c6c4c6-a903-48dd-bd28-dcb4f0b8fe6d> ;
     dct:issued "2012"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Visual Paradigm distribution of IT Architecture Ontology (PAS 77:2006 Ontology)"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/silva2012itarchitecture/ontology.vpp> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/octet-stream> ;
     fdpo:metadataIssued "2023-04-14T18:15:52.048813026Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T00:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/silva2012itarchitecture/metadata.ttl
+++ b/models/silva2012itarchitecture/metadata.ttl
@@ -17,7 +17,6 @@
     dcat:theme lcc:T;
     dct:language "en",
                  "pt-br";
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:contributor <https://dblp.org/pid/119/6024>,
                     <https://dblp.org/pid/119/6017>,
                     <https://dblp.org/pid/119/6012>,
@@ -33,7 +32,7 @@
     ocmv:ontologyType ocmv:Domain;
     ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/silva2012itarchitecture"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T18:15:35.74311328Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .
 
 <https://w3id.org/ontouml-models/model/65c6c4c6-a903-48dd-bd28-dcb4f0b8fe6d> dcat:distribution <https://w3id.org/ontouml-models/distribution/e8d04b21-786c-425e-9efc-48ef7846493d/>,
                       <https://w3id.org/ontouml-models/distribution/1714ffe3-4a5a-49b9-af35-5b36d2b63b0a/>,

--- a/models/van-ee2021modular/metadata-json.ttl
+++ b/models/van-ee2021modular/metadata-json.ttl
@@ -12,10 +12,9 @@
     dct:isPartOf <https://w3id.org/ontouml-models/model/c6ec6f27-cffa-4a38-9927-8e6b921e996a>;
     dct:issued "2021"^^xsd:gYear;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of Modular Construction Ontology"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/van-ee2021modular/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T18:19:00.326467876Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .

--- a/models/van-ee2021modular/metadata-png-o-attribute-clases.ttl
+++ b/models/van-ee2021modular/metadata-png-o-attribute-clases.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/e5389097-f11b-4f6e-aca6-f3a5d42ea583> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/c6ec6f27-cffa-4a38-9927-8e6b921e996a> ;
     dct:issued "2021"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'attribute clases' from the Modular Construction Ontology (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/van-ee2021modular/original-diagrams/attribute-clases.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:19:01.889101465Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/van-ee2021modular/metadata-png-o-bpo-attribute,-2dlist-section-.ttl
+++ b/models/van-ee2021modular/metadata-png-o-bpo-attribute,-2dlist-section-.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/5661e697-3f4f-4f1f-aa1c-52e8a66084e7> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/c6ec6f27-cffa-4a38-9927-8e6b921e996a> ;
     dct:issued "2021"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'bpo attribute, 2dlist section ' from the Modular Construction Ontology (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/van-ee2021modular/original-diagrams/bpo-attribute,-2dlist-section-.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:19:03.524948195Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/van-ee2021modular/metadata-png-o-bpo-ontology.ttl
+++ b/models/van-ee2021modular/metadata-png-o-bpo-ontology.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/23e8fe21-505a-440b-840d-c67cf393f579> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/c6ec6f27-cffa-4a38-9927-8e6b921e996a> ;
     dct:issued "2021"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'bpo ontology' from the Modular Construction Ontology (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/van-ee2021modular/original-diagrams/bpo-ontology.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:19:05.07840543Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/van-ee2021modular/metadata-png-o-element-class.ttl
+++ b/models/van-ee2021modular/metadata-png-o-element-class.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/36f7cc11-3ae2-44fc-ac15-255263ecc171> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/c6ec6f27-cffa-4a38-9927-8e6b921e996a> ;
     dct:issued "2021"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'element class' from the Modular Construction Ontology (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/van-ee2021modular/original-diagrams/element-class.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:19:06.620518795Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/van-ee2021modular/metadata-png-o-entity-classes.ttl
+++ b/models/van-ee2021modular/metadata-png-o-entity-classes.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/fb0298e8-0230-46a1-9583-8b0f11993fba> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/c6ec6f27-cffa-4a38-9927-8e6b921e996a> ;
     dct:issued "2021"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'entity classes' from the Modular Construction Ontology (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/van-ee2021modular/original-diagrams/entity-classes.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:19:08.136221405Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/van-ee2021modular/metadata-png-o-geometry-classes-2.ttl
+++ b/models/van-ee2021modular/metadata-png-o-geometry-classes-2.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/a6d077bc-cd53-481b-98b5-565e93011ccd> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/c6ec6f27-cffa-4a38-9927-8e6b921e996a> ;
     dct:issued "2021"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'geometry classes 2' from the Modular Construction Ontology (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/van-ee2021modular/original-diagrams/geometry-classes-2.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:19:09.636626689Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/van-ee2021modular/metadata-png-o-geometry-classes.ttl
+++ b/models/van-ee2021modular/metadata-png-o-geometry-classes.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/55f804f2-d0cd-46f4-9b07-8b137300161f> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/c6ec6f27-cffa-4a38-9927-8e6b921e996a> ;
     dct:issued "2021"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'geometry classes' from the Modular Construction Ontology (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/van-ee2021modular/original-diagrams/geometry-classes.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:19:11.270630665Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/van-ee2021modular/metadata-png-o-product-classes.ttl
+++ b/models/van-ee2021modular/metadata-png-o-product-classes.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/879c4b80-7617-4b9f-83b5-fa565900f0aa> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/c6ec6f27-cffa-4a38-9927-8e6b921e996a> ;
     dct:issued "2021"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'product classes' from the Modular Construction Ontology (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/van-ee2021modular/original-diagrams/product-classes.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:19:12.870677163Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/van-ee2021modular/metadata-png-o-projectdecompositionemergo.ttl
+++ b/models/van-ee2021modular/metadata-png-o-projectdecompositionemergo.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/5d5ed42d-0703-4892-a0fe-e7973d987eed> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/c6ec6f27-cffa-4a38-9927-8e6b921e996a> ;
     dct:issued "2021"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'projectdecompositionemergo' from the Modular Construction Ontology (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/van-ee2021modular/original-diagrams/projectdecompositionemergo.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:19:14.498460314Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/van-ee2021modular/metadata-turtle.ttl
+++ b/models/van-ee2021modular/metadata-turtle.ttl
@@ -7,11 +7,10 @@
 <https://w3id.org/ontouml-models/distribution/9b158615-87dd-4118-8eb0-2481a53029f7/> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/c6ec6f27-cffa-4a38-9927-8e6b921e996a> ;
     dct:issued "2021"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Turtle distribution of Modular Construction Ontology"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/van-ee2021modular/ontology.ttl> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
     fdpo:metadataIssued "2023-04-14T18:19:16.0170111Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/van-ee2021modular/metadata-vpp.ttl
+++ b/models/van-ee2021modular/metadata-vpp.ttl
@@ -8,11 +8,10 @@
     dct:format <https://www.file-extension.info/format/vpp> ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/c6ec6f27-cffa-4a38-9927-8e6b921e996a> ;
     dct:issued "2021"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Visual Paradigm distribution of Modular Construction Ontology"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/van-ee2021modular/ontology.vpp> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/octet-stream> ;
     fdpo:metadataIssued "2023-04-14T18:19:17.583122698Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T00:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/van-ee2021modular/metadata.ttl
+++ b/models/van-ee2021modular/metadata.ttl
@@ -32,7 +32,6 @@ Classes whose label joined multiple RDF elements were interpreted as "owl:sameAs
 """;
     dct:language "en",
                  "nl";
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:contributor <https://www.linkedin.com/in/tim-van-ee-911887136/>;
     dcat:keyword "construction"@en;
     mod:designedForTask ocmv:Interoperability,
@@ -43,7 +42,7 @@ Classes whose label joined multiple RDF elements were interpreted as "owl:sameAs
     ocmv:ontologyType ocmv:Application;
     ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/van-ee2021modular"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T18:18:59.076803004Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .
 
 <https://w3id.org/ontouml-models/model/c6ec6f27-cffa-4a38-9927-8e6b921e996a> dcat:distribution <https://w3id.org/ontouml-models/distribution/9b158615-87dd-4118-8eb0-2481a53029f7/>,
                       <https://w3id.org/ontouml-models/distribution/15762e63-c636-4839-a60e-199fff2c104e/>,

--- a/models/zanetti2019orm-o/metadata-json.ttl
+++ b/models/zanetti2019orm-o/metadata-json.ttl
@@ -12,10 +12,9 @@
     dct:isPartOf <https://w3id.org/ontouml-models/model/c528d763-ff22-4d52-9e03-e881b41805ce>;
     dct:issued "2019"^^xsd:gYear;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of Object/Relational Mapping Ontology"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/zanetti2019orm-o/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T18:20:26.831437244Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .

--- a/models/zanetti2019orm-o/metadata-png-n-classes-and-relationships.ttl
+++ b/models/zanetti2019orm-o/metadata-png-n-classes-and-relationships.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/508ca6cf-6940-4f4f-ad74-064c200c675b> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/c528d763-ff22-4d52-9e03-e881b41805ce> ;
     dct:issued "2019"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'classes and relationships' from the Object/Relational Mapping Ontology (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/zanetti2019orm-o/new-diagrams/classes-and-relationships.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:20:28.352006969Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/zanetti2019orm-o/metadata-png-n-inheritance.ttl
+++ b/models/zanetti2019orm-o/metadata-png-n-inheritance.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/3ca09a09-e25e-422e-b1a8-aa25a56015b9> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/c528d763-ff22-4d52-9e03-e881b41805ce> ;
     dct:issued "2019"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'inheritance' from the Object/Relational Mapping Ontology (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/zanetti2019orm-o/new-diagrams/inheritance.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:20:29.959476796Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/zanetti2019orm-o/metadata-png-n-variable.ttl
+++ b/models/zanetti2019orm-o/metadata-png-n-variable.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/1999a0f1-cf5e-4c04-9aa4-98fe47996c09> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/c528d763-ff22-4d52-9e03-e881b41805ce> ;
     dct:issued "2019"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'variable' from the Object/Relational Mapping Ontology (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/zanetti2019orm-o/new-diagrams/variable.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:20:31.46803534Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/zanetti2019orm-o/metadata-png-o-diagram1.ttl
+++ b/models/zanetti2019orm-o/metadata-png-o-diagram1.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/e1271a9a-2d30-4ad6-a53f-3127948bad48> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/c528d763-ff22-4d52-9e03-e881b41805ce> ;
     dct:issued "2019"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram1' from the Object/Relational Mapping Ontology (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/zanetti2019orm-o/original-diagrams/diagram1.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:20:33.128616241Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/zanetti2019orm-o/metadata-png-o-diagram2.ttl
+++ b/models/zanetti2019orm-o/metadata-png-o-diagram2.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/a182e9c1-b9cf-45b2-b061-92d162f9a490> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/c528d763-ff22-4d52-9e03-e881b41805ce> ;
     dct:issued "2019"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram2' from the Object/Relational Mapping Ontology (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/zanetti2019orm-o/original-diagrams/diagram2.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:20:34.615178475Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/zanetti2019orm-o/metadata-png-o-diagram3.ttl
+++ b/models/zanetti2019orm-o/metadata-png-o-diagram3.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/be2b2b3b-493a-4702-ae0c-04500dae8c10> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/c528d763-ff22-4d52-9e03-e881b41805ce> ;
     dct:issued "2019"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'diagram3' from the Object/Relational Mapping Ontology (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/zanetti2019orm-o/original-diagrams/diagram3.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:20:36.142072986Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/zanetti2019orm-o/metadata-turtle.ttl
+++ b/models/zanetti2019orm-o/metadata-turtle.ttl
@@ -7,11 +7,10 @@
 <https://w3id.org/ontouml-models/distribution/00adef72-c45f-420e-aabb-9183fb5f25ae/> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/c528d763-ff22-4d52-9e03-e881b41805ce> ;
     dct:issued "2019"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Turtle distribution of Object/Relational Mapping Ontology"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/zanetti2019orm-o/ontology.ttl> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
     fdpo:metadataIssued "2023-04-14T18:20:37.653132847Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/zanetti2019orm-o/metadata-vpp.ttl
+++ b/models/zanetti2019orm-o/metadata-vpp.ttl
@@ -8,11 +8,10 @@
     dct:format <https://www.file-extension.info/format/vpp> ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/c528d763-ff22-4d52-9e03-e881b41805ce> ;
     dct:issued "2019"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Visual Paradigm distribution of Object/Relational Mapping Ontology"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/zanetti2019orm-o/ontology.vpp> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/octet-stream> ;
     fdpo:metadataIssued "2023-04-14T18:20:39.259307356Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T00:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/zanetti2019orm-o/metadata.ttl
+++ b/models/zanetti2019orm-o/metadata.ttl
@@ -17,7 +17,6 @@
     dcat:theme lcc:T;
     skos:editorialNote "The ontology was documented based on the author's paper.";
     dct:language "en";
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:contributor <https://dblp.org/pid/256/4242>,
                     <https://dblp.org/pid/230/6733>,
                     <https://dblp.org/pid/72/3662>;
@@ -29,7 +28,7 @@
     ocmv:ontologyType ocmv:Domain;
     ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/zanetti2019orm-o"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T18:20:25.574199631Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .
 
 <https://w3id.org/ontouml-models/model/c528d763-ff22-4d52-9e03-e881b41805ce> dcat:distribution <https://w3id.org/ontouml-models/distribution/00adef72-c45f-420e-aabb-9183fb5f25ae/>,
                       <https://w3id.org/ontouml-models/distribution/1fba6c3c-9df4-4f7f-b374-cee0530be3f4/>,

--- a/models/zhou2017hazard-ontology-robotic-strolling/metadata-json.ttl
+++ b/models/zhou2017hazard-ontology-robotic-strolling/metadata-json.ttl
@@ -12,10 +12,9 @@
     dct:isPartOf <https://w3id.org/ontouml-models/model/c7dbcd4e-e12a-4f9f-a20c-e08137c36db5>;
     dct:issued "2017"^^xsd:gYear;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of Robotic Strolling System"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/zhou2017hazard-ontology-robotic-strolling/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T18:20:42.456540525Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .

--- a/models/zhou2017hazard-ontology-robotic-strolling/metadata-png-n-robotic-strolling-system.ttl
+++ b/models/zhou2017hazard-ontology-robotic-strolling/metadata-png-n-robotic-strolling-system.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/219aaf3e-8af9-4d45-a4d9-4ebf90b70a3f> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/c7dbcd4e-e12a-4f9f-a20c-e08137c36db5> ;
     dct:issued "2017"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'robotic strolling system' from the Robotic Strolling System (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/zhou2017hazard-ontology-robotic-strolling/new-diagrams/robotic-strolling-system.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:20:44.557775247Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/zhou2017hazard-ontology-robotic-strolling/metadata-png-o-robotic-strolling-system.ttl
+++ b/models/zhou2017hazard-ontology-robotic-strolling/metadata-png-o-robotic-strolling-system.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/e594a578-fae5-4ea3-92e6-5c7681c48f0b> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/c7dbcd4e-e12a-4f9f-a20c-e08137c36db5> ;
     dct:issued "2017"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'robotic strolling system' from the Robotic Strolling System (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/zhou2017hazard-ontology-robotic-strolling/original-diagrams/robotic-strolling-system.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:20:46.414448337Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/zhou2017hazard-ontology-robotic-strolling/metadata-turtle.ttl
+++ b/models/zhou2017hazard-ontology-robotic-strolling/metadata-turtle.ttl
@@ -7,11 +7,10 @@
 <https://w3id.org/ontouml-models/distribution/b709fd18-79b6-429b-a323-465254b9f34d/> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/c7dbcd4e-e12a-4f9f-a20c-e08137c36db5> ;
     dct:issued "2017"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Turtle distribution of Robotic Strolling System"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/zhou2017hazard-ontology-robotic-strolling/ontology.ttl> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
     fdpo:metadataIssued "2023-04-14T18:20:47.951837871Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/zhou2017hazard-ontology-robotic-strolling/metadata-vpp.ttl
+++ b/models/zhou2017hazard-ontology-robotic-strolling/metadata-vpp.ttl
@@ -8,11 +8,10 @@
     dct:format <https://www.file-extension.info/format/vpp> ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/c7dbcd4e-e12a-4f9f-a20c-e08137c36db5> ;
     dct:issued "2017"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Visual Paradigm distribution of Robotic Strolling System"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/zhou2017hazard-ontology-robotic-strolling/ontology.vpp> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/octet-stream> ;
     fdpo:metadataIssued "2023-04-14T18:20:49.706277116Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T00:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/zhou2017hazard-ontology-robotic-strolling/metadata.ttl
+++ b/models/zhou2017hazard-ontology-robotic-strolling/metadata.ttl
@@ -17,7 +17,6 @@
     dcat:theme lcc:T;
     skos:editorialNote "This ontology was built as a use case for evaluating importance of the Hazard Ontology.";
     dct:language "en";
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:contributor <https://dblp.org/pid/143/1123>,
                     <https://dblp.org/pid/36/2701>,
                     <https://dblp.org/pid/53/2238>,
@@ -33,7 +32,7 @@
     ocmv:ontologyType ocmv:Domain;
     ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/zhou2017hazard-ontology-robotic-strolling"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T18:20:41.066388527Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .
 
 <https://w3id.org/ontouml-models/model/c7dbcd4e-e12a-4f9f-a20c-e08137c36db5> dcat:distribution <https://w3id.org/ontouml-models/distribution/b709fd18-79b6-429b-a323-465254b9f34d/>,
                       <https://w3id.org/ontouml-models/distribution/c30ed359-c2eb-436b-8958-0596f9a5cc6c/>,

--- a/models/zhou2017hazard-ontology-train-control/metadata-json.ttl
+++ b/models/zhou2017hazard-ontology-train-control/metadata-json.ttl
@@ -12,10 +12,9 @@
     dct:isPartOf <https://w3id.org/ontouml-models/model/0ea32c8f-85e8-4749-97b9-24b59ae41dbd>;
     dct:issued "2017"^^xsd:gYear;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of Train Control System"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/zhou2017hazard-ontology-train-control/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T18:20:52.715361235Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .

--- a/models/zhou2017hazard-ontology-train-control/metadata-png-n-train-control-system-1.ttl
+++ b/models/zhou2017hazard-ontology-train-control/metadata-png-n-train-control-system-1.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/1a9e225e-38bf-49df-979c-13b9004b26a7> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/0ea32c8f-85e8-4749-97b9-24b59ae41dbd> ;
     dct:issued "2017"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'train control system 1' from the Train Control System (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/zhou2017hazard-ontology-train-control/new-diagrams/train-control-system-1.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:20:54.522733677Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/zhou2017hazard-ontology-train-control/metadata-png-n-train-control-system-2.ttl
+++ b/models/zhou2017hazard-ontology-train-control/metadata-png-n-train-control-system-2.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/2f433ae4-2e2e-4d89-9fd2-3710e96308c2> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/0ea32c8f-85e8-4749-97b9-24b59ae41dbd> ;
     dct:issued "2017"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'train control system 2' from the Train Control System (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/zhou2017hazard-ontology-train-control/new-diagrams/train-control-system-2.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:20:55.969688133Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/zhou2017hazard-ontology-train-control/metadata-png-o-train-control-system-1.ttl
+++ b/models/zhou2017hazard-ontology-train-control/metadata-png-o-train-control-system-1.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/9b77c2a0-da42-458d-9d93-b92320f4ceff> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/0ea32c8f-85e8-4749-97b9-24b59ae41dbd> ;
     dct:issued "2017"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'train control system 1' from the Train Control System (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/zhou2017hazard-ontology-train-control/original-diagrams/train-control-system-1.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:20:57.571184004Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/zhou2017hazard-ontology-train-control/metadata-png-o-train-control-system-2.ttl
+++ b/models/zhou2017hazard-ontology-train-control/metadata-png-o-train-control-system-2.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/17ecd8ff-a496-43eb-80c4-501a690243b8> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/0ea32c8f-85e8-4749-97b9-24b59ae41dbd> ;
     dct:issued "2017"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'train control system 2' from the Train Control System (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/zhou2017hazard-ontology-train-control/original-diagrams/train-control-system-2.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:20:59.156320507Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/zhou2017hazard-ontology-train-control/metadata-turtle.ttl
+++ b/models/zhou2017hazard-ontology-train-control/metadata-turtle.ttl
@@ -7,11 +7,10 @@
 <https://w3id.org/ontouml-models/distribution/e31b4d0f-4abb-47fd-b4e9-600d5811b821/> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/0ea32c8f-85e8-4749-97b9-24b59ae41dbd> ;
     dct:issued "2017"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Turtle distribution of Train Control System"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/zhou2017hazard-ontology-train-control/ontology.ttl> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
     fdpo:metadataIssued "2023-04-14T18:21:00.761872034Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/zhou2017hazard-ontology-train-control/metadata-vpp.ttl
+++ b/models/zhou2017hazard-ontology-train-control/metadata-vpp.ttl
@@ -8,11 +8,10 @@
     dct:format <https://www.file-extension.info/format/vpp> ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/0ea32c8f-85e8-4749-97b9-24b59ae41dbd> ;
     dct:issued "2017"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Visual Paradigm distribution of Train Control System"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/zhou2017hazard-ontology-train-control/ontology.vpp> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/octet-stream> ;
     fdpo:metadataIssued "2023-04-14T18:21:02.328643894Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T00:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/zhou2017hazard-ontology-train-control/metadata.ttl
+++ b/models/zhou2017hazard-ontology-train-control/metadata.ttl
@@ -17,7 +17,6 @@
     dcat:theme lcc:T;
     skos:editorialNote "This ontology was built as a use case for evaluating importance of the Hazard Ontology.";
     dct:language "en";
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:contributor <https://dblp.org/pid/143/1123>,
                     <https://dblp.org/pid/36/2701>,
                     <https://dblp.org/pid/53/2238>,
@@ -33,7 +32,7 @@
     ocmv:ontologyType ocmv:Domain;
     ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/zhou2017hazard-ontology-train-control"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T18:20:51.467454286Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .
 
 <https://w3id.org/ontouml-models/model/0ea32c8f-85e8-4749-97b9-24b59ae41dbd> dcat:distribution <https://w3id.org/ontouml-models/distribution/e31b4d0f-4abb-47fd-b4e9-600d5811b821/>,
                       <https://w3id.org/ontouml-models/distribution/8ef09e9f-ada6-4952-9e9f-34e0986b6b04/>,

--- a/models/zhou2017hazard/metadata-json.ttl
+++ b/models/zhou2017hazard/metadata-json.ttl
@@ -12,10 +12,9 @@
     dct:isPartOf <https://w3id.org/ontouml-models/model/e28bed62-0a6b-49a4-a3a9-01c8e4f527e3>;
     dct:issued "2017"^^xsd:gYear;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/json>;
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     ocmv:conformsToSchema <https://w3id.org/ontouml/schema>;
     dct:title "JSON distribution of Hazard Ontology"@en;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/zhou2017hazard/ontology.json>;
     ocmv:isComplete "true"^^xsd:boolean;
     fdpo:metadataIssued "2023-04-14T18:21:05.509815727Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .

--- a/models/zhou2017hazard/metadata-png-n-hazard-ontology.ttl
+++ b/models/zhou2017hazard/metadata-png-n-hazard-ontology.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/16ed48c3-b042-41cc-a9d4-04301817795e> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/e28bed62-0a6b-49a4-a3a9-01c8e4f527e3> ;
     dct:issued "2017"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'hazard ontology' from the Hazard Ontology (Visual Paradigm version)"@en ;
     skos:editorialNote "This image depicts a version of the original diagram re-created in the Visual Paradigm editor."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/zhou2017hazard/new-diagrams/hazard-ontology.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:21:07.047543648Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/zhou2017hazard/metadata-png-o-hazard-ontology.ttl
+++ b/models/zhou2017hazard/metadata-png-o-hazard-ontology.ttl
@@ -8,12 +8,11 @@
 <https://w3id.org/ontouml-models/distribution/577739c1-9341-4224-9f8b-dce26d195383> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/e28bed62-0a6b-49a4-a3a9-01c8e4f527e3> ;
     dct:issued "2017"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "PNG distribution of diagram 'hazard ontology' from the Hazard Ontology (original version)"@en ;
     skos:editorialNote "This image depicts the diagram as originally represented by its author(s)."@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/zhou2017hazard/original-diagrams/hazard-ontology.png> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
     fdpo:metadataIssued "2023-04-14T18:21:08.626336668Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete false .
 

--- a/models/zhou2017hazard/metadata-turtle.ttl
+++ b/models/zhou2017hazard/metadata-turtle.ttl
@@ -7,11 +7,10 @@
 <https://w3id.org/ontouml-models/distribution/93bbe0fc-3e47-4037-b4bf-1fb5b88664b1/> a dcat:Distribution ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/e28bed62-0a6b-49a4-a3a9-01c8e4f527e3> ;
     dct:issued "2017"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Turtle distribution of Hazard Ontology"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/zhou2017hazard/ontology.ttl> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
     fdpo:metadataIssued "2023-04-14T18:21:10.272090048Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T12:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/zhou2017hazard/metadata-vpp.ttl
+++ b/models/zhou2017hazard/metadata-vpp.ttl
@@ -8,11 +8,10 @@
     dct:format <https://www.file-extension.info/format/vpp> ;
     dct:isPartOf <https://w3id.org/ontouml-models/model/e28bed62-0a6b-49a4-a3a9-01c8e4f527e3> ;
     dct:issued "2017"^^xsd:gYear ;
-    dct:license <https://creativecommons.org/licenses/by/4.0/> ;
     dct:title "Visual Paradigm distribution of Hazard Ontology"@en ;
     dcat:downloadURL <https://raw.githubusercontent.com/OntoUML/ontouml-models/master/models/zhou2017hazard/ontology.vpp> ;
     dcat:mediaType <https://www.iana.org/assignments/media-types/application/octet-stream> ;
     fdpo:metadataIssued "2023-04-14T18:21:11.866522542Z"^^xsd:dateTime ;
-    fdpo:metadataModified "2026-06-24T00:00:00Z"^^xsd:dateTime ;
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime ;
     ocmv:isComplete true .
 

--- a/models/zhou2017hazard/metadata.ttl
+++ b/models/zhou2017hazard/metadata.ttl
@@ -18,7 +18,6 @@
     dcat:theme lcc:H;
     skos:editorialNote "The paper in which the hazard ontology is proposed contains use cases that extend the ontology. These were not included but in the folder hazard-ontology-use-cases2017.";
     dct:language "en";
-    dct:license <https://creativecommons.org/licenses/by/4.0/>;
     dct:contributor <https://dblp.org/pid/143/1123>,
                     <https://dblp.org/pid/36/2701>,
                     <https://dblp.org/pid/53/2238>,
@@ -33,7 +32,7 @@
     ocmv:ontologyType ocmv:Domain;
     ocmv:storageUrl "https://github.com/OntoUML/ontouml-models/tree/master/models/zhou2017hazard"^^xsd:anyURI;
     fdpo:metadataIssued "2023-04-14T18:21:04.152104584Z"^^xsd:dateTime;
-    fdpo:metadataModified "2026-06-23T12:00:00Z"^^xsd:dateTime .
+    fdpo:metadataModified "2026-08-29T22:31:45Z"^^xsd:dateTime .
 
 <https://w3id.org/ontouml-models/model/e28bed62-0a6b-49a4-a3a9-01c8e4f527e3> dcat:distribution <https://w3id.org/ontouml-models/distribution/93bbe0fc-3e47-4037-b4bf-1fb5b88664b1/>,
                       <https://w3id.org/ontouml-models/distribution/d9c7230e-3e8b-4be3-a9e9-8be974d68086/>,


### PR DESCRIPTION
## Background and problem

Some early catalog models were intentionally accepted without an explicit license in their authoritative `metadata.yaml`. Repository history first shows CC BY 4.0 being added to their generated RDF metadata during the FDP round-trip in PR [#274](https://github.com/OntoUML/ontouml-models/pull/274), commit [`3fbdf41f`](https://github.com/OntoUML/ontouml-models/commit/3fbdf41fe37a79ce23d88148c172ba4156ffb211), even though the source license values remained blank.

The current generators do not hard-code CC BY 4.0, but subsequent in-place regeneration preserved the license already present in the generated files. Consequently, 42 of the 43 historical license-less models contained an unauthorized:

```turtle
dct:license <https://creativecommons.org/licenses/by/4.0/> ;
```

The remaining license-less model is already clean and is not modified by this PR.

## Summary

* Remove the unauthorized CC BY 4.0 assertion from generated metadata for the 42 affected historical models.
* Update `fdpo:metadataModified` in those files using the fixed remediation timestamp `2026-08-29T22:31:45Z`.
* Preserve `fdpo:metadataIssued` and every other RDF triple.
* Preserve the intentional absence of a license rather than assigning a replacement or default.

## Scope

This repair modifies 394 generated metadata files:

* 42 `metadata.ttl` files
* 42 `metadata-json.ttl` files
* 42 `metadata-turtle.ttl` files
* 42 `metadata-vpp.ttl` files
* 226 `metadata-png*.ttl` files

It intentionally does not modify:

* authoritative `metadata.yaml` files;
* model-level `dct:modified` values;
* `ontology.ttl`;
* `catalog.ttl`;
* generators, workflows, tests, or documentation;
* previous releases.

This is intentionally a data-only repair. It is limited to the identified license-less models so that legitimate CC BY assertions belonging to explicitly licensed models remain untouched.

## Validation

* Confirmed exactly 394 license removals and 394 `fdpo:metadataModified` replacements, with no other changed lines.
* Parsed all 394 changed files successfully as Turtle.
* Confirmed that the repaired files contain no `dct:license` triples.
* Confirmed that `fdpo:metadataIssued` and `fdpo:metadataModified` each occur exactly once per file.
* Confirmed synchronization with all five metadata generators using `--allow-missing-license --check`.
* Confirmed that `catalog.ttl` remains semantically synchronized: 196 datasets and 323 contributors.
* Ran the complete script test suite: 429 tests passed.

## Expected workflow behavior

On this pull request, the `Publish models release` workflow will generate and parse a temporary aggregate RDF artifact for validation; it will not publish a GitHub release.

The `Process new model submission` workflow is expected to fail during classification. Its current multi-model generated-artifact allowlist accepts only `ontology.ttl`, `metadata.ttl`, and `metadata-turtle.ttl`, while this repair also necessarily changes `metadata-json.ttl`, `metadata-png*.ttl`, and `metadata-vpp.ttl`.

This is a workflow-applicability limitation rather than a failure of the repaired metadata. No workflow change is included because this PR is intentionally limited to the existing-data repair.