### PR TITLE
fix(ci): orchestrate PR generation and final validation

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -1,0 +1,227 @@
+name: Orchestrate PR validation
+
+on:
+  pull_request_target:
+    branches: [master]
+    types: [opened, synchronize, reopened, ready_for_review, edited]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Open PR number to process or recover"
+        required: true
+        type: string
+  workflow_run:
+    workflows: [Validate final PR state]
+    types: [completed]
+
+permissions: {}
+
+# Serialize writeback per PR. Reporters have separate groups and verify both
+# the current head and the newest App check before publishing a result.
+concurrency:
+  group: pr-automation-${{ github.event.pull_request.number || inputs.pr_number || format('report-{0}', github.event.workflow_run.id) }}
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    name: Classify PR and block merge
+    if: ${{ github.event_name != 'workflow_run' && github.ref == 'refs/heads/master' }}
+    runs-on: ubuntu-latest
+    environment: pr-automation
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      plan: ${{ steps.prepare.outputs.plan }}
+      head: ${{ steps.prepare.outputs.head }}
+      base: ${{ steps.prepare.outputs.base }}
+      check_id: ${{ steps.prepare.outputs.check_id }}
+      generate: ${{ steps.prepare.outputs.generate }}
+      fork: ${{ steps.prepare.outputs.fork }}
+      owner: ${{ steps.prepare.outputs.owner }}
+      repository: ${{ steps.prepare.outputs.repository }}
+      skip: ${{ steps.prepare.outputs.skip }}
+    steps:
+      - name: Check out trusted base only
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: refs/heads/master
+          persist-credentials: false
+      - name: Mint scoped check token
+        id: app
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+        with:
+          app-id: ${{ vars.PR_AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.PR_AUTOMATION_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-checks: write
+      - name: Classify complete PR diff and create pending gate
+        id: prepare
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CHECK_TOKEN: ${{ steps.app.outputs.token }}
+          APP_ID: ${{ vars.PR_AUTOMATION_APP_ID }}
+          APP_SLUG: ${{ steps.app.outputs.app-slug }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+        run: python scripts/pr_automation.py prepare
+
+  generate:
+    name: Process applicable model or catalog changes
+    needs: prepare
+    if: ${{ needs.prepare.outputs.skip != 'true' && needs.prepare.outputs.generate == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    outputs:
+      changed: ${{ steps.generate.outputs.changed }}
+    steps:
+      - name: Check out trusted generators
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ needs.prepare.outputs.base }}
+          path: trusted
+          persist-credentials: false
+      - name: Check out contributor data without credentials
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ needs.prepare.outputs.head }}
+          path: candidate
+          persist-credentials: false
+          # Only regular models/catalog DATA is exported. No PR code executes.
+          allow-unsafe-pr-checkout: true
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.11"
+      - name: Install trusted generator dependencies
+        run: python -m pip install -r trusted/scripts/requirements.txt
+      - name: Generate using trusted scripts and emit an allowlisted bundle
+        id: generate
+        env:
+          PLAN: ${{ needs.prepare.outputs.plan }}
+        run: python trusted/scripts/pr_automation.py generate
+      - name: Retain this run's generated bundle
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: generated-${{ github.run_id }}-${{ github.run_attempt }}
+          path: generated.json
+          if-no-files-found: error
+          retention-days: 1
+
+  publish:
+    name: Commit generated state and dispatch final validation
+    needs: [prepare, generate]
+    if: >-
+      ${{ always() && needs.prepare.result == 'success' && needs.prepare.outputs.skip != 'true' &&
+          (needs.generate.result == 'success' ||
+           (needs.prepare.outputs.generate != 'true' && needs.generate.result == 'skipped')) }}
+    runs-on: ubuntu-latest
+    environment: pr-automation
+    permissions:
+      contents: write
+      pull-requests: read
+      actions: write
+    steps:
+      - name: Check out trusted controller only
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ needs.prepare.outputs.base }}
+          persist-credentials: false
+      - name: Download only this run and attempt's bundle
+        if: ${{ needs.prepare.outputs.generate == 'true' }}
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: generated-${{ github.run_id }}-${{ github.run_attempt }}
+          path: bundle
+      - name: Mint scoped check token
+        id: app
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+        with:
+          app-id: ${{ vars.PR_AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.PR_AUTOMATION_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-checks: write
+      - name: Mint fork write token only for actual generated changes
+        if: ${{ needs.prepare.outputs.fork == 'true' && needs.generate.outputs.changed == 'true' }}
+        id: fork
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+        with:
+          app-id: ${{ vars.PR_AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.PR_AUTOMATION_APP_PRIVATE_KEY }}
+          owner: ${{ needs.prepare.outputs.owner }}
+          repositories: ${{ needs.prepare.outputs.repository }}
+          permission-contents: write
+      - name: Atomically write back and dispatch exact final head
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CHECK_TOKEN: ${{ steps.app.outputs.token }}
+          WRITE_TOKEN: ${{ steps.fork.outputs.token }}
+          PLAN: ${{ needs.prepare.outputs.plan }}
+          CHECK_ID: ${{ needs.prepare.outputs.check_id }}
+        run: python scripts/pr_automation.py publish
+
+  failure:
+    name: Block merge when required processing fails
+    needs: [prepare, generate, publish]
+    if: >-
+      ${{ always() && needs.prepare.result == 'success' && needs.prepare.outputs.check_id != '' &&
+          needs.prepare.outputs.skip != 'true' && needs.publish.result != 'success' }}
+    runs-on: ubuntu-latest
+    environment: pr-automation
+    permissions:
+      contents: read
+    steps:
+      - name: Check out trusted controller only
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: refs/heads/master
+          persist-credentials: false
+      - name: Mint scoped check token
+        id: app
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+        with:
+          app-id: ${{ vars.PR_AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.PR_AUTOMATION_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-checks: write
+      - name: Fail the processing gate
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CHECK_TOKEN: ${{ steps.app.outputs.token }}
+          CHECK_ID: ${{ needs.prepare.outputs.check_id }}
+        run: python scripts/pr_automation.py fail
+
+  report:
+    name: Report current final-head validation
+    if: ${{ github.event_name == 'workflow_run' && github.ref == 'refs/heads/master' }}
+    runs-on: ubuntu-latest
+    environment: pr-automation
+    permissions:
+      contents: read
+      pull-requests: read
+      actions: read
+    steps:
+      - name: Check out trusted reporter only
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: refs/heads/master
+          persist-credentials: false
+      - name: Mint scoped check token
+        id: app
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+        with:
+          app-id: ${{ vars.PR_AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.PR_AUTOMATION_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-checks: write
+      - name: Verify run identity, attempt, job result and live PR head
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CHECK_TOKEN: ${{ steps.app.outputs.token }}
+          APP_ID: ${{ vars.PR_AUTOMATION_APP_ID }}
+        run: python scripts/pr_automation.py report

--- a/.github/workflows/process-new-model-submission.yml
+++ b/.github/workflows/process-new-model-submission.yml
@@ -38,10 +38,8 @@ on:
         default: true
         type: boolean
 
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
-    paths:
-      - "models/**"
+  # Automatic PR processing is owned by pr-validation.yml.
+  # This workflow retains its existing manual maintenance interface.
 
 permissions:
   contents: read

--- a/.github/workflows/publish-models-release.yml
+++ b/.github/workflows/publish-models-release.yml
@@ -1,22 +1,6 @@
 name: Publish models release
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
-    paths:
-      - "models/**"
-      - "catalog.yaml"
-      - "catalog.ttl"
-      - "scripts/requirements.txt"
-      - "scripts/generate_ontology_turtle.py"
-      - "scripts/tests/test_generate_ontology_turtle.py"
-      - "scripts/tests/fixtures/json2graph/**"
-      - "scripts/generate_catalog_file.py"
-      - "scripts/tests/test_generate_catalog_file.py"
-      - "scripts/generate_release_file.py"
-      - "scripts/tests/test_generate_release_file.py"
-      - ".github/workflows/publish-models-release.yml"
-
   schedule:
     # Daily at 03:00 UTC. Scheduled workflows run from the default branch.
     - cron: "0 3 * * *"
@@ -47,76 +31,10 @@ permissions:
   contents: read
 
 concurrency:
-  group: publish-models-release-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.ref }}
+  group: publish-models-release-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
-  validate-release-generation:
-    name: Validate release generation
-    if: ${{ github.event_name == 'pull_request' }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-
-    steps:
-      - name: Check out pull request
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-          persist-credentials: false
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-
-      - name: Install script dependencies
-        run: python -m pip install -r scripts/requirements.txt
-
-      - name: Run ontology Turtle generator tests
-        run: python -m pytest -q scripts/tests/test_generate_ontology_turtle.py
-
-      - name: Run catalog-generator tests
-        run: python -m pytest -q scripts/tests/test_generate_catalog_file.py
-
-      - name: Check catalog synchronization
-        run: python scripts/generate_catalog_file.py . --check
-
-      - name: Run release-generator tests
-        run: python -m pytest -q scripts/tests/test_generate_release_file.py
-
-      - name: Generate release file for validation
-        run: |
-          set -euo pipefail
-          python scripts/generate_release_file.py . \
-            --release-tag 19700101 \
-            --output-dir results \
-            --list-files
-
-      - name: Validate generated release Turtle
-        run: |
-          set -euo pipefail
-          test -s results/ontouml-models-19700101.ttl
-          python - <<'PY'
-          from pathlib import Path
-
-          from rdflib import Graph
-
-          path = Path("results/ontouml-models-19700101.ttl")
-
-          graph = Graph()
-          graph.parse(path, format="turtle")
-          print(f"Parsed release graph with {len(graph)} triples.")
-          PY
-
-      - name: Upload validation artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: ontouml-models-release-pr-${{ github.event.pull_request.number }}
-          path: results/ontouml-models-19700101.ttl
-          if-no-files-found: error
-          retention-days: 30
-
   generate-and-publish-release:
     name: Generate and publish release
     if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
@@ -145,58 +63,15 @@ jobs:
       - name: Run release-generator tests
         run: python -m pytest -q scripts/tests/test_generate_release_file.py
 
-      - name: Synchronize catalog metadata
+      - name: Check catalog synchronization
         id: catalog
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          INPUT_DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || 'false' }}
-          INPUT_PUBLISH_RELEASE: ${{ github.event_name == 'workflow_dispatch' && inputs.publish_release || 'false' }}
         run: |
           set -euo pipefail
-
-          python scripts/generate_catalog_file.py .
-
-          catalog_changed="false"
-          if ! git diff --quiet -- catalog.ttl; then
-            catalog_changed="true"
-          fi
-
-          should_commit="false"
-          if [ "$EVENT_NAME" = "schedule" ]; then
-            should_commit="true"
-          elif [ "$EVENT_NAME" = "workflow_dispatch" ] &&
-               [ "$INPUT_DRY_RUN" != "true" ] &&
-               [ "$INPUT_PUBLISH_RELEASE" = "true" ]; then
-            should_commit="true"
-          fi
-
-          if [ "$catalog_changed" = "true" ] && [ "$should_commit" = "true" ]; then
-            if [ "$GITHUB_REF" != "refs/heads/master" ]; then
-              echo "Publishing releases and committing catalog synchronization are only allowed from refs/heads/master; current ref is $GITHUB_REF." >&2
-              exit 1
-            fi
-
-            git config user.name "github-actions[bot]"
-            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            git add -- catalog.ttl
-            git commit -m "chore(catalog): synchronize catalog metadata"
-
-            if ! git push origin "HEAD:${GITHUB_REF_NAME}"; then
-              echo "Could not push the synchronized catalog.ttl to ${GITHUB_REF_NAME}." >&2
-              echo "No release was published. Check branch rules or concurrent updates, then rerun the workflow." >&2
-              exit 1
-            fi
-          fi
-
-          final_release_sha="$(git rev-parse HEAD)"
-          {
-            echo "catalog_changed=$catalog_changed"
-            echo "final_release_sha=$final_release_sha"
-          } >> "$GITHUB_OUTPUT"
-
-          echo "Catalog changed: $catalog_changed"
-          echo "Catalog synchronization committed: $([ "$catalog_changed" = "true" ] && [ "$should_commit" = "true" ] && echo true || echo false)"
-          echo "Final release commit: $final_release_sha"
+          # PR validation establishes the complete catalog before merge.
+          # Publishing must not bypass the required check by pushing to master.
+          python scripts/generate_catalog_file.py . --check
+          echo "catalog_changed=false" >> "$GITHUB_OUTPUT"
+          echo "final_release_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Resolve release settings
         id: settings

--- a/.github/workflows/validate-pr-state.yml
+++ b/.github/workflows/validate-pr-state.yml
@@ -1,0 +1,57 @@
+name: Validate final PR state
+run-name: PR ${{ inputs.pr_number }} head ${{ inputs.head_sha }} base ${{ inputs.base_sha }} check ${{ inputs.check_id }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number supplied by the trusted controller"
+        required: true
+        type: string
+      head_sha:
+        description: "Exact final PR head"
+        required: true
+        type: string
+      base_sha:
+        description: "Exact trusted master commit"
+        required: true
+        type: string
+      check_id:
+        description: "Dedicated App check run ID"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  validate:
+    # This job is unconditional. The trusted harness implements applicability;
+    # the reporter never treats a skipped/neutral job as successful validation.
+    name: Validate applicable final state
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Check out trusted harness
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ github.sha }}
+          path: trusted
+          persist-credentials: false
+      - name: Check out the exact final head without credentials
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          ref: ${{ inputs.head_sha }}
+          path: candidate
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Verify immutable head, base ancestry and complete applicability
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          HEAD_SHA: ${{ inputs.head_sha }}
+          BASE_SHA: ${{ inputs.base_sha }}
+        run: python trusted/scripts/validate_pr_state.py prepare
+      - name: Validate final data, proposed code and workflows in isolated containers
+        run: python trusted/scripts/validate_pr_state.py containers

--- a/scripts/pr-validation.md
+++ b/scripts/pr-validation.md
@@ -1,0 +1,327 @@
+# PR processing, final-state validation and merge gating
+
+The required check is **PR validation**, created by a dedicated GitHub App on
+the actual PR head SHA. A successful controller job alone never authorizes a
+merge. The repository configuration below is required; copying workflow files
+does not configure branch rules, install an App or create secrets.
+
+## Architecture
+
+`pr-validation.yml` runs trusted base-branch code for every PR targeting
+`master`, without a path filter. It obtains the complete paginated PR file list,
+including previous paths for renames, and opens a pending App check before
+classification. Missing, inconsistent or over-3,000-file API results fail closed.
+
+1. Classify the changes and identify required generation.
+2. If applicable, run existing trusted generators on a regular-file-only copy
+   of contributor model/catalog data, without write credentials.
+3. Validate an allowlisted generated bundle from that same run and attempt.
+   Commit only if changes exist, using GraphQL `createCommitOnBranch` with
+   `expectedHeadOid`. A concurrent contributor update rejects the commit.
+4. Advance the pending check to final validation (or create one on the new SHA
+   after writeback) and explicitly dispatch
+   `validate-pr-state.yml` from `master`, with the PR number, head, base and check
+   ID. When the head changes, mark the old-head processing check as superseded,
+   never successful. An unchanged head keeps its single pending check.
+5. Validate the immutable final checkout. Check that its head/base still match
+   the PR and that the current base is an ancestor. The trusted harness runs
+   applicable data checks, candidate tests and workflow lint in isolated
+   containers. It checks required model outputs **before** regenerating in a
+   temporary directory; regeneration must leave the final data unchanged.
+6. A `workflow_run` reporter verifies the exact workflow path, dispatch event,
+   trusted base SHA/branch, run title, App/check identity, final-validation phase,
+   newest check, latest run attempt, live PR head/base, and the successful
+   unconditional validation job. It does not consume validation artifacts.
+   Only then does it complete the App check successfully.
+
+`Process new model submission` remains available for trusted manual maintenance;
+it no longer has a PR trigger. `Publish models release` retains scheduled/manual
+publication but no longer races PR generation. Publication checks an already
+synchronized catalog instead of committing directly to protected `master`.
+No generator semantics, model metadata or dependencies were changed.
+
+## Applicability
+
+| Change | Processing | Final validation |
+| --- | --- | --- |
+| Markdown / `documentation/**` only | None | Git whitespace checks; changed Markdown UTF-8/conflict checks; regular-file snapshot safety |
+| Scripts, dependencies, workflow/configuration files | No model generation | Full script tests, trusted catalog/release checks, candidate catalog/release checks; actionlint for workflow changes |
+| One model folder, including deleted generated artifacts | Existing submission helper, then catalog synchronization | Source envelope, required output inventory, no-drift regeneration, model RDF, catalog check and release generation/parse |
+| Entire one-model folder removed | Catalog synchronization | Verify full deletion and final catalog/release consistency |
+| Multi-model generated-only maintenance | None | All six ontology/distribution/model-metadata generator checks, RDF and catalog/release validation |
+| `catalog.yaml` | Catalog synchronization | No-drift catalog generation, catalog/release checks |
+| `catalog.ttl` only | None | Catalog/release checks |
+| `shapes/**` | None | Parse changed Turtle shapes |
+| Mixed changes | Union of applicable processing | Union of applicable validations |
+
+The existing bulk boundary permits only direct automation-generated output
+changes across models: `ontology.ttl`, `metadata.ttl`, `metadata-json.ttl`,
+`metadata-turtle.ttl`, `metadata-vpp.ttl`, and files matching
+`metadata-png-(n|o)-*.ttl`. Deletions, nested paths, unknown metadata names and
+multiple-model source changes fail closed. Final validation checks all six
+generator families. Unknown configuration files conservatively select script
+and catalog checks. No documentation build/link checker existed; this change
+adds only the lightweight documentation checks above, not a new documentation
+toolchain. Existing source requirements, including VPP and PNG requirements,
+remain unchanged.
+
+## Trust boundary
+
+- The `pull_request_target` controller checks out the trusted base separately
+  from contributor data. The data checkout's explicit unsafe-checkout opt-in
+  does **not** authorize executing that checkout. Only tracked regular
+  `models/**`, `catalog.yaml` and `catalog.ttl` files enter generation; symlinks,
+  submodules and unsafe paths are rejected. Trusted scripts/dependencies come
+  from the base. Contributor scripts, actions and dependencies never execute in
+  `pull_request_target` or in a secret-bearing reporter/writeback job.
+- Generation has only `contents: read`. The subsequent writer has no PR code
+  checkout and accepts only model metadata, ontology Turtle, metadata YAML
+  normalization and root catalog output. It cannot write PR workflow files,
+  scripts, JSON/VPP sources or unrelated model folders.
+- Final validation is explicitly dispatched from the default branch with a
+  read-only token and no environment/App secret. Candidate code and dependency
+  installation run in a separate disposable Docker container from trusted data
+  validation. Containers have read-only source mounts, a non-root user, dropped
+  capabilities, no added privileges, and temporary writable storage. They do
+  not receive host environment variables, tokens, credentials, caches, runtime
+  artifact credentials, host `.git`, or the Docker socket. Public dependency
+  downloads require network access; workflow lint has no network access.
+- Automatic execution of fork-proposed code/dependencies is not authorized by
+  this dispatch mechanism. A fork PR with code/configuration changes first
+  blocks with an explanation; a maintainer must dispatch the controller from
+  `master` with its PR number. GitHub requires repository write access for a
+  manual workflow run, and the controller additionally requires a User sender,
+  not a bot dispatch. This is a deliberate authorization step for untrusted
+  fork code, distinct from technical validation. New contributor commits need
+  authorization again; the resulting generated bot head is validated by the
+  same authorized processing chain. Fork model-data/documentation PRs execute
+  only trusted tools and do not require this code-execution authorization.
+- The App private key must exist **only** in the restricted `pr-automation`
+  environment. A repository-wide secret would let an added same-repository PR
+  workflow request it and forge the required App check. The environment's
+  selected-branch policy, not a PR-editable YAML condition, enforces this boundary.
+- The required check must be pinned to this dedicated App's integration ID.
+  Requiring a name from “any source” or from the shared GitHub Actions App would
+  allow unrelated PR-controlled workflows to imitate it.
+- Fork writeback requires an App installation authorized by the fork owner on
+  that repository. The writer obtains a token restricted to that one fork and
+  `contents: write`. No privileged token is passed to fork code. Without this
+  authorization, a model PR remains blocked with a token/writeback error; a
+  maintainer may instead process an authorized same-repository submission branch.
+- Legacy manual maintenance still executes the selected branch's scripts with
+  its existing write mode. Only dispatch it on reviewed/trusted branches. The
+  automatic controller is the supported way to recover an untrusted PR.
+
+Use GitHub-hosted ephemeral runners. Do not replace them with a persistent
+self-hosted runner for untrusted validation. Review future generator/parser
+changes as part of the trusted processing boundary.
+
+## Bot updates, concurrency and stale results
+
+Same-repository generated commits use `GITHUB_TOKEN`. Current GitHub behavior
+creates approval-required `pull_request` runs for token-generated
+opened/synchronize/reopened events; ordinary token-generated `push` events do
+not recursively start workflows. This implementation removes the old automatic
+PR consumers and uses the documented `workflow_dispatch` exception explicitly.
+It never depends on a token-generated event starting follow-up validation.
+
+Fork App writeback can emit a new PR event. Per-PR controller concurrency
+serializes it after writeback; an authenticated matching App actor with a
+matching pending/successful final check does not repeat generation. Commit
+messages and claimed Git authors are not used as authorization. Manual recovery
+is never suppressed by this bot check. There are no sleeps or polling loops.
+
+Different heads have different App checks. Reporters reject stale heads/bases
+and old attempts, and do not complete an older check when a newer App check for
+the same head exists. Required-check rules apply to the current SHA; an older
+successful commit is insufficient. Strict up-to-date checks additionally prevent
+an outdated base from being merged. Update the PR branch after `master` changes;
+the new head re-enters processing. Merge queue is not configured or supported
+by this design; add a reviewed `merge_group` path before enabling it.
+
+Failed generation prevents dispatch. Failed/skipped/cancelled/neutral/pending
+validation cannot produce success. If an outage or cancellation prevents the
+reporter from completing, the gate stays pending and blocks merge; use recovery.
+The obsolete source-head processing check can display failure ("superseded");
+the final head's App check represents eligibility. Native workflow
+jobs, including intentionally skipped generation, are not individually required.
+
+## External repository configuration
+
+These are **administrator actions**, separate from the repository ZIP. Do not
+activate an incomplete setup on a busy repository. No setting is changed by
+these files or by local tests.
+
+1. Create a dedicated GitHub App (for example `ontouml-pr-validation`) with
+   repository **Checks: read and write**, **Commit statuses: read and write**,
+   **Contents: read and write**, and implicit **Metadata: read**. No webhook
+   subscriptions or organization/user permissions are needed. Permit
+   installation by other accounts if fork
+   writeback is offered. Install it on the selected catalog repository. Fork
+   owners separately authorize installation on their selected fork; enabling
+   Actions write tokens/secrets for fork PRs is neither needed nor permitted.
+2. Create environment **`pr-automation`** in repository Settings → Environments.
+   Select **Selected branches and tags** and add exactly one **Branch** rule:
+   **`master`**. Add no tag rule, wildcard or PR merge-ref rule. Do not use
+   “Protected branches only” (it can permit all branches if none are protected).
+   Set no required environment reviewers and no wait timer, and disable
+   administrator bypass. Store **`PR_AUTOMATION_APP_PRIVATE_KEY`** only as an
+   environment secret. Remove any broader copy of this key. Set repository
+   Actions variable **`PR_AUTOMATION_APP_ID`** to the numeric App ID (not its
+   installation ID). Keep ordinary fork approval/security policies unchanged.
+3. Create a separate active branch ruleset **`PR automated validation`**, target
+   **`refs/heads/master`**, with **no bypass actors**, including administrators
+   and the App. Enable **Require status checks to pass** with context exactly
+   **`PR validation`**, expected source **the dedicated App** (its integration
+   ID), and **Require branches to be up to date before merging**. Set
+   `do_not_enforce_on_create: false` if using the REST ruleset representation.
+   Do not require individual model/release/native controller jobs.
+4. Keep human review policy in a separate ruleset. A review bypass in that
+   ruleset must not bypass the no-bypass automated-validation ruleset. Retain
+   existing deletion/force-push protections. Inspect any legacy branch
+   protection and remove obsolete path-filtered required checks only when
+   replacing them with the stable App gate; do not weaken unrelated rules.
+
+Inspect the App source and successful check in a test PR before making it
+required; GitHub's selector requires a recently successful check. Bootstrap in
+an isolated test repository whose **default branch is `master`** and contains
+this implementation. `workflow_dispatch` and `workflow_run` require workflow
+definitions on the default branch, so an implementation PR cannot exercise
+the new controller end-to-end before that deployment.
+
+For production rollout: obtain authorization, merge the reviewed implementation
+under the current policy, configure the App/environment, run a controlled PR
+through final validation, then activate and verify the required App check.
+Do not merge other PRs during this controlled transition. Re-evaluate already
+open PRs via manual recovery. Confirm both administrators and ordinary maintainers
+are blocked by failing/pending automated checks. A missing App/configuration is
+not a reason to merge without the gate.
+
+### Configuration inspected for this change
+
+At `master` commit `1e7149af010fb6a85c6928f54fcb5ad60e01d26f`, rechecked on
+2026-09-01, visible active ruleset `21749910` (`master-1`) protects
+deletion/non-fast-forward updates with
+no bypass. Ruleset `21749911` (`master-2`) requires PRs with zero ordinary
+approvals, enables extra approval for unattributed changes, and allows an
+administrator-role bypass. Neither visible ruleset contains required status
+checks. The classic branch-protection endpoint returned HTTP 403; its complete
+configuration was not accessible and is not assumed absent. The unattributed
+change approval setting is a human authorization concern, separate from an
+Actions run's `action_required` state and the new automated gate.
+
+## Regression evidence: PR #357
+
+The [regression PR](https://github.com/OntoUML/ontouml-models/pull/357) used a
+same-repository branch. Human source commit
+`16548d285659c0b16b94379b505c7aa718cbb310` deliberately removed generated TKTOnto
+artifacts. Both workflows started at 17:17:45 UTC on 2026-08-28.
+
+The [failed release run](https://github.com/OntoUML/ontouml-models/actions/runs/33194012789)
+passed dependency installation and ontology/catalog tests, then failed catalog
+synchronization at 17:18:43; later release validation was skipped. Processing
+run `33194012755` finished at 17:19:07 after writing bot commit
+`238e6f827830f9a44cae63ef6c4343bc7e817baa` at 17:19:03. Thus the failing release
+check evaluated a state the other workflow had not yet finished establishing.
+
+Bot-head release run `33194119694`, attempt 1, concluded `action_required` with
+`github-actions[bot]` as actor/triggering actor. Attempt 2 succeeded after
+`pedropaulofb` triggered it. The existing workflow writes using checkout's
+default `GITHUB_TOKEN`; GitHub's documented token-generated PR approval rule
+explains this same-repository bot behavior without invoking first-time fork
+approval as an explanation. The replacement explicitly validates the bot head
+and does not need that approval-dependent follow-up path.
+
+## Regression evidence: PR #360
+
+[PR #360](https://github.com/OntoUML/ontouml-models/pull/360), merged as
+`8a51a23312ca124e887fccb3eb76bf85584ed359`, changed 394 direct generated
+metadata files across 42 model folders: 42 each of `metadata-json.ttl`,
+`metadata-turtle.ttl`, `metadata-vpp.ttl`, and `metadata.ttl`, plus 226
+`metadata-png-*.ttl` files. That is generated-only catalog maintenance, not 42
+source submissions. The classifier accepts exactly those generated families
+without invoking model generation; final validation checks the corresponding
+six generators. Deletions and unrecognized metadata names still fail closed.
+
+## Local validation and limits
+
+`scripts/tests/test_pr_automation.py` covers classification, renames/pagination,
+unsafe paths, PR #360 bulk metadata, missing outputs, generation failure,
+atomic writeback ordering,
+no-op generation, stale head/base/attempts/checks, result/source spoofing,
+documentation/script cases, and workflow/container boundaries. Existing
+generator tests continue to cover source conversion and metadata behavior.
+
+From the repository root with Python 3.11+ and actionlint 1.7.12 on PATH:
+
+```cmd
+python -m pip install -r scripts/requirements.txt
+```
+
+```cmd
+python -m pytest -q scripts/tests/test_pr_automation.py && actionlint -shellcheck= && git diff --check
+```
+
+```cmd
+python -m pytest -q scripts/tests && python scripts/generate_catalog_file.py . --check
+```
+
+The container workflow runs actionlint with ShellCheck disabled explicitly;
+it still validates workflow syntax, expressions, action inputs and dependencies.
+These local tests do not prove GitHub event delivery, permissions, App check
+association, Docker runtime behavior or actual merge denial. Verify those in
+the live matrix after authorized deployment. Do not infer live success from an
+API fake or from a previously completed run using an older implementation.
+
+## Live GitHub regression matrix
+
+Use separate disposable PRs and inspect check SHA/source and the merge box.
+Leave other PRs unmerged until activation is verified.
+
+| Scenario | Required observation |
+| --- | --- |
+| 1. Source-only model; derived files absent (PR #357 equivalent) | Pending gate before generation; derived files committed; head changes; no release validation before writeback; final head passes inventory, no-drift, catalog and release checks before merge is allowed |
+| 2. Invalid source / generation failure | Generation fails, no final dispatch or success, merge blocked |
+| 3. Valid generation plus failing applicable test/validation | Generated head exists but gate fails; merge blocked |
+| 4. Documentation only | Generation skipped as not applicable; documentation validation completes; no required model workflow left pending |
+| 5. Script/generator/workflow change | Candidate tests, catalog/release checks and applicable workflow lint run; no model generation without model/catalog input changes |
+| 6. New commit after success (also during generation/validation) | Old result cannot authorize new SHA; atomic writer cannot overwrite it; new head must pass; base advancement requires updating the PR branch |
+| 7. Bot-generated artifacts | Exactly the required writeback; explicit final-head validation; no recursive commits; no approval-required legacy PR workflow; same-repository and authorized-fork cases both exercised |
+| 8. Multi-model generated distribution metadata (PR #360 equivalent) | No model generation/writeback; all six generator checks run against the final head; exact generated families pass while deletions/unknown names block |
+
+Also verify fork models without an App installation fail closed, forks without
+generation need no fork write token, fork code changes cannot run without a
+maintainer-authorized controller dispatch, a PR-added job cannot access the environment
+key or spoof the App gate, and cancelled/old attempts cannot produce success.
+Prove admin review bypass cannot bypass pending/failed automated validation.
+
+## Recovery
+
+Resolve the actual generation, permission, configuration or validation error.
+If the base advanced, merge/rebase the current `master` into the PR branch.
+Then use Actions → **Orchestrate PR validation** → **Run workflow**, select
+`master`, and enter the open PR number. This performs classification and
+processing again, then validates the current head; idempotent generation does
+not make another commit. Do not rerun an obsolete head to approve a new one.
+
+Equivalent **authorized external action**, with `PR_NUMBER` replaced by the
+actual open PR number:
+
+```cmd
+gh workflow run pr-validation.yml --repo OntoUML/ontouml-models --ref master -f pr_number=PR_NUMBER
+```
+
+This dispatch may commit generated files to that PR branch; it is not a
+read-only local test. Do not bypass the check or grant fork secrets to recover.
+
+## GitHub semantics used
+
+- [Workflow-generated events and the GITHUB_TOKEN approval exception](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow)
+- [Authorization to run a workflow manually](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow)
+- [Event refs, workflow_dispatch, pull_request_target and workflow_run](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows)
+- [Required checks: current SHA, skipped jobs, path filters and expected source](https://docs.github.com/en/pull-requests/how-tos/merge-and-close-pull-requests/troubleshooting-required-status-checks)
+- [Checks API: check head_sha, external identity and results](https://docs.github.com/en/rest/checks/runs)
+- [GraphQL commit operations and expectedHeadOid](https://docs.github.com/en/graphql/reference/commits)
+- [Secure use of pull_request_target](https://docs.github.com/en/actions/reference/security/securely-using-pull_request_target)
+- [Environment branch restrictions and secret availability](https://docs.github.com/en/actions/reference/workflows-and-actions/deployments-and-environments)
+- [Available repository rules and required-check source selection](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/available-rules-for-rulesets)

--- a/scripts/pr_automation.py
+++ b/scripts/pr_automation.py
@@ -1,0 +1,462 @@
+"""Trusted PR controller. Never import or execute files from a PR checkout.
+
+The dedicated App owns the required check; GitHub Actions job names are not
+merge credentials. See pr-validation.md for the required environment/ruleset.
+"""
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import urllib.error
+import urllib.request
+from pathlib import Path, PurePosixPath
+
+CHECK_NAME = "PR validation"
+BASE_BRANCH = "master"
+VALIDATION_WORKFLOW = "validate-pr-state.yml"
+VALIDATION_JOB = "Validate applicable final state"
+SHA = re.compile(r"[0-9a-f]{40}\Z")
+RUN_TITLE = re.compile(r"PR ([1-9][0-9]*) head ([0-9a-f]{40}) base ([0-9a-f]{40}) check ([1-9][0-9]*)\Z")
+BULK_FILES = {
+    "ontology.ttl",
+    "metadata.ttl",
+    "metadata-json.ttl",
+    "metadata-turtle.ttl",
+    "metadata-vpp.ttl",
+}
+BULK_PNG_FILE = re.compile(r"metadata-png-(?:n|o)-.+\.ttl\Z")
+MAX_BUNDLE_BYTES = 64 * 1024 * 1024
+
+
+class AutomationError(RuntimeError):
+    """A failure that must leave the merge gate closed."""
+
+
+def require(condition, message):
+    if not condition:
+        raise AutomationError(message)
+
+
+def safe_path(value):
+    require(isinstance(value, str) and bool(value), "Empty or invalid path")
+    path = PurePosixPath(value)
+    require(not path.is_absolute() and str(path) == value and "\\" not in value
+            and not re.search(r"[\x00-\x1f\x7f]", value)
+            and not any(part in {"..", ".git"} for part in path.parts),
+            f"Unsafe repository path: {value!r}")
+    return value
+
+
+def bulk_generated_file(name):
+    """Return whether a direct model file is automation-generated bulk output."""
+    return name in BULK_FILES or bool(BULK_PNG_FILE.fullmatch(name))
+
+
+def classify(files):
+    """Classify a complete diff, including both sides of renames.
+
+    Preserve the existing one-model / bulk-generated boundary. Mixed changes
+    take the union of applicable validation, not an exclusive first match.
+    """
+    paths, removed = set(), set()
+    for item in files:
+        path = safe_path(item["filename"])
+        paths.add(path)
+        if item["status"] == "removed":
+            removed.add(path)
+        if item.get("previous_filename"):
+            previous = safe_path(item["previous_filename"])
+            paths.add(previous)
+            removed.add(previous)
+    require(bool(paths), "No changed files; refusing an empty classification")
+    model_paths = sorted(path for path in paths if path.startswith("models/") and not path.lower().endswith(".md"))
+    require(all(len(PurePosixPath(path).parts) >= 3 for path in model_paths),
+            "Model paths must be within a direct models/<slug> folder")
+    folders = sorted({"/".join(path.split("/")[:2]) for path in model_paths})
+    mode = "none"
+    if len(folders) == 1:
+        mode = "normal"
+    elif folders:
+        require(all(len(path.split("/")) == 3 and bulk_generated_file(path.split("/")[-1])
+                    and path not in removed for path in model_paths),
+                "Multiple models require generated-only maintenance; split source submissions")
+        mode = "bulk-generated"
+    docs = sorted(path for path in paths if path.lower().endswith(".md"))
+    workflows = any(path.startswith(".github/workflows/") for path in paths)
+    shapes = any(path.startswith("shapes/") for path in paths)
+    code = any(not (path.startswith(("models/", "documentation/", "shapes/"))
+                       or path.lower().endswith(".md")
+                       or path in {"catalog.yaml", "catalog.ttl"}) for path in paths)
+    catalog = bool(folders) or code or bool(paths & {"catalog.yaml", "catalog.ttl"})
+    return {"mode": mode, "models": folders, "paths": sorted(paths), "removed": sorted(removed),
+            "docs": docs, "code": code, "workflows": workflows, "shapes": shapes,
+            "catalog": catalog, "generate": mode == "normal" or "catalog.yaml" in paths}
+
+
+def git(root, *args):
+    return subprocess.check_output(["git", "-C", str(root), *args])
+
+
+def copy_tracked(source, destination, *, data_only=False):
+    """Export only regular tracked files. Reject symlinks, submodules and traversal."""
+    destination.mkdir(parents=True, exist_ok=True)
+    for record in git(source, "ls-tree", "-rz", "HEAD").split(b"\0"):
+        if not record:
+            continue
+        header, raw_path = record.split(b"\t", 1)
+        mode, kind, _ = header.decode("ascii").split()
+        path = safe_path(raw_path.decode("utf-8"))
+        if data_only and not (path.startswith("models/") or path in {"catalog.yaml", "catalog.ttl"}):
+            continue
+        require(kind == "blob" and mode in {"100644", "100755"}, f"Non-regular tracked file: {path}")
+        src = source / path
+        require(src.is_file() and not src.is_symlink()
+                and source.resolve() in src.resolve().parents, f"Unsafe checkout file: {path}")
+        dest = destination / path
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(src, dest)
+
+
+def data_workspace(trusted, source, destination):
+    copy_tracked(source, destination, data_only=True)
+    shutil.copytree(trusted / "scripts", destination / "scripts", ignore=shutil.ignore_patterns("__pycache__"))
+    (destination / "models").mkdir(exist_ok=True)
+
+
+def file_hashes(root):
+    result = {}
+    for parent in (root / "models", root / "catalog.yaml", root / "catalog.ttl"):
+        paths = parent.rglob("*") if parent.is_dir() else [parent]
+        for path in paths:
+            if path.is_file():
+                require(not path.is_symlink(), "Generation produced a symlink")
+                result[path.relative_to(root).as_posix()] = hashlib.sha256(path.read_bytes()).hexdigest()
+    return result
+
+
+def process_data(root, plan):
+    """Reuse the current generators, executing only the trusted scripts copy."""
+    if plan["mode"] == "normal":
+        model = plan["models"][0]
+        if (root / model).is_dir():
+            subprocess.run([sys.executable, "scripts/process_new_model_submission.py", model,
+                            "--repository", "OntoUML/ontouml-models", "--branch", BASE_BRANCH],
+                           cwd=root, check=True)
+        else:
+            require(all(path in plan["removed"] for path in plan["paths"]
+                        if path.startswith(model + "/")), "Missing model folder is not a complete deletion")
+    if plan["catalog"]:
+        subprocess.run([sys.executable, "scripts/generate_catalog_file.py", "."], cwd=root, check=True)
+
+
+def allowed_output(path, plan):
+    if path == "catalog.ttl":
+        return plan["catalog"]
+    parts = path.split("/")
+    return (plan["mode"] == "normal" and len(parts) == 3
+            and "/".join(parts[:2]) == plan["models"][0]
+            and (parts[2] in {"metadata.yaml", "ontology.ttl", "metadata.ttl"}
+                 or (parts[2].startswith("metadata-") and parts[2].endswith(".ttl"))))
+
+
+def validate_bundle(bundle, plan):
+    require(bundle.get("head") == plan["head"] and bundle.get("base") == plan["base"], "Stale generation bundle")
+    additions = bundle.get("additions", [])
+    require(isinstance(additions, list), "Invalid bundle additions")
+    seen, total = set(), 0
+    for item in additions:
+        require(set(item) == {"path", "contents"}, "Unexpected bundle fields")
+        path = safe_path(item["path"])
+        require(path not in seen and allowed_output(path, plan), f"Out-of-scope generated file: {path}")
+        seen.add(path)
+        try:
+            contents = base64.b64decode(item["contents"], validate=True)
+        except (ValueError, TypeError) as exc:
+            raise AutomationError("Invalid generated file encoding") from exc
+        total += len(contents)
+        require(total <= MAX_BUNDLE_BYTES, "Generated bundle exceeds 64 MiB")
+    require(set(bundle) == {"head", "base", "additions"}, "Unexpected generation bundle fields")
+    return additions
+
+
+def generate(trusted, candidate, plan, output):
+    require(git(candidate, "rev-parse", "HEAD").decode().strip() == plan["head"], "Wrong generation head")
+    require(git(trusted, "rev-parse", "HEAD").decode().strip() == plan["base"], "Wrong trusted base")
+    with tempfile.TemporaryDirectory(prefix="ontouml-pr-generation-") as temp:
+        root = Path(temp)
+        data_workspace(trusted, candidate, root)
+        before = file_hashes(root)
+        process_data(root, plan)
+        after = file_hashes(root)
+        require(not (before.keys() - after.keys()), "Generators unexpectedly removed files")
+        additions = [{"path": path, "contents": base64.b64encode((root / path).read_bytes()).decode("ascii")}
+                     for path in sorted(after) if before.get(path) != after[path]]
+        bundle = {"head": plan["head"], "base": plan["base"], "additions": additions}
+        validate_bundle(bundle, plan)
+        output.write_text(json.dumps(bundle), encoding="utf-8")
+        return bundle
+
+
+class GitHub:
+    def __init__(self, repo, token):
+        require(bool(re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", repo)), "Invalid repository")
+        require(bool(token), "Missing GitHub token")
+        self.repo, self.token = repo, token
+
+    def request(self, method, path, body=None):
+        url = "https://api.github.com" + path
+        data = None if body is None else json.dumps(body).encode("utf-8")
+        request = urllib.request.Request(url, data=data, method=method, headers={
+            "Authorization": f"Bearer {self.token}", "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28", "Content-Type": "application/json"})
+        try:
+            with urllib.request.urlopen(request, timeout=60) as response:
+                raw = response.read()
+                return json.loads(raw) if raw else None
+        except urllib.error.HTTPError as exc:
+            raise AutomationError(f"GitHub {method} {path} failed (HTTP {exc.code})") from exc
+
+    def api(self, method, path, body=None):
+        return self.request(method, f"/repos/{self.repo}/{path}", body)
+
+    def pr(self, number):
+        pr = self.api("GET", f"pulls/{int(number)}")
+        require(pr["state"] == "open" and pr["base"]["ref"] == BASE_BRANCH
+                and pr["base"]["repo"]["full_name"] == self.repo, "PR is closed or has an unsupported base")
+        require(pr["head"]["repo"] is not None, "PR source repository is unavailable")
+        require(not (pr["head"]["repo"]["full_name"] == self.repo and pr["head"]["ref"] == BASE_BRANCH),
+                "Refusing to write to the protected base branch")
+        require(SHA.fullmatch(pr["head"]["sha"]) and SHA.fullmatch(pr["base"]["sha"]), "Invalid GitHub SHA")
+        return pr
+
+    def files(self, pr):
+        count = pr["changed_files"]
+        require(0 < count <= 3000, "PR file list exceeds API coverage; split this PR")
+        files = []
+        for page in range(1, (count + 99) // 100 + 1):
+            files.extend(self.api("GET", f"pulls/{pr['number']}/files?per_page=100&page={page}"))
+        require(len(files) == count and len({item["filename"] for item in files}) == count,
+                "Incomplete or changing PR file list")
+        return files
+
+    def check(self, check_id):
+        return self.api("GET", f"check-runs/{int(check_id)}")
+
+    def checks(self, head):
+        # filter=latest is completion-time based. Inspect all matching runs so
+        # an older completion cannot hide a newer pending check.
+        result = []
+        for page in range(1, 11):
+            response = self.api("GET", f"commits/{head}/check-runs?check_name=PR%20validation&filter=all&per_page=100&page={page}")
+            result.extend(response["check_runs"])
+            if len(result) >= response["total_count"]:
+                return result
+        raise AutomationError("Too many matching checks to establish the newest check safely")
+
+    def start_check(self, plan, phase, check_id=None):
+        marker = {key: plan[key] for key in ("pr", "head", "base", "controller")}
+        marker["phase"] = phase
+        body = {
+            "name": CHECK_NAME, "head_sha": plan["head"], "status": "in_progress",
+            "external_id": json.dumps(marker, separators=(",", ":")),
+            "details_url": f"https://github.com/{self.repo}/actions/runs/{plan['controller']}",
+            "output": {"title": "Processing required" if phase == "processing" else "Final validation pending",
+                       "summary": f"PR #{plan['pr']}; head `{plan['head']}`; base `{plan['base']}`. Merge remains blocked."}}
+        if check_id is not None:
+            del body["head_sha"]  # A check's SHA is immutable.
+            self.api("PATCH", f"check-runs/{int(check_id)}", body)
+            return int(check_id)
+        return self.api("POST", "check-runs", body)["id"]
+
+    def finish_check(self, check_id, success, summary, details_url=None):
+        body = {"status": "completed", "conclusion": "success" if success else "failure",
+                "output": {"title": "All applicable validations passed" if success else "PR validation blocked",
+                           "summary": summary[:60000]}}
+        if details_url:
+            body["details_url"] = details_url
+        self.api("PATCH", f"check-runs/{int(check_id)}", body)
+
+
+def same_state(pr, plan):
+    require(pr["head"]["sha"] == plan["head"] and pr["base"]["sha"] == plan["base"],
+            "PR head or base changed; this run cannot authorize the new state")
+
+
+def check_marker(check, app_id):
+    require(check["name"] == CHECK_NAME and check["app"]["id"] == int(app_id), "Wrong check source")
+    try:
+        marker = json.loads(check["external_id"])
+    except (TypeError, ValueError) as exc:
+        raise AutomationError("Unrecognized check identity") from exc
+    require(marker["head"] == check["head_sha"], "Check SHA identity mismatch")
+    return marker
+
+
+def already_dispatched(checks, pr, app_id, actor, app_slug):
+    if actor != app_slug + "[bot]":
+        return False
+    owned = [check for check in checks if check.get("app", {}).get("id") == int(app_id)]
+    for check in sorted(owned, key=lambda item: item["id"], reverse=True)[:1]:
+        marker = check_marker(check, app_id)
+        if (marker.get("phase") == "validation" and marker.get("pr") == pr["number"]
+                and marker.get("head") == pr["head"]["sha"] and marker.get("base") == pr["base"]["sha"]
+                and (check["status"] != "completed" or check.get("conclusion") == "success")):
+            return True
+    return False
+
+
+def output_values(**values):
+    with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as stream:
+        for key, value in values.items():
+            text = json.dumps(value, separators=(",", ":")) if isinstance(value, (dict, list, bool)) else str(value)
+            require("\n" not in text and "\r" not in text, "Unsafe workflow output")
+            stream.write(f"{key}={text}\n")
+
+
+def prepare(read_api, checks_api, number, *, controller, app_id, actor, app_slug, automatic, manual_user=False):
+    pr = read_api.pr(number)
+    if automatic and already_dispatched(checks_api.checks(pr["head"]["sha"]), pr, app_id, actor, app_slug):
+        output_values(skip=True)
+        return
+    plan = {"pr": pr["number"], "head": pr["head"]["sha"], "base": pr["base"]["sha"],
+            "controller": int(controller), "head_repo": pr["head"]["repo"]["full_name"], "head_ref": pr["head"]["ref"]}
+    check_id = checks_api.start_check(plan, "processing")
+    output_values(check_id=check_id)
+    try:
+        plan.update(classify(read_api.files(pr)))
+        same_state(read_api.pr(number), plan)
+        require(not (plan["code"] and plan["head_repo"] != read_api.repo)
+                or (not automatic and manual_user),
+                "Fork code/dependency changes require a maintainer to dispatch Orchestrate PR validation "
+                "on master with this PR number. Automatic dispatch must not bypass fork code-execution approval.")
+        owner, name = plan["head_repo"].split("/")
+        output_values(plan=plan, head=plan["head"], base=plan["base"], generate=plan["generate"],
+                      fork=plan["head_repo"] != read_api.repo, owner=owner, repository=name, skip=False)
+        print("Applicable processing: " + json.dumps(plan, sort_keys=True))
+    except Exception as exc:
+        checks_api.finish_check(check_id, False, f"Processing cannot start: {exc}")
+        raise
+
+
+def create_commit(write_api, plan, additions):
+    query = """mutation($input: CreateCommitOnBranchInput!) {
+      createCommitOnBranch(input: $input) { commit { oid } }
+    }"""
+    result = write_api.request("POST", "/graphql", {"query": query, "variables": {"input": {
+        "branch": {"repositoryNameWithOwner": plan["head_repo"], "branchName": plan["head_ref"]},
+        "expectedHeadOid": plan["head"], "message": {"headline": "chore(metadata): synchronize PR generated artifacts"},
+        "fileChanges": {"additions": additions}}}})
+    require(not result.get("errors"), "Atomic generated commit rejected; branch may have changed")
+    head = result["data"]["createCommitOnBranch"]["commit"]["oid"]
+    require(bool(SHA.fullmatch(head)), "Commit API did not return a SHA")
+    return head
+
+
+def publish(read_api, checks_api, write_api, plan, check_id, bundle=None):
+    active_check = check_id
+    try:
+        same_state(read_api.pr(plan["pr"]), plan)
+        additions = validate_bundle(bundle, plan) if plan["generate"] else []
+        final = dict(plan)
+        if additions:
+            final["head"] = create_commit(write_api, plan, additions)
+        same_state(read_api.pr(plan["pr"]), final)
+        if final["head"] == plan["head"]:
+            active_check = checks_api.start_check(final, "validation", check_id)
+        else:
+            active_check = checks_api.start_check(final, "validation")
+            checks_api.finish_check(check_id, False, f"Processing complete; superseded by final-head check #{active_check} on `{final['head']}`.")
+        read_api.api("POST", f"actions/workflows/{VALIDATION_WORKFLOW}/dispatches", {
+            "ref": BASE_BRANCH, "inputs": {"pr_number": str(plan["pr"]), "head_sha": final["head"],
+                                           "base_sha": final["base"], "check_id": str(active_check)}})
+        print(f"Final validation dispatched for PR #{plan['pr']} at {final['head']}; check {active_check}")
+        return final["head"]
+    except Exception:
+        checks_api.finish_check(active_check, False, "Generation/writeback/dispatch failed. No success was granted; inspect the controller log.")
+        raise
+
+
+def report_identity(run, check, app_id):
+    match = RUN_TITLE.fullmatch(run.get("display_title", ""))
+    require(match is not None, "Unrecognized validation run title")
+    number, head, base, check_id = match.groups()
+    require(run["event"] == "workflow_dispatch" and run["path"] == f".github/workflows/{VALIDATION_WORKFLOW}"
+            and run["head_branch"] == BASE_BRANCH and run["head_sha"] == base,
+            "Validation was not dispatched from the expected trusted base")
+    marker = check_marker(check, app_id)
+    require(check["id"] == int(check_id) and marker.get("phase") == "validation"
+            and marker.get("pr") == int(number) and marker.get("head") == head and marker.get("base") == base,
+            "Validation run does not match the App-owned final-head check")
+    return marker
+
+
+def report(read_api, checks_api, event_run, app_id):
+    # Reruns use the same run ID: never accept an older attempt's completion.
+    run = read_api.api("GET", f"actions/runs/{event_run['id']}")
+    if run["run_attempt"] != event_run["run_attempt"] or run["status"] != "completed":
+        return
+    match = RUN_TITLE.fullmatch(run.get("display_title", ""))
+    require(match is not None, "Unrecognized validation run title")
+    check_id = int(match[4])
+    check = checks_api.check(check_id)
+    plan = report_identity(run, check, app_id)
+    newer = [item for item in checks_api.checks(plan["head"])
+             if item.get("app", {}).get("id") == int(app_id) and item["id"] > check_id]
+    if newer:
+        return
+    try:
+        same_state(read_api.pr(plan["pr"]), plan)
+    except AutomationError:
+        checks_api.finish_check(check_id, False, "PR head/base changed after dispatch. This result is stale.")
+        return
+    jobs = read_api.api("GET", f"actions/runs/{run['id']}/attempts/{run['run_attempt']}/jobs?per_page=100")
+    success = (run["conclusion"] == "success" and jobs["total_count"] == 1
+               and len(jobs["jobs"]) == 1 and jobs["jobs"][0]["name"] == VALIDATION_JOB
+               and jobs["jobs"][0]["status"] == "completed" and jobs["jobs"][0]["conclusion"] == "success")
+    same_state(read_api.pr(plan["pr"]), plan)
+    checks_api.finish_check(check_id, success,
+                            f"Final head `{plan['head']}`; base `{plan['base']}`. "
+                            + ("All applicable processing and validation succeeded." if success else "Applicable final validation failed, was skipped, or did not complete successfully."),
+                            run["html_url"])
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("operation", choices=["prepare", "generate", "publish", "fail", "report"])
+    args = parser.parse_args()
+    if args.operation == "generate":
+        bundle = generate(Path("trusted"), Path("candidate"), json.loads(os.environ["PLAN"]), Path("generated.json"))
+        output_values(changed=bool(bundle["additions"]))
+        return
+    read_api = GitHub(os.environ["GITHUB_REPOSITORY"], os.environ["GH_TOKEN"])
+    checks_api = GitHub(read_api.repo, os.environ["CHECK_TOKEN"])
+    if args.operation == "prepare":
+        event = json.loads(Path(os.environ["GITHUB_EVENT_PATH"]).read_text())
+        automatic = os.environ["GITHUB_EVENT_NAME"] == "pull_request_target"
+        number = event["pull_request"]["number"] if automatic else int(os.environ["PR_NUMBER"])
+        prepare(read_api, checks_api, number, controller=os.environ["GITHUB_RUN_ID"],
+                app_id=os.environ["APP_ID"], actor=os.environ["GITHUB_ACTOR"],
+                app_slug=os.environ["APP_SLUG"], automatic=automatic,
+                manual_user=not automatic and event.get("sender", {}).get("type") == "User")
+    elif args.operation == "publish":
+        plan = json.loads(os.environ["PLAN"])
+        bundle = json.loads(Path("bundle/generated.json").read_text()) if plan["generate"] else None
+        write_api = GitHub(plan["head_repo"], os.environ.get("WRITE_TOKEN") or os.environ["GH_TOKEN"])
+        publish(read_api, checks_api, write_api, plan, int(os.environ["CHECK_ID"]), bundle)
+    elif args.operation == "fail":
+        checks_api.finish_check(int(os.environ["CHECK_ID"]), False, "Required processing failed or was cancelled; inspect the controller run.")
+    else:
+        event = json.loads(Path(os.environ["GITHUB_EVENT_PATH"]).read_text())
+        report(read_api, checks_api, event["workflow_run"], int(os.environ["APP_ID"]))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/process-new-model-submission.md
+++ b/scripts/process-new-model-submission.md
@@ -6,7 +6,9 @@ This document describes the automation for processing a single OntoUML/UFO Catal
 
 The workflow is implemented by:
 
-- `.github/workflows/process-new-model-submission.yml`
+- `.github/workflows/pr-validation.yml` (automatic PR controller)
+- `.github/workflows/validate-pr-state.yml` (final-head validation)
+- `.github/workflows/process-new-model-submission.yml` (manual maintenance only)
 - `scripts/process_new_model_submission.py`
 
 It also expects the repository's validation/generation scripts to be available, including:
@@ -23,66 +25,23 @@ It also expects the repository's validation/generation scripts to be available, 
 
 The helper script is intentionally an orchestrator. It does not duplicate conversion, metadata-generation, or BibTeX-validation logic. It validates/fixes `metadata.yaml`, validates the submission envelope, classifies changed model paths, runs the ontology and metadata generators in the intended order, and performs final Turtle/RDF checks.
 
-## Supported submission mode
+## Automatic processing and merge eligibility
 
-Automatic model-submission processing supports **pull requests opened from branches inside the catalog repository**.
+All PRs to `master` enter the [PR validation controller](pr-validation.md). It classifies the complete changed-file list and runs only applicable processing and validation. Documentation and script-only PRs do not invoke model-submission generation. Mixed changes receive the union of applicable checks.
 
-The intended flow is:
+For a one-model submission, automation validates the source files, generates `ontology.ttl`, synchronizes distribution/model metadata and `catalog.ttl`, and commits changed generated files to the PR branch. It then explicitly dispatches validation of that exact final head. The App-owned `PR validation` check succeeds only after final-state validation succeeds. The required repository ruleset, not a maintainer's memory of workflow progress, blocks an incomplete submission.
 
-1. A trusted contributor creates a branch in `OntoUML/ontouml-models` and adds the source files for one model folder, without `ontology.ttl`.
-2. The contributor opens a PR to `master`.
-3. The workflow validates the sources, generates `ontology.ttl`, synchronizes distribution/model metadata and `catalog.ttl`, and commits changed files back to the PR branch.
-4. The generated files and release validation results are reviewed before a curator merges the complete PR manually.
-
-**Fork-based PR writeback is not supported.** If a PR is opened from a fork, the submission workflow fails with an explicit message explaining the same-repository restriction. Contributors without branch access should use the contribution form linked in the [README](../README.md#contribute-by-submitting-an-ontology) or contact a catalog administrator.
-
-## Triggers
-
-The workflow supports two triggers.
-
-### Automatic same-repository pull request trigger
-
-```yaml
-on:
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
-    paths:
-      - "models/**"
-```
-
-For normal one-model PRs, the workflow:
-
-1. rejects fork-based PRs;
-2. detects the unique changed model folder under `models/`;
-3. rejects PRs that modify files outside the target model folder, except generated root `catalog.ttl`;
-4. processes that model folder;
-5. commits generated files back to the PR branch when changes exist.
+Same-repository writeback uses `GITHUB_TOKEN`. Fork writeback uses a narrowly scoped GitHub App installation token, which requires the fork owner to install the catalog automation App on that fork. A fork PR without applicable generation needs no fork write permission. Missing write authorization blocks generation explicitly; it does not silently accept missing outputs or require contributors to generate them manually. See the [setup and trust boundary](pr-validation.md#external-repository-configuration).
 
 ### Generated-artifact-only bulk maintenance
 
-A same-repository PR touching more than one model folder is accepted only when every changed model file is directly inside `models/<slug>/` and is one of:
+The existing bulk mode remains: more than one model folder is supported only when every changed model file is a direct automation-generated output: `ontology.ttl`, `metadata.ttl`, `metadata-json.ttl`, `metadata-turtle.ttl`, `metadata-vpp.ttl`, or `metadata-png-(n|o)-*.ttl`. Deletions are not bulk maintenance. This mode checks all six generator families and final RDF/catalog/release consistency without writeback. Multiple model source submissions must be split into separate PRs. A one-model generated-file change still invokes normal processing.
 
-- `ontology.ttl`;
-- `metadata.ttl`;
-- `metadata-turtle.ttl`.
+### Manual maintenance
 
-Generated root `catalog.ttl` may also change. This selects `bulk-generated` mode: a read-only job checks full-catalog ontology and dependent metadata synchronization, parses model Turtle files, and verifies that validation did not modify the checkout. It does not generate a bot commit.
+`Process new model submission` retains its `workflow_dispatch` interface and inputs: `model_path`, `metadata_timestamp`, `metadata_repository`, `metadata_branch`, `allow_missing_license`, `dry_run`, and `commit_changes`. It no longer has an automatic PR trigger. Use it only on a branch whose workflow, scripts and dependencies a maintainer already trusts. Do not dispatch it on unreviewed PR code: its existing commit mode has write credentials.
 
-This narrowly scoped migration/maintenance mode does not allow multi-model contributor-source submissions or unrelated code/workflow changes. A PR touching only one model folder still uses normal processing, even if its changes are generated files only.
-
-### Manual trigger
-
-The manual `workflow_dispatch` trigger remains available for controlled testing, recovery, and fork-side experimentation.
-
-Manual inputs include:
-
-- `model_path`
-- `metadata_timestamp`
-- `metadata_repository`
-- `metadata_branch`
-- `allow_missing_license`
-- `dry_run`
-- `commit_changes`
+For automatic PR recovery, dispatch `Orchestrate PR validation` on `master` with the PR number, as documented in the [recovery instructions](pr-validation.md#recovery). Manual maintenance is not a substitute for the required final-head check and cannot bypass the protected `master` ruleset.
 
 ## Required source files
 
@@ -256,53 +215,15 @@ For PR-ready metadata intended for the main repository, keep the default:
 --branch master
 ```
 
-## Testing in GitHub Actions in the fork
+## Testing in GitHub Actions
 
-1. Ensure the workflow, helper, and pinned dependencies are committed and pushed to the branch being tested in `pedropaulofb/ontouml-models-dev`.
-2. Create a separate temporary test branch from that branch inside the fork repository.
-3. Add one model folder with the required source files and no `ontology.ttl` or generated metadata.
-4. Open a test PR back to the implementation branch in the same fork repository, not to the upstream catalog. Keep workflow/helper changes out of the test PR's diff.
-5. Confirm that the workflow creates and commits `ontology.ttl`, distribution/model metadata, and the catalog update.
-6. Inspect the generated commit and release validation. If GitHub requests approval for a follow-up run, a maintainer must approve it before its results can be assessed.
-7. Confirm that processing the bot-updated head reports `No generated changes to commit.` and creates no further commit.
-8. Close the temporary test PR without merging it; keep smoke-test data out of the implementation branch.
-
-To test the same workflow manually, use **Actions** → **Process new model submission** → **Run workflow**.
+Use the [eight-scenario integration matrix](pr-validation.md#live-github-regression-matrix) in an isolated test repository whose default branch contains the complete implementation. Test source-only submissions, failed generation, failed final validation, documentation, script changes, new heads, bot updates, and bulk distribution-metadata maintenance. Confirm merge denial while the required check is pending or failing, not just the workflow conclusion.
 
 ## Automatic commits
 
-For normal same-repository PRs, the workflow automatically commits `ontology.ttl`, generated metadata, and any normalized source YAML back to the PR branch after validation, generation, and catalog synchronization succeed. The read-only bulk-maintenance job never writes back.
+The controller writes only allowlisted generated files, permitted `metadata.yaml` normalization, and `catalog.ttl`. An atomic commit operation requires the PR branch still to have the expected source SHA; concurrent contributor updates are never overwritten. A no-op generation creates no commit. The final validation dispatch uses the resulting SHA whether or not a commit was necessary.
 
-For manual runs, commits occur only when `commit_changes` is `true` and `dry_run` is `false`.
-
-The workflow:
-
-1. runs all validation and generation steps;
-2. stops immediately if any step fails;
-3. stages only the requested model folder (including normalized `metadata.yaml`) and generated root catalog with this GitHub Actions Bash excerpt, not a local Cmder command:
-
-   ```bash
-   git add -- "$MODEL_PATH" catalog.ttl
-   ```
-
-4. commits only when staged changes exist;
-5. pushes the commit to the PR branch or, for manual runs, to the checked-out branch.
-
-A synchronized rerun leaves the generated files unchanged and logs `No generated changes to commit.`. Converter warnings alone do not cause a commit. Workflow results must be checked on the bot-updated PR head; pending approval is not a successful validation.
-
-The commit message has this form:
-
-```text
-chore(metadata): process model submission example-model
-```
-
-The normal processing job requires:
-
-```yaml
-permissions:
-  contents: write
-  pull-requests: read
-```
+For legacy manual runs, commits still occur only when `commit_changes` is `true` and `dry_run` is `false`. Review the local/manual diff before committing after any failure. Required PR validation must still pass on the resulting head before merge.
 
 ## Failure behavior
 
@@ -317,19 +238,12 @@ Malformed JSON, a fatal converter error, or an invalid generated graph stops pro
 
 Diagnostics are reported in GitHub check results and grouped workflow logs, not posted as PR comments. Review warnings separately from fatal errors; warnings do not by themselves make generation fail.
 
-For pull requests, the workflow also fails when:
-
-- the PR comes from a fork;
-- files outside the permitted model folder(s) and generated root `catalog.ttl` are changed;
-- multiple model folders are changed without satisfying the generated-artifact-only bulk-maintenance rules;
-- changed paths under `models/` are not inside a direct model folder.
+For pull requests, the required check also blocks when generation/writeback is unauthorized, the complete changed-file list cannot be obtained, multi-model source changes violate the existing boundary, final artifacts are absent or stale, or the head/base changes during processing or validation. It never treats an irrelevant workflow's absence as failure. See [PR validation](pr-validation.md) for the exact state transitions and recovery procedure.
 
 ## Current limitations
 
-- Automatic write-back is limited to same-repository PR branches.
-- Fork-based PR automation is intentionally deferred.
 - Normal submission processing and manual runs handle one model folder; multi-model generated-only maintenance is read-only.
-- `references.bib` is optional and is validated only when present; the workflow does not pass `--require` to `scripts/validate_references_bib.py`.
-- `references.bib` receives structural BibTeX/BibLaTeX validation only, not semantic validation of mandatory fields per entry type.
-- `ontology.vpp` is checked at file level only; no Visual Paradigm parser is introduced.
-- VPP-to-JSON export and synchronization are the contributor's responsibility.
+- Fork writeback requires an explicitly authorized App installation on the fork; no write-capable credential is exposed to contributor code.
+- Generation uses trusted base-branch tools. Land generator changes first if a new submission requires behavior unavailable on `master`.
+- `references.bib` is optional and receives structural BibTeX/BibLaTeX validation, not semantic validation of mandatory fields per entry type.
+- The existing submission envelope requires `ontology.vpp`; it is checked at file level only. VPP-to-JSON export and synchronization remain the contributor's responsibility.

--- a/scripts/tests/test_pr_automation.py
+++ b/scripts/tests/test_pr_automation.py
@@ -1,0 +1,552 @@
+"""Orchestration regressions; API fakes do not prove hosted event permissions."""
+from __future__ import annotations
+
+import base64
+import copy
+import json
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / "scripts"))
+import pr_automation as automation
+import validate_pr_state as validation
+
+HEAD, BASE, FINAL = "a" * 40, "b" * 40, "c" * 40
+APP_ID = 42
+
+
+def changed(*paths, status="modified"):
+    return [{"filename": path, "status": status} for path in paths]
+
+
+def plan_for(*paths):
+    plan = automation.classify(changed(*paths))
+    plan.update(pr=357, head=HEAD, base=BASE, controller=100, head_repo="OntoUML/ontouml-models", head_ref="submission")
+    return plan
+
+
+class FakeAPI:
+    repo = "OntoUML/ontouml-models"
+
+    def __init__(self):
+        self.pr_data = {"number": 357, "state": "open", "changed_files": 1,
+                        "head": {"sha": HEAD, "ref": "submission", "repo": {"full_name": self.repo}},
+                        "base": {"sha": BASE, "ref": "master", "repo": {"full_name": self.repo}}}
+        self.files_data = changed("README.md")
+        self.events, self.check_store = [], {}
+        self.check_counter, self.run_data = 1000, {}
+        self.job = {"name": automation.VALIDATION_JOB, "status": "completed", "conclusion": "success"}
+        self.reject_commit = False
+
+    def pr(self, number):
+        return automation.GitHub.pr(self, number)
+
+    def files(self, pr):
+        return automation.GitHub.files(self, pr)
+
+    def start_check(self, plan, phase, check_id=None):
+        return automation.GitHub.start_check(self, plan, phase, check_id)
+
+    def finish_check(self, *args, **kwargs):
+        return automation.GitHub.finish_check(self, *args, **kwargs)
+
+    def check(self, check_id):
+        return copy.deepcopy(self.check_store[check_id])
+
+    def checks(self, head):
+        return [copy.deepcopy(value) for value in self.check_store.values() if value["head_sha"] == head]
+
+    def api(self, method, path, body=None):
+        self.events.append((method, path, copy.deepcopy(body)))
+        if path == "pulls/357":
+            return copy.deepcopy(self.pr_data)
+        if path.startswith("pulls/357/files?"):
+            page = int(path.split("page=")[-1])
+            return self.files_data[(page - 1) * 100:page * 100]
+        if method == "POST" and path == "check-runs":
+            self.check_counter += 1
+            value = dict(body, id=self.check_counter, app={"id": APP_ID})
+            self.check_store[value["id"]] = value
+            return copy.deepcopy(value)
+        if method == "PATCH" and path.startswith("check-runs/"):
+            self.check_store[int(path.split("/")[-1])].update(body)
+            return None
+        if path.endswith("/jobs?per_page=100"):
+            return {"total_count": 1, "jobs": [copy.deepcopy(self.job)]}
+        if path.startswith("actions/runs/"):
+            return copy.deepcopy(self.run_data)
+        if method == "POST" and path.endswith("/dispatches"):
+            return None
+        raise AssertionError((method, path, body))
+
+    def request(self, method, path, body=None):
+        assert method == "POST" and path == "/graphql"
+        self.events.append((method, path, copy.deepcopy(body)))
+        assert body["variables"]["input"]["expectedHeadOid"] == HEAD
+        if self.reject_commit:
+            return {"errors": [{"message": "Head changed"}]}
+        self.pr_data["head"]["sha"] = FINAL
+        return {"data": {"createCommitOnBranch": {"commit": {"oid": FINAL}}}}
+
+
+def start(api, plan, phase="processing"):
+    return api.start_check(plan, phase)
+
+
+def completion(api, *, conclusion="success"):
+    plan = plan_for("README.md")
+    check_id = start(api, plan, "validation")
+    run = {"id": 200, "run_attempt": 1, "status": "completed", "conclusion": conclusion,
+           "display_title": f"PR 357 head {HEAD} base {BASE} check {check_id}",
+           "event": "workflow_dispatch", "path": ".github/workflows/validate-pr-state.yml",
+           "head_branch": "master", "head_sha": BASE, "html_url": "https://github.com/example/run/200"}
+    api.run_data = run
+    return check_id, copy.deepcopy(run)
+
+
+@pytest.mark.parametrize("paths,mode,generate,code,catalog,workflows", [
+    (["README.md"], "none", False, False, False, False),
+    (["models/legacy/README.md"], "none", False, False, False, False),
+    (["scripts/generate-catalog-file.md", "documentation/logo/logo.png"], "none", False, False, False, False),
+    (["scripts/generate_catalog_file.py"], "none", False, True, True, False),
+    (["scripts/requirements.txt"], "none", False, True, True, False),
+    ([".github/workflows/publish-models-release.yml"], "none", False, True, True, True),
+    (["models/new/ontology.json", "models/new/metadata.yaml"], "normal", True, False, True, False),
+    (["models/new/ontology.json", "README.md", "scripts/validate_metadata_yaml.py"], "normal", True, True, True, False),
+    (["catalog.yaml"], "none", True, False, True, False),
+    (["catalog.ttl"], "none", False, False, True, False),
+    (["shapes/shape.ttl"], "none", False, False, False, False),
+    (["models/a/ontology.ttl", "models/a/metadata.ttl",
+      "models/b/metadata-json.ttl", "models/b/metadata-turtle.ttl",
+      "models/c/metadata-vpp.ttl", "models/d/metadata-png-o-main.ttl",
+      "models/e/metadata-png-n-main.ttl"],
+     "bulk-generated", False, False, True, False),
+    ([".gitignore"], "none", False, True, True, False),
+])
+def test_applicability(paths, mode, generate, code, catalog, workflows):
+    plan = automation.classify(changed(*paths))
+    assert (plan["mode"], plan["generate"], plan["code"], plan["catalog"], plan["workflows"]) == (mode, generate, code, catalog, workflows)
+
+
+def test_regression_357_sources_added_and_generated_files_removed():
+    files = changed("models/bilal2026tktonto/ontology.json", "models/bilal2026tktonto/metadata.yaml", status="added")
+    files += changed("models/bilal2026tktonto/ontology.ttl", "models/bilal2026tktonto/metadata.ttl", status="removed")
+    assert automation.classify(files)["generate"]
+
+
+def test_regression_360_bulk_distribution_metadata_is_applicable_without_generation():
+    paths = []
+    for index in range(42):
+        model = f"models/model-{index:02d}"
+        paths.extend(f"{model}/{name}" for name in (
+            "metadata-json.ttl", "metadata-turtle.ttl",
+            "metadata-vpp.ttl", "metadata.ttl"))
+    paths.extend(
+        f"models/model-{index % 42:02d}/metadata-png-o-diagram-{index:03d}.ttl"
+        for index in range(226)
+    )
+    plan = automation.classify(changed(*paths))
+    assert len(plan["paths"]) == 394
+    assert len(plan["models"]) == 42
+    assert plan["mode"] == "bulk-generated"
+    assert plan["catalog"] and not plan["generate"]
+
+
+def test_deleting_only_generated_file_of_existing_model_still_generates():
+    assert automation.classify(changed("models/existing/ontology.ttl", status="removed"))["mode"] == "normal"
+
+
+def test_rename_cannot_hide_script_change_as_documentation():
+    files = [{"filename": "documentation/old-generator.md", "previous_filename": "scripts/generator.py", "status": "renamed"}]
+    assert automation.classify(files)["code"]
+
+
+@pytest.mark.parametrize("name", [
+    "ontology.ttl", "metadata.ttl", "metadata-json.ttl",
+    "metadata-turtle.ttl", "metadata-vpp.ttl", "metadata-png-o-main.ttl",
+    "metadata-png-n-main.ttl",
+])
+def test_bulk_generated_metadata_deletion_fails_closed(name):
+    files = changed(f"models/a/{name}", status="removed")
+    files += changed("models/b/metadata.ttl")
+    with pytest.raises(automation.AutomationError):
+        automation.classify(files)
+
+
+@pytest.mark.parametrize("paths", [
+    ["models/a/ontology.json", "models/b/ontology.json"],
+    ["models/a/metadata-custom.ttl", "models/b/metadata.ttl"],
+    ["models/a/metadata-png-x-main.ttl", "models/b/metadata.ttl"],
+    ["models/a/metadata-png-o-.ttl", "models/b/metadata.ttl"],
+    ["models/a"],
+    [],
+])
+def test_unsupported_changes_fail_closed(paths):
+    with pytest.raises(automation.AutomationError):
+        automation.classify(changed(*paths))
+
+
+@pytest.mark.parametrize("path", ["../escape", "/tmp/escape", "models//a", "models/./a", "models/../a", "models\\a", "models/a\noutput=true", ".git/config"])
+def test_paths_cannot_escape_or_inject_workflow_outputs(path):
+    with pytest.raises(automation.AutomationError):
+        automation.safe_path(path)
+
+
+def test_complete_api_pagination_includes_late_model_file():
+    api = FakeAPI()
+    api.files_data = changed(*(f"documentation/{i}.md" for i in range(399)), "models/a/ontology.json")
+    api.pr_data["changed_files"] = 400
+    assert automation.classify(api.files(api.pr_data))["generate"]
+    assert len([event for event in api.events if "/files?" in event[1]]) == 4
+
+
+@pytest.mark.parametrize("count", [0, 3001, 2])
+def test_incomplete_or_oversized_api_diff_is_not_docs_only(count):
+    api = FakeAPI()
+    api.pr_data["changed_files"] = count
+    with pytest.raises(automation.AutomationError):
+        api.files(api.pr_data)
+
+
+def bundle_for(plan, path="models/new/ontology.ttl"):
+    return {"head": plan["head"], "base": plan["base"], "additions": [{"path": path, "contents": base64.b64encode(b"generated").decode()}]}
+
+
+@pytest.mark.parametrize("path", ["scripts/steal.py", ".github/workflows/steal.yml", "models/other/ontology.ttl", "models/new/ontology.json", "models/new/ontology.vpp", "../escape"])
+def test_writeback_accepts_only_generated_files_in_target_model(path):
+    plan = plan_for("models/new/ontology.json")
+    with pytest.raises(automation.AutomationError):
+        automation.validate_bundle(bundle_for(plan, path), plan)
+
+
+@pytest.mark.parametrize("change", ["sha", "duplicate", "encoding", "deletions"])
+def test_invalid_bundles_fail_closed(change):
+    plan = plan_for("models/new/ontology.json")
+    bundle = bundle_for(plan)
+    if change == "sha":
+        bundle["head"] = FINAL
+    elif change == "duplicate":
+        bundle["additions"] *= 2
+    elif change == "encoding":
+        bundle["additions"][0]["contents"] = "not-base64!"
+    else:
+        bundle["deletions"] = ["README.md"]
+    with pytest.raises(automation.AutomationError):
+        automation.validate_bundle(bundle, plan)
+
+
+def test_new_model_writeback_precedes_dispatch_of_bot_head():
+    api, plan = FakeAPI(), plan_for("models/new/ontology.json")
+    first = start(api, plan)
+    assert automation.publish(api, api, api, plan, first, bundle_for(plan)) == FINAL
+    commit = next(i for i, event in enumerate(api.events) if event[1] == "/graphql")
+    dispatch = next(i for i, event in enumerate(api.events) if event[1].endswith("/dispatches"))
+    assert commit < dispatch
+    inputs = api.events[dispatch][2]["inputs"]
+    check = api.check_store[int(inputs["check_id"])]
+    assert inputs["head_sha"] == check["head_sha"] == FINAL
+    assert check["status"] == "in_progress"
+    assert api.check_store[first]["conclusion"] == "failure"
+    assert not any(check.get("conclusion") == "success" for check in api.check_store.values())
+
+
+def test_documentation_dispatches_validation_without_generation_or_writeback():
+    api, plan = FakeAPI(), plan_for("README.md")
+    automation.publish(api, api, api, plan, start(api, plan))
+    assert not any(event[1] == "/graphql" for event in api.events)
+    assert any(event[1].endswith("/dispatches") for event in api.events)
+    assert len(api.check_store) == 1
+    assert list(api.check_store.values())[0]["status"] == "in_progress"
+
+
+def test_noop_generation_does_not_create_recursive_commits():
+    api, plan = FakeAPI(), plan_for("models/new/ontology.json")
+    automation.publish(api, api, api, plan, start(api, plan), dict(bundle_for(plan), additions=[]))
+    assert not any(event[1] == "/graphql" for event in api.events)
+
+
+def test_atomic_writeback_rejects_concurrent_human_commit():
+    api, plan = FakeAPI(), plan_for("models/new/ontology.json")
+    api.reject_commit = True
+    check_id = start(api, plan)
+    with pytest.raises(automation.AutomationError, match="Atomic"):
+        automation.publish(api, api, api, plan, check_id, bundle_for(plan))
+    assert api.check_store[check_id]["conclusion"] == "failure"
+    assert not any(event[1].endswith("/dispatches") for event in api.events)
+
+
+@pytest.mark.parametrize("mutation", ["head", "base", "closed"])
+def test_stale_or_closed_pr_cannot_publish(mutation):
+    api, plan = FakeAPI(), plan_for("README.md")
+    check_id = start(api, plan)
+    if mutation == "closed":
+        api.pr_data["state"] = "closed"
+    else:
+        api.pr_data[mutation]["sha"] = FINAL
+    with pytest.raises(automation.AutomationError):
+        automation.publish(api, api, api, plan, check_id)
+    assert api.check_store[check_id]["conclusion"] == "failure"
+
+
+@pytest.mark.parametrize("conclusion", ["failure", "cancelled", "action_required", "skipped", "neutral", "timed_out"])
+def test_non_successful_final_validation_blocks_merge(conclusion):
+    api = FakeAPI()
+    check_id, event = completion(api, conclusion=conclusion)
+    automation.report(api, api, event, APP_ID)
+    assert api.check_store[check_id]["conclusion"] == "failure"
+
+
+def test_success_requires_actual_unskipped_validation_job():
+    api = FakeAPI()
+    check_id, event = completion(api)
+    api.job["conclusion"] = "skipped"
+    automation.report(api, api, event, APP_ID)
+    assert api.check_store[check_id]["conclusion"] == "failure"
+
+
+def test_final_validation_success_is_bound_to_current_head():
+    api = FakeAPI()
+    check_id, event = completion(api)
+    automation.report(api, api, event, APP_ID)
+    assert api.check_store[check_id]["conclusion"] == "success"
+    api.pr_data["head"]["sha"] = FINAL
+    automation.report(api, api, event, APP_ID)
+    assert api.check_store[check_id]["conclusion"] == "failure"
+    assert not api.checks(FINAL)
+
+
+def test_pending_attempt_never_completes_gate():
+    api = FakeAPI()
+    check_id, event = completion(api)
+    api.run_data["status"] = "in_progress"
+    automation.report(api, api, event, APP_ID)
+    assert api.check_store[check_id]["status"] == "in_progress"
+
+
+def test_old_attempt_cannot_authorize_rerun():
+    api = FakeAPI()
+    check_id, event = completion(api)
+    api.run_data["run_attempt"] = 2
+    automation.report(api, api, event, APP_ID)
+    assert api.check_store[check_id]["status"] == "in_progress"
+
+
+def test_newer_check_for_same_head_supersedes_older_run():
+    api = FakeAPI()
+    check_id, event = completion(api)
+    newer = start(api, plan_for("README.md"))
+    automation.report(api, api, event, APP_ID)
+    assert api.check_store[check_id]["status"] == api.check_store[newer]["status"] == "in_progress"
+
+
+@pytest.mark.parametrize("field,value", [("event", "pull_request"), ("head_branch", "untrusted"), ("head_sha", HEAD), ("path", ".github/workflows/fake.yml")])
+def test_spoofed_or_wrong_base_workflow_cannot_report(field, value):
+    api = FakeAPI()
+    check_id, event = completion(api)
+    api.run_data[field] = value
+    with pytest.raises(automation.AutomationError):
+        automation.report(api, api, event, APP_ID)
+    assert api.check_store[check_id]["status"] == "in_progress"
+
+
+@pytest.mark.parametrize("change", ["app", "phase"])
+def test_report_requires_app_owned_final_validation_check(change):
+    api = FakeAPI()
+    check_id, event = completion(api)
+    if change == "app":
+        api.check_store[check_id]["app"]["id"] += 1
+    else:
+        marker = json.loads(api.check_store[check_id]["external_id"])
+        marker["phase"] = "processing"
+        api.check_store[check_id]["external_id"] = json.dumps(marker)
+    with pytest.raises(automation.AutomationError):
+        automation.report(api, api, event, APP_ID)
+
+
+def test_only_authenticated_app_actor_suppresses_duplicate_bot_processing():
+    api = FakeAPI()
+    completion(api)
+    assert automation.already_dispatched(api.checks(HEAD), api.pr_data, APP_ID, "catalog-ci[bot]", "catalog-ci")
+    assert not automation.already_dispatched(api.checks(HEAD), api.pr_data, APP_ID, "contributor", "catalog-ci")
+
+
+def test_classification_failure_creates_a_failed_gate(tmp_path, monkeypatch):
+    api = FakeAPI()
+    api.pr_data["changed_files"] = 3001
+    monkeypatch.setenv("GITHUB_OUTPUT", str(tmp_path / "outputs"))
+    with pytest.raises(automation.AutomationError):
+        automation.prepare(api, api, 357, controller=100, app_id=APP_ID,
+                           actor="human", app_slug="catalog-ci", automatic=True)
+    assert list(api.check_store.values())[0]["conclusion"] == "failure"
+
+
+def test_manual_recovery_is_not_suppressed_for_app_actor(tmp_path, monkeypatch):
+    api = FakeAPI()
+    completion(api)
+    monkeypatch.setenv("GITHUB_OUTPUT", str(tmp_path / "outputs"))
+    automation.prepare(api, api, 357, controller=101, app_id=APP_ID,
+                       actor="catalog-ci[bot]", app_slug="catalog-ci", automatic=False)
+    assert len(api.check_store) == 2
+
+
+@pytest.mark.parametrize("automatic,manual_user,allowed", [(True,False,False),(False,False,False),(False,True,True)])
+def test_fork_code_needs_maintainer_authorized_dispatch(tmp_path, monkeypatch, automatic, manual_user, allowed):
+    api = FakeAPI()
+    api.pr_data["head"]["repo"]["full_name"] = "contributor/ontouml-models"
+    api.files_data = changed("scripts/generate_catalog_file.py")
+    monkeypatch.setenv("GITHUB_OUTPUT", str(tmp_path / "outputs"))
+    kwargs = dict(controller=100, app_id=APP_ID, actor="human", app_slug="catalog-ci",
+                  automatic=automatic, manual_user=manual_user)
+    if allowed:
+        automation.prepare(api, api, 357, **kwargs)
+        assert list(api.check_store.values())[0]["status"] == "in_progress"
+    else:
+        with pytest.raises(automation.AutomationError, match="Fork code/dependency"):
+            automation.prepare(api, api, 357, **kwargs)
+        assert list(api.check_store.values())[0]["conclusion"] == "failure"
+
+
+def test_missing_generated_files_fail_before_regeneration(tmp_path):
+    from test_process_new_model_submission import make_model, make_repo
+    root = make_repo(tmp_path)
+    make_model(root, name="new", include_ontology_turtle=False)
+    with pytest.raises(Exception, match="Expected generated file"):
+        validation.require_generated_outputs(root, plan_for("models/new/ontology.json"))
+
+
+def test_bulk_validation_covers_every_generated_metadata_family(tmp_path, monkeypatch):
+    source, trusted = tmp_path / "source", tmp_path / "trusted"
+    for root in (source / "models/a", source / "models/b", trusted / "scripts"):
+        root.mkdir(parents=True)
+    for path in (source / "models/a/metadata-json.ttl",
+                 source / "models/b/metadata-png-o-main.ttl"):
+        path.write_text("", encoding="utf-8")
+    calls = []
+    monkeypatch.setattr(validation.subprocess, "run",
+                        lambda command, **kwargs: calls.append(command))
+    monkeypatch.setattr(validation, "release_check", lambda root: None)
+    plan = automation.classify(changed(
+        "models/a/metadata-json.ttl", "models/b/metadata-png-o-main.ttl"))
+    validation.validate_data(source, trusted, plan)
+    assert [Path(command[1]).name for command in calls] == [
+        check[0] for check in validation.BULK_GENERATOR_CHECKS]
+
+
+def test_source_only_model_real_generation_and_final_state_validation(tmp_path):
+    from test_generate_png_metadata import minimal_png
+    from test_process_new_model_submission import make_model, make_repo
+    from test_validate_metadata_yaml import VALID_METADATA
+    root = make_repo(tmp_path)
+    shutil.copytree(ROOT / "scripts", root / "scripts", dirs_exist_ok=True, ignore=shutil.ignore_patterns("__pycache__"))
+    shutil.copyfile(ROOT / "catalog.yaml", root / "catalog.yaml")
+    model = make_model(root, name="new", include_ontology_turtle=False)
+    (model / "new-diagrams/main.png").write_bytes(minimal_png())
+    (model / "metadata.yaml").write_text(VALID_METADATA, encoding="utf-8")
+    shutil.copyfile(ROOT / "scripts/tests/fixtures/json2graph/minimal-single-language/ontology.json", model / "ontology.json")
+    plan = plan_for("models/new/ontology.json", "models/new/metadata.yaml")
+    with pytest.raises(Exception, match="Expected generated file"):
+        validation.require_generated_outputs(root, plan)
+    automation.process_data(root, plan)
+    validation.require_generated_outputs(root, plan)
+    before = automation.file_hashes(root)
+    validation.validate_data(root, ROOT, plan)
+    assert automation.file_hashes(root) == before
+
+
+def test_check_listing_includes_new_pending_runs_not_only_latest_completion(monkeypatch):
+    api = automation.GitHub("OntoUML/ontouml-models", "test-token")
+    calls = []
+    def fake_api(method, path):
+        calls.append(path)
+        assert "filter=all" in path
+        page = int(path.split("page=")[-1])
+        return {"total_count": 101, "check_runs": [{"id": index} for index in range(100)] if page == 1 else [{"id": 101, "status": "in_progress"}]}
+    monkeypatch.setattr(api, "api", fake_api)
+    assert api.checks(HEAD)[-1]["status"] == "in_progress"
+    assert len(calls) == 2
+
+
+def test_generation_failure_never_emits_partial_bundle(tmp_path, monkeypatch):
+    plan = plan_for("models/new/ontology.json")
+    monkeypatch.setattr(automation, "git", lambda root, *args: (HEAD if root.name == "candidate" else BASE).encode())
+    monkeypatch.setattr(automation, "data_workspace", lambda *args: None)
+    monkeypatch.setattr(automation, "file_hashes", lambda *args: {})
+    def fail(*args):
+        raise subprocess.CalledProcessError(1, "generator")
+    monkeypatch.setattr(automation, "process_data", fail)
+    output = tmp_path / "generated.json"
+    with pytest.raises(subprocess.CalledProcessError):
+        automation.generate(Path("trusted"), Path("candidate"), plan, output)
+    assert not output.exists()
+
+
+def test_export_rejects_symlinks_before_data_parsing(tmp_path, monkeypatch):
+    monkeypatch.setattr(automation, "git", lambda *args: b"120000 blob deadbeef\tmodels/a/metadata.yaml\0")
+    with pytest.raises(automation.AutomationError, match="Non-regular"):
+        automation.copy_tracked(tmp_path / "source", tmp_path / "export", data_only=True)
+
+
+def test_documentation_conflict_is_an_applicable_failure(tmp_path):
+    (tmp_path / "README.md").write_text("<<<<<<< branch\nconflict\n")
+    with pytest.raises(automation.AutomationError, match="conflict"):
+        validation.validate_docs(tmp_path, plan_for("README.md"))
+
+
+def test_container_does_not_mount_host_credentials_or_docker_socket(tmp_path):
+    command = validation.container_command(tmp_path / "source", tmp_path / "trusted", tmp_path / "plan.json", "code")
+    assert "--privileged" not in command and "--env" not in command and "-e" not in command
+    assert "--read-only" in command and "--cap-drop=ALL" in command
+    assert all("docker.sock" not in arg and ".git" not in arg for arg in command)
+    assert command[-1].startswith("python -m venv /tmp/venv")
+    assert "-r /repo/scripts/requirements.txt" in command[-1]
+
+
+def test_docs_only_container_does_not_install_model_dependencies(tmp_path):
+    command = validation.container_command(tmp_path / "source", tmp_path / "trusted", tmp_path / "plan.json", "data", dependencies=False)
+    assert "pip install" not in command[-1]
+
+
+def workflow(name):
+    return yaml.load((ROOT / ".github/workflows" / name).read_text(), Loader=yaml.BaseLoader)
+
+
+def test_workflow_dependencies_and_trust_boundaries():
+    controller = workflow("pr-validation.yml")
+    assert "paths" not in controller["on"]["pull_request_target"]
+    assert controller["concurrency"]["cancel-in-progress"] == "false"
+    jobs = controller["jobs"]
+    assert jobs["publish"]["needs"] == ["prepare", "generate"]
+    assert "always()" in jobs["publish"]["if"] and "needs.generate.result == 'success'" in jobs["publish"]["if"]
+    assert jobs["generate"]["permissions"] == {"contents": "read"}
+    assert "environment" not in jobs["generate"]
+    for name in ("prepare", "publish", "failure", "report"):
+        assert jobs[name]["environment"] == "pr-automation"
+        for step in jobs[name]["steps"]:
+            assert step.get("with", {}).get("path") != "candidate"
+    validator = workflow("validate-pr-state.yml")
+    assert set(validator["on"]) == {"workflow_dispatch"}
+    assert len(validator["jobs"]) == 1
+    job = validator["jobs"]["validate"]
+    assert "if" not in job and "environment" not in job
+    assert job["name"] == automation.VALIDATION_JOB
+    assert "secrets." not in (ROOT / ".github/workflows/validate-pr-state.yml").read_text()
+    for old in ("process-new-model-submission.yml", "publish-models-release.yml"):
+        assert "pull_request" not in workflow(old)["on"]
+    release = (ROOT / ".github/workflows/publish-models-release.yml").read_text()
+    assert "git push" not in release
+    assert "generate_catalog_file.py . --check" in release
+
+
+def test_new_orchestration_actions_are_pinned_to_commits():
+    for name in ("pr-validation.yml", "validate-pr-state.yml"):
+        for job in workflow(name)["jobs"].values():
+            for step in job.get("steps", []):
+                if "uses" in step:
+                    assert re.fullmatch(r"[^@\s]+@[0-9a-f]{40}", step["uses"])

--- a/scripts/validate_pr_state.py
+++ b/scripts/validate_pr_state.py
@@ -1,0 +1,191 @@
+"""Validate an immutable final PR snapshot using the trusted base's harness.
+
+PR executables and dependencies run only inside disposable containers, never
+in the controller or reporter. The containers receive no host credentials.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+# Also works with python -I: do not search a PR's cwd for the trusted module.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from pr_automation import (GitHub, SHA, classify, copy_tracked,
+                           file_hashes, git, process_data, require, same_state)
+
+BULK_GENERATOR_CHECKS = (
+    ("generate_ontology_turtle.py", "--all", "--models-dir", "models",
+     "--check", "--quiet"),
+    ("generate_json_metadata.py", "--all", "--models-dir", "models",
+     "--allow-missing-license", "--check", "--quiet"),
+    ("generate_png_metadata.py", "--all", "--models-dir", "models",
+     "--allow-missing-license", "--check", "--quiet"),
+    ("generate_turtle_metadata.py", "--all", "--models-dir", "models",
+     "--allow-missing-license", "--check", "--quiet"),
+    ("generate_vpp_metadata.py", "--all", "--models-dir", "models",
+     "--allow-missing-license", "--check", "--quiet"),
+    ("metadata_yaml_to_ttl.py", "--all", "--models-dir", "models",
+     "--allow-missing-license", "--check", "--quiet"),
+)
+
+
+def validate_docs(root, plan):
+    for name in plan["docs"]:
+        path = root / name
+        if name in plan["removed"] and not path.exists():
+            continue
+        text = path.read_text(encoding="utf-8")
+        require(not re.search(r"^(?:<<<<<<< |=======\s*$|>>>>>>> )", text, re.MULTILINE),
+                f"Unresolved conflict marker in {name}")
+    print(f"Checked {len(plan['docs'])} changed Markdown paths for UTF-8/conflict markers.")
+
+
+def release_check(root):
+    from rdflib import Graph
+    subprocess.run([sys.executable, "scripts/generate_catalog_file.py", ".", "--check"], cwd=root, check=True)
+    with tempfile.TemporaryDirectory(prefix="ontouml-pr-release-") as output:
+        subprocess.run([sys.executable, "scripts/generate_release_file.py", ".", "--release-tag", "19700101",
+                        "--output-dir", output], cwd=root, check=True)
+        path = Path(output) / "ontouml-models-19700101.ttl"
+        require(path.is_file() and path.stat().st_size > 0, "Release output is absent/empty")
+        graph = Graph().parse(path, format="turtle")
+        print(f"Parsed release graph: {len(graph)} triples.")
+
+
+def require_generated_outputs(root, plan):
+    import process_new_model_submission as submission
+    if plan["mode"] != "normal":
+        return
+    model = root / plan["models"][0]
+    if not model.exists():
+        return  # process_data verifies complete model deletion below.
+    diagrams = submission.validate_required_sources(model, root)
+    outputs = submission.expected_generated_metadata_paths(model, diagrams)
+    submission.ensure_expected_outputs_exist(outputs, root)
+    submission.validate_all_turtle_files(model, root)
+
+
+def validate_data(source, trusted, plan):
+    """Check existing outputs BEFORE regeneration; regeneration must be a no-op."""
+    validate_docs(source, plan)
+    if plan["shapes"]:
+        from rdflib import Graph
+        for name in plan["paths"]:
+            if name.startswith("shapes/") and name.endswith(".ttl") and (source / name).exists():
+                Graph().parse(source / name, format="turtle")
+    if not plan["catalog"]:
+        return
+    with tempfile.TemporaryDirectory(prefix="ontouml-final-state-") as temp:
+        root = Path(temp)
+        shutil.copytree(source / "models", root / "models")
+        for name in ("catalog.yaml", "catalog.ttl"):
+            if (source / name).is_file():
+                shutil.copyfile(source / name, root / name)
+        shutil.copytree(trusted / "scripts", root / "scripts", ignore=shutil.ignore_patterns("__pycache__"))
+        require_generated_outputs(root, plan)
+        if plan["generate"]:
+            before = file_hashes(root)
+            process_data(root, plan)
+            require(before == file_hashes(root), "Final head is missing or has stale generated artifacts")
+        if plan["mode"] == "bulk-generated":
+            for script, *flags in BULK_GENERATOR_CHECKS:
+                subprocess.run([sys.executable, "scripts/" + script, *flags], cwd=root, check=True)
+        from rdflib import Graph
+        paths = sorted((root / "models").glob("*/*.ttl"))
+        require(bool(paths), "No model Turtle files found")
+        for path in paths:
+            Graph().parse(path, format="turtle")
+        print(f"Parsed {len(paths)} model Turtle files.")
+        release_check(root)
+
+
+def validate_proposed_code(source, plan):
+    if plan["code"]:
+        subprocess.run([sys.executable, "-m", "pytest", "-q", "-p", "no:cacheprovider", "scripts/tests"], cwd=source, check=True)
+        release_check(source)
+
+
+def container_command(source, trusted, plan_file, phase, *, dependencies=True):
+    require(phase in {"data", "code"}, "Unknown validation phase")
+    requirements = "/trusted/scripts/requirements.txt" if phase == "data" else "/repo/scripts/requirements.txt"
+    # Fixed shell source, never interpolated contributor input. pip also runs in
+    # the container: a PR can change requirements/build hooks, not host access.
+    command = " -I /trusted/scripts/validate_pr_state.py " + phase + " --source /repo --trusted /trusted --plan /plan.json"
+    bootstrap = ("python -m venv /tmp/venv && /tmp/venv/bin/python -m pip install --disable-pip-version-check -r "
+                 + requirements + " && /tmp/venv/bin/python" + command) if dependencies else "python" + command
+    return ["docker", "run", "--rm", "--read-only", "--cap-drop=ALL", "--security-opt=no-new-privileges",
+            "--user", "65534:65534", "--tmpfs", "/tmp:rw,exec,nosuid,size=4g", "--workdir", "/repo",
+            "--mount", f"type=bind,src={source.resolve()},dst=/repo,readonly",
+            "--mount", f"type=bind,src={trusted.resolve()},dst=/trusted,readonly",
+            "--mount", f"type=bind,src={plan_file.resolve()},dst=/plan.json,readonly",
+            "python:3.11", "sh", "-c", bootstrap]
+
+
+def prepare_snapshot(source, trusted, number, head, base, plan_file):
+    require(SHA.fullmatch(head) and SHA.fullmatch(base), "Invalid dispatch SHA")
+    api = GitHub(os.environ["GITHUB_REPOSITORY"], os.environ["GH_TOKEN"])
+    pr = api.pr(number)
+    identity = {"head": head, "base": base}
+    same_state(pr, identity)
+    require(git(source, "rev-parse", "HEAD").decode().strip() == head, "Checkout is not the dispatched final head")
+    require(git(trusted, "rev-parse", "HEAD").decode().strip() == base, "Trusted checkout is not the dispatched base")
+    subprocess.run(["git", "-C", str(source), "merge-base", "--is-ancestor", base, head], check=True)
+    subprocess.run(["git", "-C", str(source), "diff", "--check", f"{base}...{head}"], check=True)
+    plan = classify(api.files(pr))
+    plan.update(identity)
+    same_state(api.pr(number), plan)
+    plan_file.write_text(json.dumps(plan), encoding="utf-8")
+    print("Final-head applicability: " + json.dumps(plan, sort_keys=True))
+
+
+def run_containers(source, trusted, plan_file):
+    plan = json.loads(plan_file.read_text())
+    with tempfile.TemporaryDirectory(prefix="ontouml-isolated-validation-") as temp:
+        root = Path(temp)
+        root.chmod(0o755)
+        snapshot = root / "source"
+        copy_tracked(source, snapshot)
+        harness = root / "trusted"
+        shutil.copytree(trusted / "scripts", harness / "scripts", ignore=shutil.ignore_patterns("__pycache__"))
+        # Neither .git nor host environment variables, credentials, runtime
+        # tokens, artifact/cache credentials or the Docker socket are mounted.
+        subprocess.run(container_command(snapshot, harness, plan_file, "data",
+                                         dependencies=plan["catalog"] or plan["shapes"]), check=True)
+        if plan["code"]:
+            subprocess.run(container_command(snapshot, harness, plan_file, "code"), check=True)
+        if plan["workflows"]:
+            subprocess.run(["docker", "run", "--rm", "--network=none", "--read-only", "--cap-drop=ALL",
+                            "--security-opt=no-new-privileges", "--user", "65534:65534",
+                            "--workdir", "/repo", "--mount", f"type=bind,src={snapshot},dst=/repo,readonly",
+                            "rhysd/actionlint:1.7.12", "-shellcheck="], check=True)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("operation", choices=["prepare", "containers", "data", "code"])
+    parser.add_argument("--source", type=Path, default=Path("candidate"))
+    parser.add_argument("--trusted", type=Path, default=Path("trusted"))
+    parser.add_argument("--plan", type=Path, default=Path("final-plan.json"))
+    args = parser.parse_args()
+    if args.operation == "prepare":
+        prepare_snapshot(args.source, args.trusted, int(os.environ["PR_NUMBER"]),
+                         os.environ["HEAD_SHA"], os.environ["BASE_SHA"], args.plan)
+    elif args.operation == "containers":
+        run_containers(args.source, args.trusted, args.plan)
+    else:
+        plan = json.loads(args.plan.read_text())
+        if args.operation == "data":
+            validate_data(args.source, args.trusted, plan)
+        else:
+            validate_proposed_code(args.source, plan)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Context

PR #357 exposed a race between model generation and release validation.

The source commit intentionally omitted automation-generated artifacts. `Process new model submission` began regenerating them, while `Publish models release` independently validated the same incomplete source head. [[Run 33194012789](https://github.com/OntoUML/ontouml-models/actions/runs/33194012789)](https://github.com/OntoUML/ontouml-models/actions/runs/33194012789) consequently failed at catalog synchronization before processing had finished.

After processing committed the generated artifacts, the PR head changed. Validation for that bot-generated head initially entered `action_required`, so the state intended for merge was not validated automatically.

The existing path-filtered workflows therefore could:

* validate an intermediate state before required generation completed;
* associate results with a superseded PR head;
* require manual intervention after bot writeback;
* leave applicability and merge eligibility distributed across independent checks.

## Solution

This PR introduces an applicability-aware orchestration path with one stable merge gate: **`PR validation`**.

The new orchestration:

1. runs trusted base-branch controller code for every PR targeting `master`;
2. retrieves and classifies the complete PR file list;
3. creates a pending `PR validation` check on the current head;
4. performs required model/catalog generation before final validation;
5. commits only an allowlisted generated bundle, using an atomic expected-head write;
6. explicitly dispatches validation for the exact resulting head and base;
7. validates the immutable final state using the trusted base harness;
8. completes the gate only after verifying the live PR head, check identity, workflow identity, run attempt, and unconditional validation-job success.

A changed PR head cannot inherit success from an older commit. Generation failures, missing generated artifacts, pending or failed validation, cancelled runs, stale attempts, and reporter outages all leave the gate non-successful and therefore blocking.

The existing automatic PR triggers are removed from:

* `Process new model submission`;
* `Publish models release`.

The former remains available for trusted manual maintenance. The latter retains scheduled/manual publication but now requires an already synchronized catalog and no longer races model processing or commits directly to `master`.

## Applicability

Validation is selected from the complete PR diff:

* **Documentation-only:** whitespace, UTF-8, unresolved-conflict, and regular-file safety checks; no model generation.
* **Scripts, dependencies, workflows, or configuration:** complete script tests, catalog/release checks, and `actionlint` where applicable; no model generation unless model/catalog inputs also changed.
* **Single-model submission:** existing source processing, generated metadata and ontology creation, catalog synchronization, required-output inventory, no-drift regeneration, RDF parsing, and catalog/release validation.
* **Complete model deletion:** catalog synchronization and final catalog/release consistency.
* **Multi-model generated-only maintenance:** no submission processing; all six generated-artifact families are checked.
* **Catalog or shape changes:** applicable catalog/release or Turtle parsing checks.
* **Mixed changes:** the union of applicable processing and validation.

Unknown or unsafe change combinations fail closed instead of silently bypassing validation.

## Security model

The privileged `pull_request_target` controller executes only trusted code from the base branch. Contributor-controlled code, workflows, actions, and dependencies are not executed in privileged generation, reporting, or writeback jobs.

Model generation receives only allowlisted regular model/catalog data and has no write credentials. Final candidate code and dependency validation runs in disposable, read-only, non-root Docker containers without host credentials, environment secrets, `.git`, caches, additional capabilities, or the Docker socket.

Fork PRs containing code or dependency changes require an explicit maintainer-authorized dispatch before that code is evaluated. Fork model-data and documentation changes continue through trusted tooling without weakening normal fork security policies.

Bot-generated commits are followed by an explicit final-head dispatch rather than relying on approval-sensitive bot-generated PR events. Head checks and per-PR concurrency prevent recursive generation and stale writeback.

## Regression coverage

The implementation includes tests for:

* the PR #357 source-only model and missing-artifact case;
* generation failure without partial bundle publication;
* final-validation failure;
* documentation-only changes;
* script, generator, dependency, and workflow changes;
* head changes during generation or after successful validation;
* stale heads, bases, checks, workflow attempts, and result spoofing;
* atomic expected-head writeback;
* bot-generated final heads;
* fork trust and authorization boundaries;
* unsafe paths, symlinks, submodules, and unexpected generated files;
* generated-only multi-model maintenance equivalent to PR #360;
* workflow dependencies, permission boundaries, and pinned actions.

## Local validation

Completed against `master` commit `1e7149af010fb6a85c6928f54fcb5ad60e01d26f`:

* `93 passed` — focused orchestration tests;
* `522 passed` — complete script test suite;
* `actionlint 1.7.12` — workflow validation passed;
* `git diff --check` — passed;
* catalog synchronization — passed with 197 datasets and 327 contributors;
* all six generated-artifact consistency checks — passed;
* release generation — 2,778 Turtle files and 1,344,006 triples;
* generated release graph parsing — passed with 1,344,006 triples.

Expected legacy JSON2Graph warnings were emitted according to the repository’s existing `warn` and `preserve` policies.

Local validation does not prove GitHub-hosted event delivery, App identity, environment restrictions, permission behavior, or actual ruleset merge denial. Those require the controlled live rollout below.

## Required repository configuration

Repository files alone cannot activate the merge gate. After review, administrators must:

1. create and install a dedicated GitHub App with Checks, Commit statuses, and Contents read/write permissions;
2. create the restricted `pr-automation` environment, limited to the `master` branch, containing only the App private-key secret;
3. set `PR_AUTOMATION_APP_ID` to the App ID;
4. add a no-bypass ruleset requiring **`PR validation`** from that dedicated App and requiring the branch to be up to date;
5. remove only obsolete path-filtered required checks after the new gate is proven operational.

Human-review policy remains separate and must not bypass the automated-validation ruleset.

Because `workflow_dispatch` and `workflow_run` definitions must exist on the default branch, the complete GitHub-hosted orchestration cannot be exercised from this implementation branch alone. Deployment should use a controlled transition: merge under the current policy, configure the App/environment, validate representative disposable PRs, and only then activate the required gate.

## Live acceptance matrix

Before completing rollout, verify:

* source-only model submission with bot writeback and final-head validation;
* generation failure;
* final-validation failure;
* documentation-only change;
* script/generator/workflow change;
* new contributor commit after prior success;
* same-repository and authorized-fork bot writeback;
* generated-only multi-model maintenance;
* pending/failed checks blocking both maintainers and administrators;
* old heads and old workflow attempts never authorizing the current head.

Detailed architecture, security rationale, configuration steps, recovery instructions, and regression evidence are documented in `scripts/pr-validation.md`.