### PR TITLE
fix(validation): lint workflows by explicit path

### DIFF
--- a/scripts/tests/test_pr_automation.py
+++ b/scripts/tests/test_pr_automation.py
@@ -528,6 +528,27 @@ def test_container_does_not_mount_host_credentials_or_docker_socket(tmp_path):
     assert "-r /repo/scripts/requirements.txt" in command[-1]
 
 
+def test_actionlint_uses_explicit_workflow_paths_without_git_mount(tmp_path):
+    snapshot = tmp_path / "source"
+    workflow_root = snapshot / ".github" / "workflows"
+    workflow_root.mkdir(parents=True)
+    (workflow_root / "publish.yml").write_text("name: publish\n", encoding="utf-8")
+    (workflow_root / "validate.yaml").write_text("name: validate\n", encoding="utf-8")
+    (workflow_root / "README.md").write_text("ignored\n", encoding="utf-8")
+
+    command = validation.actionlint_command(snapshot)
+
+    assert command[-3] == "-shellcheck="
+    assert command[-2:] == [
+        ".github/workflows/publish.yml",
+        ".github/workflows/validate.yaml",
+    ]
+    assert not any(
+        argument.startswith("--mount") and ".git" in argument
+        for argument in command
+    )
+
+
 def test_docs_only_container_does_not_install_model_dependencies(tmp_path):
     command = validation.container_command(tmp_path / "source", tmp_path / "trusted", tmp_path / "plan.json", "data", dependencies=False)
     assert "pip install" not in command[-1]

--- a/scripts/validate_pr_state.py
+++ b/scripts/validate_pr_state.py
@@ -128,6 +128,28 @@ def container_command(source, trusted, plan_file, phase, *, dependencies=True):
             "python:3.11", "sh", "-c", bootstrap]
 
 
+def actionlint_command(snapshot):
+    workflow_root = snapshot / ".github" / "workflows"
+    workflow_files = sorted(
+        path.relative_to(snapshot).as_posix()
+        for suffix in (".yml", ".yaml")
+        for path in workflow_root.glob(f"*{suffix}")
+        if path.is_file()
+    )
+    require(
+        workflow_files,
+        "Workflow changes detected but no workflow files were found",
+    )
+    return [
+        "docker", "run", "--rm", "--network=none", "--read-only",
+        "--cap-drop=ALL", "--security-opt=no-new-privileges",
+        "--user", "65534:65534", "--workdir", "/repo",
+        "--mount", f"type=bind,src={snapshot},dst=/repo,readonly",
+        "rhysd/actionlint:1.7.12", "-shellcheck=",
+        *workflow_files,
+    ]
+
+
 def prepare_snapshot(source, trusted, number, head, base, plan_file):
     require(SHA.fullmatch(head) and SHA.fullmatch(base), "Invalid dispatch SHA")
     api = GitHub(os.environ["GITHUB_REPOSITORY"], os.environ["GH_TOKEN"])
@@ -161,10 +183,7 @@ def run_containers(source, trusted, plan_file):
         if plan["code"]:
             subprocess.run(container_command(snapshot, harness, plan_file, "code"), check=True)
         if plan["workflows"]:
-            subprocess.run(["docker", "run", "--rm", "--network=none", "--read-only", "--cap-drop=ALL",
-                            "--security-opt=no-new-privileges", "--user", "65534:65534",
-                            "--workdir", "/repo", "--mount", f"type=bind,src={snapshot},dst=/repo,readonly",
-                            "rhysd/actionlint:1.7.12", "-shellcheck="], check=True)
+            subprocess.run(actionlint_command(snapshot), check=True)
 
 
 def main():


### PR DESCRIPTION
## Summary

Fix the trusted final-state validator so that actionlint can validate workflow files from the isolated snapshot.

## Problem

The validator intentionally copies the candidate repository without its `.git` directory. However, actionlint was invoked without explicit workflow paths and therefore attempted to discover a Git repository from `/repo`. This caused the final validation to fail with:

`no project was found in any parent directories of "/repo"`

## Changes

- Added `actionlint_command(snapshot)` to construct the isolated Docker command.
- Passes explicit relative paths for all `.yml` and `.yaml` files under `.github/workflows`.
- Preserves the existing isolated execution controls:
  - no network access;
  - read-only filesystem;
  - dropped capabilities;
  - non-root user;
  - no `.git` mount.
- Added a regression test confirming that explicit workflow paths are included and `.git` is not mounted.

## Validation

- `python -m pytest -q scripts/tests/test_pr_automation.py` — 96 passed.
- `python -m pytest -q scripts/tests` — 525 passed.
- `git diff --check` — passed.

Docker is not installed locally, so the actionlint container was not run on the developer machine. The GitHub Actions validation will execute it in the intended containerized environment.