### PR TITLE
fix(ci): dispatch final validation with App token

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -122,7 +122,6 @@ jobs:
     permissions:
       contents: write
       pull-requests: read
-      actions: write
     steps:
       - name: Check out trusted controller only
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
@@ -144,6 +143,15 @@ jobs:
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.event.repository.name }}
           permission-checks: write
+      - name: Mint scoped validation-dispatch token
+        id: dispatch
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+        with:
+          app-id: ${{ vars.PR_AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.PR_AUTOMATION_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-actions: write
       - name: Mint fork write token only for actual generated changes
         if: ${{ needs.prepare.outputs.fork == 'true' && needs.generate.outputs.changed == 'true' }}
         id: fork
@@ -158,6 +166,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           CHECK_TOKEN: ${{ steps.app.outputs.token }}
+          DISPATCH_TOKEN: ${{ steps.dispatch.outputs.token }}
           WRITE_TOKEN: ${{ steps.fork.outputs.token }}
           PLAN: ${{ needs.prepare.outputs.plan }}
           CHECK_ID: ${{ needs.prepare.outputs.check_id }}

--- a/scripts/pr-validation.md
+++ b/scripts/pr-validation.md
@@ -19,10 +19,11 @@ classification. Missing, inconsistent or over-3,000-file API results fail closed
    Commit only if changes exist, using GraphQL `createCommitOnBranch` with
    `expectedHeadOid`. A concurrent contributor update rejects the commit.
 4. Advance the pending check to final validation (or create one on the new SHA
-   after writeback) and explicitly dispatch
-   `validate-pr-state.yml` from `master`, with the PR number, head, base and check
-   ID. When the head changes, mark the old-head processing check as superseded,
-   never successful. An unchanged head keeps its single pending check.
+   after writeback) and explicitly dispatch, using a dedicated App token scoped
+   only to **Actions: write**, `validate-pr-state.yml` from `master`, with the PR
+   number, head, base and check ID. When the head changes, mark the old-head
+   processing check as superseded, never successful. An unchanged head keeps its
+   single pending check.
 5. Validate the immutable final checkout. Check that its head/base still match
    the PR and that the current base is an ancestor. The trusted harness runs
    applicable data checks, candidate tests and workflow lint in isolated
@@ -79,10 +80,12 @@ remain unchanged.
   normalization and root catalog output. It cannot write PR workflow files,
   scripts, JSON/VPP sources or unrelated model folders.
 - Final validation is explicitly dispatched from the default branch with a
-  read-only token and no environment/App secret. Candidate code and dependency
-  installation run in a separate disposable Docker container from trusted data
-  validation. Containers have read-only source mounts, a non-root user, dropped
-  capabilities, no added privileges, and temporary writable storage. They do
+  dedicated App token scoped only to **Actions: write**. The dispatched workflow
+  itself has a read-only `GITHUB_TOKEN` and no environment/App secret. Candidate
+  code and dependency installation run in a separate disposable Docker container
+  from trusted data validation. Containers have read-only source mounts, a
+  non-root user, dropped capabilities, no added privileges, and temporary
+  writable storage. They do
   not receive host environment variables, tokens, credentials, caches, runtime
   artifact credentials, host `.git`, or the Docker socket. Public dependency
   downloads require network access; workflow lint has no network access.
@@ -122,8 +125,10 @@ Same-repository generated commits use `GITHUB_TOKEN`. Current GitHub behavior
 creates approval-required `pull_request` runs for token-generated
 opened/synchronize/reopened events; ordinary token-generated `push` events do
 not recursively start workflows. This implementation removes the old automatic
-PR consumers and uses the documented `workflow_dispatch` exception explicitly.
-It never depends on a token-generated event starting follow-up validation.
+PR consumers. It uses a dedicated App token for the explicit `workflow_dispatch`
+so the validator's completion can emit the `workflow_run` that starts the
+reporter. It never depends on a `GITHUB_TOKEN`-generated event starting follow-up
+validation.
 
 Fork App writeback can emit a new PR event. Per-PR controller concurrency
 serializes it after writeback; an authenticated matching App actor with a
@@ -153,13 +158,17 @@ activate an incomplete setup on a busy repository. No setting is changed by
 these files or by local tests.
 
 1. Create a dedicated GitHub App (for example `ontouml-pr-validation`) with
-   repository **Checks: read and write**, **Commit statuses: read and write**,
-   **Contents: read and write**, and implicit **Metadata: read**. No webhook
-   subscriptions or organization/user permissions are needed. Permit
-   installation by other accounts if fork
-   writeback is offered. Install it on the selected catalog repository. Fork
+   repository **Actions: read and write**, **Checks: read and write**,
+   **Commit statuses: read and write**, **Contents: read and write**, and implicit
+   **Metadata: read**. The controller mints separate tokens for check updates,
+   validation dispatch and writeback, each restricted to its one required
+   permission. No webhook subscriptions or organization/user permissions are
+   needed. Permit installation by other accounts if fork writeback is offered.
+   Install it on the selected catalog repository. Fork
    owners separately authorize installation on their selected fork; enabling
    Actions write tokens/secrets for fork PRs is neither needed nor permitted.
+   When adding **Actions** to an existing App, approve the updated installation
+   permission before running the smoke test.
 2. Create environment **`pr-automation`** in repository Settings → Environments.
    Select **Selected branches and tags** and add exactly one **Branch** rule:
    **`master`**. Add no tag rule, wildcard or PR merge-ref rule. Do not use
@@ -243,11 +252,27 @@ source submissions. The classifier accepts exactly those generated families
 without invoking model generation; final validation checks the corresponding
 six generators. Deletions and unrecognized metadata names still fail closed.
 
+## Regression evidence: PR #364
+
+The documentation-only [smoke PR](https://github.com/OntoUML/ontouml-models/pull/364)
+confirmed classification, skipped model generation and successful final-state
+validation on head `765d3eec2a397a9bd9f5f857b0319e2fd500a5db`. Controller run
+[`33564600951`](https://github.com/OntoUML/ontouml-models/actions/runs/33564600951)
+dispatched successful validator run
+[`33564741071`](https://github.com/OntoUML/ontouml-models/actions/runs/33564741071)
+with `GITHUB_TOKEN`, but no `workflow_run` reporter started and App check
+`100044997788` remained pending. This is consistent with GitHub's recursion rule:
+apart from `workflow_dispatch` and `repository_dispatch`, events caused by
+`GITHUB_TOKEN` do not create workflow runs. The controller now dispatches with
+the dedicated App's Actions-only token so validator completion can start the
+independent reporter. A new live smoke run must confirm hosted event delivery
+before the App check is made required.
+
 ## Local validation and limits
 
 `scripts/tests/test_pr_automation.py` covers classification, renames/pagination,
 unsafe paths, PR #360 bulk metadata, missing outputs, generation failure,
-atomic writeback ordering,
+atomic writeback ordering, dedicated App dispatch,
 no-op generation, stale head/base/attempts/checks, result/source spoofing,
 documentation/script cases, and workflow/container boundaries. Existing
 generator tests continue to cover source conversion and metadata behavior.

--- a/scripts/pr_automation.py
+++ b/scripts/pr_automation.py
@@ -360,7 +360,7 @@ def create_commit(write_api, plan, additions):
     return head
 
 
-def publish(read_api, checks_api, write_api, plan, check_id, bundle=None):
+def publish(read_api, checks_api, write_api, dispatch_api, plan, check_id, bundle=None):
     active_check = check_id
     try:
         same_state(read_api.pr(plan["pr"]), plan)
@@ -374,7 +374,7 @@ def publish(read_api, checks_api, write_api, plan, check_id, bundle=None):
         else:
             active_check = checks_api.start_check(final, "validation")
             checks_api.finish_check(check_id, False, f"Processing complete; superseded by final-head check #{active_check} on `{final['head']}`.")
-        read_api.api("POST", f"actions/workflows/{VALIDATION_WORKFLOW}/dispatches", {
+        dispatch_api.api("POST", f"actions/workflows/{VALIDATION_WORKFLOW}/dispatches", {
             "ref": BASE_BRANCH, "inputs": {"pr_number": str(plan["pr"]), "head_sha": final["head"],
                                            "base_sha": final["base"], "check_id": str(active_check)}})
         print(f"Final validation dispatched for PR #{plan['pr']} at {final['head']}; check {active_check}")
@@ -450,7 +450,8 @@ def main():
         plan = json.loads(os.environ["PLAN"])
         bundle = json.loads(Path("bundle/generated.json").read_text()) if plan["generate"] else None
         write_api = GitHub(plan["head_repo"], os.environ.get("WRITE_TOKEN") or os.environ["GH_TOKEN"])
-        publish(read_api, checks_api, write_api, plan, int(os.environ["CHECK_ID"]), bundle)
+        dispatch_api = GitHub(read_api.repo, os.environ["DISPATCH_TOKEN"])
+        publish(read_api, checks_api, write_api, dispatch_api, plan, int(os.environ["CHECK_ID"]), bundle)
     elif args.operation == "fail":
         checks_api.finish_check(int(os.environ["CHECK_ID"]), False, "Required processing failed or was cancelled; inspect the controller run.")
     else:

--- a/scripts/tests/test_pr_automation.py
+++ b/scripts/tests/test_pr_automation.py
@@ -43,7 +43,7 @@ class FakeAPI:
         self.events, self.check_store = [], {}
         self.check_counter, self.run_data = 1000, {}
         self.job = {"name": automation.VALIDATION_JOB, "status": "completed", "conclusion": "success"}
-        self.reject_commit = False
+        self.reject_commit = self.reject_dispatch = False
 
     def pr(self, number):
         return automation.GitHub.pr(self, number)
@@ -83,6 +83,8 @@ class FakeAPI:
         if path.startswith("actions/runs/"):
             return copy.deepcopy(self.run_data)
         if method == "POST" and path.endswith("/dispatches"):
+            if self.reject_dispatch:
+                raise automation.AutomationError("Dispatch rejected")
             return None
         raise AssertionError((method, path, body))
 
@@ -245,7 +247,7 @@ def test_invalid_bundles_fail_closed(change):
 def test_new_model_writeback_precedes_dispatch_of_bot_head():
     api, plan = FakeAPI(), plan_for("models/new/ontology.json")
     first = start(api, plan)
-    assert automation.publish(api, api, api, plan, first, bundle_for(plan)) == FINAL
+    assert automation.publish(api, api, api, api, plan, first, bundle_for(plan)) == FINAL
     commit = next(i for i, event in enumerate(api.events) if event[1] == "/graphql")
     dispatch = next(i for i, event in enumerate(api.events) if event[1].endswith("/dispatches"))
     assert commit < dispatch
@@ -259,16 +261,34 @@ def test_new_model_writeback_precedes_dispatch_of_bot_head():
 
 def test_documentation_dispatches_validation_without_generation_or_writeback():
     api, plan = FakeAPI(), plan_for("README.md")
-    automation.publish(api, api, api, plan, start(api, plan))
+    automation.publish(api, api, api, api, plan, start(api, plan))
     assert not any(event[1] == "/graphql" for event in api.events)
     assert any(event[1].endswith("/dispatches") for event in api.events)
     assert len(api.check_store) == 1
     assert list(api.check_store.values())[0]["status"] == "in_progress"
 
 
+def test_validation_dispatch_uses_dedicated_app_client():
+    api, dispatcher, plan = FakeAPI(), FakeAPI(), plan_for("README.md")
+    automation.publish(api, api, api, dispatcher, plan, start(api, plan))
+    assert not any(event[1].endswith("/dispatches") for event in api.events)
+    dispatches = [event for event in dispatcher.events if event[1].endswith("/dispatches")]
+    assert len(dispatches) == 1
+    assert dispatches[0][2]["ref"] == automation.BASE_BRANCH
+
+
+def test_validation_dispatch_failure_closes_gate():
+    api, dispatcher, plan = FakeAPI(), FakeAPI(), plan_for("README.md")
+    dispatcher.reject_dispatch = True
+    check_id = start(api, plan)
+    with pytest.raises(automation.AutomationError, match="Dispatch rejected"):
+        automation.publish(api, api, api, dispatcher, plan, check_id)
+    assert api.check_store[check_id]["conclusion"] == "failure"
+
+
 def test_noop_generation_does_not_create_recursive_commits():
     api, plan = FakeAPI(), plan_for("models/new/ontology.json")
-    automation.publish(api, api, api, plan, start(api, plan), dict(bundle_for(plan), additions=[]))
+    automation.publish(api, api, api, api, plan, start(api, plan), dict(bundle_for(plan), additions=[]))
     assert not any(event[1] == "/graphql" for event in api.events)
 
 
@@ -277,7 +297,7 @@ def test_atomic_writeback_rejects_concurrent_human_commit():
     api.reject_commit = True
     check_id = start(api, plan)
     with pytest.raises(automation.AutomationError, match="Atomic"):
-        automation.publish(api, api, api, plan, check_id, bundle_for(plan))
+        automation.publish(api, api, api, api, plan, check_id, bundle_for(plan))
     assert api.check_store[check_id]["conclusion"] == "failure"
     assert not any(event[1].endswith("/dispatches") for event in api.events)
 
@@ -291,7 +311,7 @@ def test_stale_or_closed_pr_cannot_publish(mutation):
     else:
         api.pr_data[mutation]["sha"] = FINAL
     with pytest.raises(automation.AutomationError):
-        automation.publish(api, api, api, plan, check_id)
+        automation.publish(api, api, api, api, plan, check_id)
     assert api.check_store[check_id]["conclusion"] == "failure"
 
 
@@ -526,6 +546,15 @@ def test_workflow_dependencies_and_trust_boundaries():
     assert "always()" in jobs["publish"]["if"] and "needs.generate.result == 'success'" in jobs["publish"]["if"]
     assert jobs["generate"]["permissions"] == {"contents": "read"}
     assert "environment" not in jobs["generate"]
+    assert jobs["publish"]["permissions"] == {"contents": "write", "pull-requests": "read"}
+    publish_steps = {step.get("id"): step for step in jobs["publish"]["steps"] if step.get("id")}
+    assert publish_steps["app"]["with"]["permission-checks"] == "write"
+    assert "permission-actions" not in publish_steps["app"]["with"]
+    assert publish_steps["dispatch"]["with"]["permission-actions"] == "write"
+    assert "permission-checks" not in publish_steps["dispatch"]["with"]
+    publish_command = next(step for step in jobs["publish"]["steps"]
+                           if step.get("run") == "python scripts/pr_automation.py publish")
+    assert publish_command["env"]["DISPATCH_TOKEN"] == "${{ steps.dispatch.outputs.token }}"
     for name in ("prepare", "publish", "failure", "report"):
         assert jobs[name]["environment"] == "pr-automation"
         for step in jobs[name]["steps"]:


### PR DESCRIPTION
## Context

PR #363 introduced centralized pull-request orchestration and a stable `PR validation` check intended to represent the automated merge gate.

The documentation-only smoke test in PR #364 confirmed that:

* PR classification worked correctly;
* model generation was skipped as not applicable;
* the final-state validator was dispatched;
* final validation itself completed successfully.

However, the `PR validation` App check remained pending because the reporter workflow was never started.

## Root cause

The controller dispatched `validate-pr-state.yml` using `GITHUB_TOKEN`.

Although the dispatched validation workflow completed successfully, GitHub’s recursion-prevention behavior prevented its completion from triggering the subsequent `workflow_run` reporter. Consequently, the reporter could not complete the App-owned `PR validation` check.

Evidence:

* Controller run: https://github.com/OntoUML/ontouml-models/actions/runs/33564600951
* Successful validator run: https://github.com/OntoUML/ontouml-models/actions/runs/33564741071
* Smoke-test PR: https://github.com/OntoUML/ontouml-models/pull/364

## Solution

This PR:

* mints a dedicated GitHub App token restricted to `Actions: write`;
* uses that token exclusively to dispatch final-state validation;
* keeps check updates, workflow dispatch, and generated-artifact writeback on separately scoped tokens;
* removes `Actions: write` from the controller job’s `GITHUB_TOKEN`;
* fails the pending merge gate if validation dispatch is rejected;
* adds regression tests for dedicated App dispatch and dispatch failure;
* documents the root cause, required App permission, and live regression evidence.

The dispatched validator itself remains read-only and receives neither the App private key nor a privileged token. Contributor-controlled code is not executed in a secret-bearing or write-capable context.

## Validation performed

* Focused PR-automation test suite: **95 passed**
* Complete script test suite: **524 passed**
* Workflow validation with actionlint **1.7.12**: passed
* `git diff --check`: passed
* Changed-file scope verified: four expected files only

## Live verification after merge

Because `workflow_dispatch` and `workflow_run` use workflow definitions from the default branch, the complete correction can only be exercised after this PR is merged.

After deployment, PR #364 will be updated with the new `master` head. The expected result is:

1. the controller dispatches validation using the App token;
2. final-state validation succeeds;
3. the `workflow_run` reporter starts automatically;
4. the App-owned `PR validation` check succeeds on the current PR head;
5. PR #364 is closed without merging;
6. the verified App check can then be configured as the required automated merge gate.

The GitHub App’s new `Actions: read and write` permission has already been configured and its installation permission update approved.
